### PR TITLE
Invalid AMQP exceptions handling

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -570,14 +570,14 @@ zend_module_entry amqp_module_entry = {
 #endif
 	STANDARD_MODULE_PROPERTIES
 };
-	/* }}} */
+/* }}} */
 
 #ifdef COMPILE_DL_AMQP
 	ZEND_GET_MODULE(amqp)
 #endif
 
 
-void amqp_error(amqp_rpc_reply_t x, char ** pstr)
+void amqp_error(amqp_rpc_reply_t x, char **pstr, amqp_connection_object *connection, amqp_channel_object *channel)
 {
 	/* Trim new lines */
 	switch (x.reply_type) {
@@ -600,6 +600,10 @@ void amqp_error(amqp_rpc_reply_t x, char ** pstr)
 						m->reply_code,
 						(int) m->reply_text.len,
 						(char *)m->reply_text.bytes);
+
+					/* Close connection with all its channels */
+					php_amqp_disconnect(connection);
+
 					/* No more error handling necessary, returning. */
 					return;
 				}
@@ -609,6 +613,10 @@ void amqp_error(amqp_rpc_reply_t x, char ** pstr)
 						m->reply_code,
 						(int)m->reply_text.len,
 						(char *)m->reply_text.bytes);
+
+					/* Close channel */
+					remove_channel_from_connection(connection, channel);
+
 					/* No more error handling necessary, returning. */
 					return;
 				}

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -182,7 +182,8 @@ PHP_METHOD(amqp_channel_class, __construct)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char ** pstr = (char **) &str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
@@ -436,7 +437,7 @@ PHP_METHOD(amqp_channel_class, startTransaction)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char **pstr = (char **)&str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);
@@ -484,7 +485,7 @@ PHP_METHOD(amqp_channel_class, commitTransaction)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char **pstr = (char **)&str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);
@@ -531,7 +532,7 @@ PHP_METHOD(amqp_channel_class, rollbackTransaction)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char **pstr = (char **)&str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_channel_exception_class_entry, *pstr, 0 TSRMLS_CC);

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -522,7 +522,8 @@ PHP_METHOD(amqp_exchange_class, declareExchange)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char ** pstr = (char **) &str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		zend_throw_exception(amqp_exchange_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		efree(*pstr);
 		return;
@@ -589,7 +590,8 @@ PHP_METHOD(amqp_exchange_class, delete)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char ** pstr = (char **) &str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		zend_throw_exception(amqp_exchange_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;
@@ -940,7 +942,8 @@ PHP_METHOD(amqp_exchange_class, bind)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char ** pstr = (char **) &str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		zend_throw_exception(amqp_exchange_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
 		return;

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -757,7 +757,8 @@ PHP_METHOD(amqp_queue_class, declareQueue)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char ** pstr = (char **) &str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		channel->is_connected = '\0';
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -836,7 +837,7 @@ PHP_METHOD(amqp_queue_class, bind)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char **pstr = (char **)&str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
@@ -1236,7 +1237,8 @@ PHP_METHOD(amqp_queue_class, purge)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char **pstr = (char **)&str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -1307,7 +1309,8 @@ PHP_METHOD(amqp_queue_class, cancel)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char **pstr = (char **)&str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		amqp_maybe_release_buffers(connection->connection_resource->connection_state);
@@ -1376,7 +1379,7 @@ PHP_METHOD(amqp_queue_class, unbind)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char ** pstr = (char **) &str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
 
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
@@ -1444,7 +1447,8 @@ PHP_METHOD(amqp_queue_class, delete)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		char str[256];
 		char **pstr = (char **)&str;
-		amqp_error(res, pstr);
+		amqp_error(res, pstr, connection, channel);
+
 		channel->is_connected = 0;
 		zend_throw_exception(amqp_queue_exception_class_entry, *pstr, 0 TSRMLS_CC);
 		amqp_maybe_release_buffers(connection->connection_resource->connection_state);

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -149,7 +149,6 @@ PHP_MINIT_FUNCTION(amqp);
 PHP_MSHUTDOWN_FUNCTION(amqp);
 PHP_MINFO_FUNCTION(amqp);
 
-void amqp_error(amqp_rpc_reply_t x, char ** pstr);
 amqp_table_t *convert_zval_to_arguments(zval *zvalArguments);
 char *stringify_bytes(amqp_bytes_t bytes);
 
@@ -171,8 +170,6 @@ extern zend_class_entry *amqp_exception_class_entry,
 #define CHANNEL_MAX							10			/* max number of channels allowed */
 #define HEADER_FOOTER_SIZE					8			/*  7 bytes up front, then payload, then 1 byte footer */
 #define AMQP_HEARTBEAT						0	   		/* heartbeat */
-
-#define DEFAULT_NUM_CONNECTION_CHANNELS		255
 
 #define DEFAULT_PORT						"5672"		/* default AMQP port */
 #define DEFAULT_HOST						"localhost"
@@ -410,6 +407,8 @@ typedef struct _amqp_envelope_object {
 #endif
 
 #define PHP_AMQP_VERSION "1.3.1-dev"
+
+void amqp_error(amqp_rpc_reply_t x, char **pstr, amqp_connection_object *connection, amqp_channel_object *channel);
 
 #endif	/* PHP_AMQP_H */
 

--- a/tests/amqpexchange_declare_existent.phpt
+++ b/tests/amqpexchange_declare_existent.phpt
@@ -9,6 +9,8 @@ $cnn->connect();
 
 $ch = new AMQPChannel($cnn);
 
+echo 'Channel id: ', $ch->getChannelId(), PHP_EOL;
+
 $exchangge_name = "exchange-" . microtime(true);
 
 $ex = new AMQPExchange($ch);
@@ -20,7 +22,7 @@ try {
     $ex = new AMQPExchange($ch);
     $ex->setName($exchangge_name);
     $ex->setType(AMQP_EX_TYPE_TOPIC);
-    echo "Exchange declared: ", $ex->declareExchange() ? "true" : "false", PHP_EOL;
+    $ex->declareExchange();
 } catch (AMQPExchangeException $e) {
     echo $e->getMessage(), PHP_EOL;
 }
@@ -28,9 +30,17 @@ try {
 echo "Channel connected: ", $ch->isConnected() ? "true" : "false", PHP_EOL;
 echo "Connection connected: ", $cnn->isConnected() ? "true" : "false", PHP_EOL;
 
+try {
+    $ex = new AMQPExchange($ch);
+} catch (AMQPChannelException $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
 ?>
 --EXPECTF--
+Channel id: %d
 Exchange declared: true
 Server channel error: 406, message: PRECONDITION_FAILED - cannot redeclare exchange 'exchange-%d.%d' in vhost '/' with different type, durable, internal or autodelete value
 Channel connected: false
 Connection connected: true
+Could not create exchange. No channel available.


### PR DESCRIPTION
According to AMQP Specification, section 4.8 - "Error Handling" on some kind or exception as they declared in section 1.2. - "AMQP­ defined Constants" we have to close channel or even connection (with all of it channels) and mark those object as disconnected to prevent their further usage in case of try-catch application survive.

In case of re-declaring already existent exchange with different params we doesn't properly close channel, which may lead in unexpected behavior when same channel being used.
