### PR TITLE
Invalid system call for closing connection socket in windows

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -238,7 +238,7 @@ void php_amqp_disconnect(amqp_connection_object *connection)
 		amqp_destroy_connection(resource->connection_state);
 		
 		if (resource->fd) {
-			close(resource->fd);
+			AMQP_CLOSE_SOCKET(resource->fd)
 		}
 	}
 

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -370,6 +370,12 @@ typedef struct _amqp_envelope_object {
 # define AMQP_RPC_REPLY_T_CAST (amqp_rpc_reply_t)
 #endif
 
+#ifdef PHP_WIN32
+# define AMQP_CLOSE_SOCKET(fd) closesocket(fd);
+#else
+# define AMQP_CLOSE_SOCKET(fd) close(fd);
+#endif
+
 
 #ifdef ZTS
 #define AMQP_G(v) TSRMG(amqp_globals_id, zend_amqp_globals *, v)


### PR DESCRIPTION
In windows one should call `closesocket` instead of `close`.
I could not set up a clean example, but in some cases this invalid call leads to crash on PHP cleanup stage.
