### PR TITLE
__construct exception

### DIFF
--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -179,7 +179,7 @@ PHP_METHOD(amqp_exchange_class, __construct)
 	amqp_channel_object *channel;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "OO", &id, amqp_exchange_class_entry, &channelObj, amqp_channel_class_entry) == FAILURE) {
-		zend_throw_exception(amqp_exchange_exception_class_entry, "Parameter must be an instance of AMQPConnection.", 0 TSRMLS_CC);
+		zend_throw_exception(amqp_exchange_exception_class_entry, "Parameter must be an instance of AMQPChannel.", 0 TSRMLS_CC);
 		RETURN_NULL();
 	}
 


### PR DESCRIPTION
Wrong exception message.

`"Parameter must be an instance of AMQPConnection."`

should be

`"Parameter must be an instance of AMQPChannel."`
