### PR TITLE
Resource compiler error

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,4 +1,5 @@
-;; AMQP
+AMQP bindings for PHP
+all who contributed to php-amqp project
 Alexandre Kalendarev <akalend@mail.ru> (original author)
 Pieter de Zwart <pdezwart@php.net> (lead)
 Andrey Hristov (contributor)


### PR DESCRIPTION
I tried to check out current master branch and build it as a shared library with PHP 5.3.15 and VC9.
Running `nmake` resulted in the following error

```
C:\Users\Crazy\Documents\GitHub\php-amqp>nmake

Microsoft (R) Program Maintenance Utility Version 9.00.30729.01
Copyright (C) Microsoft Corporation. All rights reserved.

amqp.c
amqp_channel.c
amqp_connection.c
amqp_envelope.c
amqp_exchange.c
amqp_queue.c
        rc /I C:\php\SDK/include /n /fo Release_TS\php_amqp.dll.res /d FILE_DES
CRIPTION="\";; AMQP\"" /d FILE_NAME="\"php_amqp.dll\"" /d URL="\"http://www.php.
net\"" /d INTERNAL_NAME="\"AMQP extension\"" /d THANKS_GUYS="\"Thanks to Alexand
re Kalendarev <akalend@mail.ru> (original author)\"" C:\php\SDK\build\template.r
c
Не удается найти указанный файл.
NMAKE : fatal error U1077: 'rc' : return code '0x1'
Stop.

C:\Users\Crazy\Documents\GitHub\php-amqp>
```

Unfortunately, I could not find a way to make Microsoft Resource Compiler give me any additional information about what's going wrong, but after a bit of investigating I found this piece of code
https://github.com/php/php-src/blob/master/win32/build/confutils.js#L920
which takes the first line of CREDITS file and passes it to FILE_DESCRIPTION parameter, then takes seconds line of that file and passes it to THANKS_GUYS parameter.
My guess is that `rc` (or maybe the cause is in the `template.rc` file, I dunno) doesn't like symbols like semicolon and less-than/greater-than signs.

Anyway, I changed CREDITS file and everything worked!
