### PR TITLE
Fix for #50: race condition with multiple channels

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -162,18 +162,21 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_isConnected, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_getChannelId, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_setPrefetchSize, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
 	ZEND_ARG_INFO(0, size)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_getPrefetchSize, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_getPrefetchSize, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_setPrefetchCount, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
 	ZEND_ARG_INFO(0, count)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_getPrefetchCount, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_getPrefetchCount, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_qos, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
@@ -445,6 +448,9 @@ zend_function_entry amqp_connection_class_functions[] = {
 zend_function_entry amqp_channel_class_functions[] = {
 	PHP_ME(amqp_channel_class, __construct, 	arginfo_amqp_channel_class__construct,		ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_channel_class, isConnected, 	arginfo_amqp_channel_class_isConnected,		ZEND_ACC_PUBLIC)
+
+	PHP_ME(amqp_channel_class, getChannelId,    arginfo_amqp_channel_class_getChannelId,    ZEND_ACC_PUBLIC)
+
 	PHP_ME(amqp_channel_class, setPrefetchSize, arginfo_amqp_channel_class_setPrefetchSize,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_channel_class, getPrefetchSize, arginfo_amqp_channel_class_getPrefetchSize,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_channel_class, setPrefetchCount,arginfo_amqp_channel_class_setPrefetchCount,ZEND_ACC_PUBLIC)

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -228,6 +228,24 @@ PHP_METHOD(amqp_channel_class, isConnected)
 }
 /* }}} */
 
+/* {{{ proto bool amqp::getChannelId()
+get amqp channel ID */
+PHP_METHOD(amqp_channel_class, getChannelId)
+{
+	zval *id;
+	amqp_channel_object *channel;
+
+	/* Try to pull amqp object out of method params */
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &id, amqp_channel_class_entry) == FAILURE) {
+		return;
+	}
+
+	/* Get the channel object out of the store */
+	channel = (amqp_channel_object *)zend_object_store_get_object(id TSRMLS_CC);
+
+	RETURN_LONG(channel->channel_id);
+}
+/* }}} */
 
 /* {{{ proto bool amqp::setPrefetchCount(long count)
 set the number of prefetches */

--- a/amqp_channel.h
+++ b/amqp_channel.h
@@ -29,6 +29,7 @@ zend_object_value amqp_channel_ctor(zend_class_entry *ce TSRMLS_DC);
 
 PHP_METHOD(amqp_channel_class, __construct);
 PHP_METHOD(amqp_channel_class, isConnected);
+PHP_METHOD(amqp_channel_class, getChannelId);
 PHP_METHOD(amqp_channel_class, setPrefetchSize);
 PHP_METHOD(amqp_channel_class, getPrefetchSize);
 PHP_METHOD(amqp_channel_class, setPrefetchCount);

--- a/stubs/AMQPChannel.php
+++ b/stubs/AMQPChannel.php
@@ -41,6 +41,15 @@ class AMQPChannel
     }
 
     /**
+     * Return internal channel ID
+     *
+     * @return integer
+     */
+    public function getChannelId ()
+    {
+    }
+
+    /**
      * Set the Quality Of Service settings for the given channel.
      *
      * Specify the amount of data to prefetch in terms of window size (octets)

--- a/tests/bug_gh50-1.phpt
+++ b/tests/bug_gh50-1.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Channel creation race condition (https://github.com/pdezwart/php-amqp/issues/50) (1)
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$connection = new AMQPConnection();
+$connection->connect();
+
+for ($i = 0; $i < 3; $i++) {
+
+    $channel = new AMQPChannel($connection);
+    var_dump($channel->getChannelId());
+
+    $queue = new AMQPQueue($channel);
+    $queue->setName('test' . $i);
+
+    $queue->declare();
+    $queue->delete();
+}
+?>
+==DONE==
+--EXPECT--
+int(1)
+int(2)
+int(3)
+==DONE==

--- a/tests/bug_gh50-2.phpt
+++ b/tests/bug_gh50-2.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Channel creation race condition (https://github.com/pdezwart/php-amqp/issues/50) (2)
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$connection = new AMQPConnection();
+$connection->connect();
+
+for ($i = 0; $i < 3; $i++) {
+
+    $channel = new AMQPChannel($connection);
+    var_dump($channel->getChannelId());
+
+    $queue = new AMQPQueue($channel);
+    $queue->setName('test' . $i);
+
+    $queue->declare();
+    $queue->delete();
+
+	unset($queue);
+	unset($channel);
+}
+?>
+==DONE==
+--EXPECT--
+int(1)
+int(2)
+int(3)
+==DONE==

--- a/tests/bug_gh50-3.phpt
+++ b/tests/bug_gh50-3.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Channel creation race condition (https://github.com/pdezwart/php-amqp/issues/50) (3)
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$connection = new AMQPConnection();
+$connection->connect();
+
+for ($i = 0; $i < 3; $i++) {
+
+    $channel = new AMQPChannel($connection);
+    var_dump($channel->getChannelId());
+
+    $queue = new AMQPQueue($channel);
+    $queue->setName('test' . $i);
+
+    $queue->declare();
+    $queue->delete();
+}
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+for ($i = 0; $i < 3; $i++) {
+
+    $channel = new AMQPChannel($connection);
+    var_dump($channel->getChannelId());
+
+    $queue = new AMQPQueue($channel);
+    $queue->setName('test' . $i);
+
+    $queue->declare();
+    $queue->delete();
+}
+
+
+?>
+==DONE==
+--EXPECT--
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)
+==DONE==

--- a/tests/bug_gh50-4.phpt
+++ b/tests/bug_gh50-4.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Channel creation race condition (https://github.com/pdezwart/php-amqp/issues/50) (4)
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$connection = new AMQPConnection();
+$connection->connect();
+
+$channels = array();
+
+for ($i = 0; $i < 3; $i++) {
+
+    $channel = $channels[] = new AMQPChannel($connection);
+    var_dump($channel->getChannelId());
+
+    $queue = new AMQPQueue($channel);
+    $queue->setName('test' . $i);
+
+    $queue->declare();
+    $queue->delete();
+}
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+for ($i = 0; $i < 3; $i++) {
+
+    $channel = $channels[] = new AMQPChannel($connection);
+    var_dump($channel->getChannelId());
+
+    $queue = new AMQPQueue($channel);
+    $queue->setName('test' . $i);
+
+    $queue->declare();
+    $queue->delete();
+}
+
+
+?>
+==DONE==
+--EXPECT--
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)
+==DONE==


### PR DESCRIPTION
Fix for opening multiple channels for the same connection (as reported in #50). Instead of freeing channel IDs, we mark them as used.

I am not sure about the ugly casts between long and amqp_channel structs to store an additional state. The other option would be to introduce an int array of slot_states to do it properly. What do you think?
