### PR TITLE
Use git tag and commit hash as version and revision whenever it is possible

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -859,7 +859,7 @@ PHP_MINFO_FUNCTION(amqp)
 {
 	php_info_print_table_start();
 	php_info_print_table_header(2, "Version",					PHP_AMQP_VERSION);
-	php_info_print_table_header(2, "Revision",					"$Revision: 327551 $");
+	php_info_print_table_header(2, "Revision",					PHP_AMQP_REVISION);
 	php_info_print_table_header(2, "Compiled",					__DATE__ " @ "  __TIME__);
 	php_info_print_table_header(2, "AMQP protocol version", 	"0-9-1");
 	php_info_print_table_header(2, "librabbitmq version", amqp_version());

--- a/config.m4
+++ b/config.m4
@@ -60,6 +60,25 @@ if test "$PHP_AMQP" != "no"; then
 	LIBNAME=rabbitmq
 	LIBSYMBOL=rabbitmq
 
+	if test -z "$TRAVIS" ; then
+		type git &>/dev/null
+
+		if test $? -eq 0 ; then
+			git describe --tags &>/dev/null
+
+			if test $? -eq 0 ; then
+				AC_DEFINE_UNQUOTED([PHP_AMQP_VERSION], ["`git describe --tags --abbr=0`-dev"], [git version])
+			fi
+
+			git rev-parse --short HEAD &>/dev/null
+
+			if test $? -eq 0 ; then
+				AC_DEFINE_UNQUOTED([PHP_AMQP_REVISION], ["`git rev-parse --short HEAD`"], [git revision])
+			fi
+		else
+			AC_MSG_NOTICE([git not installed. Cannot obtain php_amqp version tag. Install git.])
+		fi
+	fi
 
 	PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $AMQP_DIR/lib, AMQP_SHARED_LIBADD)
 	PHP_SUBST(AMQP_SHARED_LIBADD)

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -402,7 +402,13 @@ typedef struct _amqp_envelope_object {
 #define AMQP_G(v) (amqp_globals.v)
 #endif
 
+#ifndef PHP_AMQP_VERSION
 #define PHP_AMQP_VERSION "1.4.0"
+#endif
+
+#ifndef PHP_AMQP_REVISION
+#define PHP_AMQP_REVISION "no revision"
+#endif
 
 void amqp_error(amqp_rpc_reply_t x, char **pstr, amqp_connection_object *connection, amqp_channel_object *channel);
 


### PR DESCRIPTION
After migrating from svn codebase relies on  `PHP_AMQP_VERSION` constant and on revision string that depend of svn keyword (which is obviously doesn't work in git).

This changes doesn't affect codebase and just use git tag as version and git commit hash as revision in `php --ri amqp` output whenever it possible.

Also, it is possible to specify revision via `PHP_AMQP_REVISION` constant now.

**Before**:

```
Version => 1.4.0
Revision => $Revision: 327551 $
```

**after**:

When built from sources:

```
Version => v1.4.0-dev
Revision => 0abce99
```

When built with pecl:

```
Version => 1.4.0
Revision => no revision
```

_once again, revision may be defined via `PHP_AMQP_REVISION` constant in php_amqp.h_

I hope this changes will help to make issue reports more verbose.

The question is that generated extension version used in [package-version test](https://github.com/pdezwart/php-amqp/blob/master/tests/package-version.phpt), so I propose to auto-generate version only for local environments (see `TRAVIS` env vairable check in `config.m4`). Personally I don't like introducing env-specific variables in config files, but for now I see no other appropriate choice to deal with this problem. One of possible solutions: git tags juggling and/or package-version test skipping.
