### PR TITLE
Debug version segfaults on PHP shutdown

### DIFF
--- a/amqp_object_store.c
+++ b/amqp_object_store.c
@@ -4,9 +4,9 @@
 
 #include "php.h"
 
-#include "amqp_zend_object_store_patch.h"
+#include "amqp_object_store.h"
 
-void *amqp_zend_object_store_get_valid_object(const zval *zobject TSRMLS_DC)
+void *amqp_object_store_get_valid_object(const zval *zobject TSRMLS_DC)
 {
 	zend_object_handle handle;
 	zend_object_store_bucket bucket;

--- a/amqp_object_store.h
+++ b/amqp_object_store.h
@@ -1,0 +1,4 @@
+#ifndef AMQP_OBJECT_STORE_PATCH_H
+#define AMQP_OBJECT_STORE_PATCH_H
+void *amqp_object_store_get_valid_object(const zval *zobject TSRMLS_DC);
+#endif

--- a/amqp_zend_object_store_patch.h
+++ b/amqp_zend_object_store_patch.h
@@ -1,4 +1,0 @@
-#ifndef AMQP_ZEND_OBJECT_STORE_PATCH_H
-#define AMQP_ZEND_OBJECT_STORE_PATCH_H
-void *amqp_zend_object_store_get_valid_object(const zval *zobject TSRMLS_DC);
-#endif

--- a/config.m4
+++ b/config.m4
@@ -64,7 +64,7 @@ if test "$PHP_AMQP" != "no"; then
 	PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $AMQP_DIR/lib, AMQP_SHARED_LIBADD)
 	PHP_SUBST(AMQP_SHARED_LIBADD)
 
-	AMQP_SOURCES="amqp.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_channel.c amqp_envelope.c amqp_zend_object_store_patch.c"
+	AMQP_SOURCES="amqp.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_channel.c amqp_envelope.c amqp_object_store.c"
 
 	PHP_NEW_EXTENSION(amqp, $AMQP_SOURCES, $ext_shared)
 fi

--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@ if (PHP_AMQP != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("amqp.h", "CFLAGS_AMQP", PHP_PHP_BUILD + "\\include;" + PHP_AMQP) &&
 		CHECK_LIB("rabbinmq_a.lib;rabbitmq.lib;rabbitmq.1.lib", "amqp", PHP_PHP_BUILD + "\\lib;" + PHP_AMQP)) {
 //		ADD_FLAG("CFLAGS_AMQP", "/D HAVE_AMQP_GETSOCKOPT");
-		EXTENSION('amqp', 'amqp.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_channel.c amqp_envelope.c amqp_zend_object_store_patch.c');
+		EXTENSION('amqp', 'amqp.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_channel.c amqp_envelope.c amqp_object_store.c');
 		AC_DEFINE('HAVE_AMQP', 1);
 	} else {
 		WARNING("amqp not enabled; libraries and headers not found");

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -106,7 +106,7 @@ static zend_always_inline zend_bool zval_set_isref_to_p(zval* pz, zend_bool isre
 
 
 #include "amqp.h"
-#include "amqp_zend_object_store_patch.h"
+#include "amqp_object_store.h"
 
 extern zend_module_entry amqp_module_entry;
 #define phpext_amqp_ptr &amqp_module_entry
@@ -231,7 +231,7 @@ extern zend_class_entry *amqp_exception_class_entry,
 	efree(object); \
 
 #define AMQP_GET_CHANNEL(object) \
-	(amqp_channel_object *) amqp_zend_object_store_get_valid_object((object)->channel TSRMLS_CC);
+	(amqp_channel_object *) amqp_object_store_get_valid_object((object)->channel TSRMLS_CC);
 
 #define AMQP_ASSIGN_CHANNEL(channel, object) \
 	if (!(object)->channel) { \
@@ -240,7 +240,7 @@ extern zend_class_entry *amqp_exception_class_entry,
 	channel = AMQP_GET_CHANNEL(object)
 
 #define AMQP_GET_CONNECTION(object) \
-	(amqp_connection_object *) amqp_zend_object_store_get_valid_object((object)->connection TSRMLS_CC);
+	(amqp_connection_object *) amqp_object_store_get_valid_object((object)->connection TSRMLS_CC);
 
 #define AMQP_ASSIGN_CONNECTION(connection, object) \
 	if (!(object)->connection) { \


### PR DESCRIPTION
I'm not very sure myself if this is a serious issue, because as far as I know, hardly anyone builds php with `--enable-debug` flag, but the underlying problem seems disturbing to me.

Consider building PHP with flags `--enable-debug --with-amqp` and executing following code in it:

``` php
class A
{
    public function fail()
    {
        $c = new AMQPConnection();
        $c->connect();
        self::$b = new AMQPChannel($c);
    }
}

$a = new A();
$a->fail();
```

It produces fatal error, as it should, but at shutdown PHP segfaults.
What happens here is that `AMQPConnection` object gets removed from zend object store earlier than `AMQPChannel` object. Meanwhile `AMQP_ASSIGN_CONNECTION` macro returns pointer to a block of memory that's already been `efree`'d. In non-debug version this works somehow, because no one else touches that block after `amqp_connection_dtor` sets all pointers there to zero. But in debug mode allocator behaves a bit different, `memset`ting free memory with special value.
https://github.com/php/php-src/blob/master/Zend/zend_alloc.c#L2074

PHP code above is simply to provide a clean example, because our production php code behaves the same way without any fatal errors.

I'd like to suggest a couple of solutions.
1. Make `AMQP_GET_CONNECTION` and `AMQP_GET_CHANNEL` macros double-check that bucket holding the necessary object is still valid (there's a flag in zend object store bucket that's set to zero after calling cleanup function for that object https://github.com/php/php-src/blob/master/Zend/zend_objects_API.h#L33 ).
   
   Pros:
   - it's easier to implement
   
   Cons:
   - this solution uses some arcane knowledge about inner structure of object store, which could pose compatibility issues with future versions of PHP
2. Delete all channels that's tied to `AMQPConnection` from object store manually just before connection itself is deleted from object store.
   
   Pros:
   - cleaning up objects right at the time when we know for sure they're not needed anymore makes more sense
   
   Cons:
   - I really have very little idea how to do this properly, mostly because I'm not sure if it's okay to call `zend_objects_store_del_ref` or `zend_objects_store_del_ref_by_handle_ex` from `zend_objects_store_free_object_storage`.

Again, I'm not sure if this issue requires serious attention, but at least I'd like to hear some comments on this from active contributors.

Sorry for long and probably pointless explanation =D
