### PR TITLE
release connection buffers after dealing with simple_rpc result

### DIFF
--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -172,6 +172,7 @@ PHP_METHOD(amqp_channel_class, __construct)
 		char ** pstr = (char **) &str;
 		amqp_error(res, pstr);
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -374,6 +375,7 @@ PHP_METHOD(amqp_channel_class, startTransaction)
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -420,6 +422,7 @@ PHP_METHOD(amqp_channel_class, commitTransaction)
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -465,6 +468,7 @@ PHP_METHOD(amqp_channel_class, rollbackTransaction)
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -560,6 +560,7 @@ PHP_METHOD(amqp_exchange_class, delete)
 		char ** pstr = (char **) &str;
 		amqp_error(res, pstr);
 		zend_throw_exception(amqp_exchange_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -890,6 +891,7 @@ PHP_METHOD(amqp_exchange_class, bind)
 		char ** pstr = (char **) &str;
 		amqp_error(res, pstr);
 		zend_throw_exception(amqp_exchange_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -806,6 +806,7 @@ PHP_METHOD(amqp_queue_class, bind)
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -1209,6 +1210,7 @@ PHP_METHOD(amqp_queue_class, purge)
 		amqp_error(res, pstr);
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -1279,6 +1281,7 @@ PHP_METHOD(amqp_queue_class, cancel)
 		amqp_error(res, pstr);
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -1349,6 +1352,7 @@ PHP_METHOD(amqp_queue_class, unbind)
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -1416,6 +1420,7 @@ PHP_METHOD(amqp_queue_class, delete)
 		amqp_error(res, pstr);
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
+		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
 	}
 	amqp_maybe_release_buffers(connection->connection_resource->connection_state);


### PR DESCRIPTION
Please review.

Quoting alanxz: Client programs should call amqp_maybe_release_buffers() after they are done with any data returned by amqp_simple_rpc() in order to release the memory allocated.
