### PR TITLE
Proposal: skip var_dump test on php-5.2

### DIFF
--- a/tests/amqpchannel_var_dump.phpt
+++ b/tests/amqpchannel_var_dump.phpt
@@ -1,7 +1,10 @@
 --TEST--
 AMQPChannel var_dump
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php
+if (!extension_loaded("amqp") || version_compare(PHP_VERSION, '5.3', '<')) {
+  print "skip";
+}
 --FILE--
 <?php
 $cnn = new AMQPConnection();

--- a/tests/amqpconnection_var_dump.phpt
+++ b/tests/amqpconnection_var_dump.phpt
@@ -1,7 +1,10 @@
 --TEST--
 AMQPConnection var_dump
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php
+if (!extension_loaded("amqp") || version_compare(PHP_VERSION, '5.3', '<')) {
+  print "skip";
+}
 --FILE--
 <?php
 $cnn = new AMQPConnection();

--- a/tests/amqpenvelope_var_dump.phpt
+++ b/tests/amqpenvelope_var_dump.phpt
@@ -1,7 +1,10 @@
 --TEST--
 AMQPEnvelope var_dump
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php 
+if (!extension_loaded("amqp") || version_compare(PHP_VERSION, '5.3', '<')) {
+  print "skip";
+}
 --FILE--
 <?php
 $cnn = new AMQPConnection();

--- a/tests/amqpexchange_var_dump.phpt
+++ b/tests/amqpexchange_var_dump.phpt
@@ -1,7 +1,10 @@
 --TEST--
 AMQPExchange var_dump
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php
+if (!extension_loaded("amqp") || version_compare(PHP_VERSION, '5.3', '<')) {
+  print "skip";
+}
 --FILE--
 <?php
 $cnn = new AMQPConnection();

--- a/tests/amqpqueue_var_dump.phpt
+++ b/tests/amqpqueue_var_dump.phpt
@@ -1,7 +1,10 @@
 --TEST--
 AMQPQueue var_dump
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php
+if (!extension_loaded("amqp") || version_compare(PHP_VERSION, '5.3', '<')) {
+  print "skip";
+}
 --FILE--
 <?php
 $cnn = new AMQPConnection();


### PR DESCRIPTION
Hot on the heels of issue #15 here is a proposal to just skip the var_dump tests on php < 5.3, since nobody is likely to go through the trouble of implementing them anyways.

Veto anyone?
