### PR TITLE
Removed Exception for unknown exchange type

### DIFF
--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -315,16 +315,6 @@ PHP_METHOD(amqp_exchange_class, setType)
 
 	/* Pull the exchange off the object store */
 	exchange = (amqp_exchange_object *)zend_object_store_get_object(id TSRMLS_CC);
-
-	if (strcmp(type, AMQP_EX_TYPE_DIRECT) != 0
-	&& strcmp(type, AMQP_EX_TYPE_HEADERS) != 0
-	&& strcmp(type, AMQP_EX_TYPE_TOPIC) != 0
-	&& strcmp(type, AMQP_EX_TYPE_FANOUT) != 0
-	) {
-		zend_throw_exception(amqp_exchange_exception_class_entry, "Could not set exchange type. Exchange type must be one of 'direct', 'topic', 'headers' or 'fanout'.", 0 TSRMLS_CC);
-		return;
-	}
-
 	AMQP_SET_TYPE(exchange, type)
 }
 /* }}} */

--- a/tests/amqpexchange_invalid_type.phpt
+++ b/tests/amqpexchange_invalid_type.phpt
@@ -1,0 +1,25 @@
+--TEST--
+AMQPExchange
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+$ex = new AMQPExchange($ch);
+$ex->setName("exchange-" . time());
+$ex->setType("invalid_exchange_type");
+try {
+	$ex->declare();
+} catch (Exception $e) {
+	echo get_class($e);
+	echo PHP_EOL;
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+AMQPExchangeException
+Server connection error: 503, message: COMMAND_INVALID - unknown exchange type 'invalid_exchange_type'

--- a/tests/amqpexchange_publish_timeout.phpt
+++ b/tests/amqpexchange_publish_timeout.phpt
@@ -30,24 +30,24 @@ $start = $end = 0;
 
 // try to exceed resources limit
 try {
-    while(true) {
-        $start = microtime(true);
-        $ex->publish($message, 'ignored-for-fanout', AMQP_NOPARAM, array('expiration' => 5000));
-    }
+	while(true) {
+		$start = microtime(true);
+		$ex->publish($message, 'ignored-for-fanout', AMQP_NOPARAM, array('expiration' => 5000));
+	}
 } catch (Exception $e) {}
 
 try {
 	while(true) {
 		$start = microtime(true);
-        // at this point publishing should be banned immediately
+        	// at this point publishing should be banned immediately
 		$ex->publish($message, 'ignored-for-fanout', AMQP_NOPARAM, array('expiration' => 5000));
 	}
 } catch (Exception $e) {
 	$end = microtime(true);
 	echo get_class($e);
 	echo PHP_EOL;
-    echo $e->getMessage();
-    echo PHP_EOL;
+	echo $e->getMessage();
+	echo PHP_EOL;
 }
 //$delay = abs($end - $start - $timeout);
 //echo $delay < 0.005 ? 'true' : 'false';


### PR DESCRIPTION
Custom exchange types (e.g. rabbitmq_consistent_hash_exchange) are not supported because of this exception. 
After removing this code on unknown exchange types, there will be an other meaningful exception.
Fatal error: Uncaught exception 'AMQPExchangeException' with message 'Server connection error: 503, message: COMMAND_INVALID - unknown exchange type 'unknown_exchange'

Any concerns about this?
