### PR TITLE
Fix deprecation warnings when deprecated amqp.timeout overriden by it original value

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -611,10 +611,10 @@ PHP_METHOD(amqp_connection_class, __construct)
 		}
 	} else {
 
-	   if (DEFAULT_TIMEOUT != INI_STR("amqp.timeout")) {
+	   if (strcmp(DEFAULT_TIMEOUT, INI_STR("amqp.timeout")) != 0) {
 		   php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "INI setting 'amqp.timeout' is deprecated; use 'amqp.read_timeout' instead");
 
-		   if (DEFAULT_READ_TIMEOUT == INI_STR("amqp.read_timeout")) {
+		   if (strcmp(DEFAULT_READ_TIMEOUT, INI_STR("amqp.read_timeout")) == 0) {
 				connection->read_timeout = INI_FLT("amqp.timeout");
 		   } else {
 				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "INI setting 'amqp.read_timeout' will be used instead of 'amqp.timeout'");

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
+X.Y.Z Release:
+    * Add AMQP_DURABLE flag support to AMQPExchange::setFlags (librabbitmq version >= 0.5.3 required) (Bogdan Padalko)
+    * Fix inconsistent INI values comparison which leads to deprecation warnings (Bogdan Padalko)
+
 1.4.0 Release:
     * Fix #72: Publishing to an exchange with an empty name is valid and should not throw an exception (lstrojny)
     * Fix #77: AMQPQueue::delete() now no longer returns a boolean, but an integer of how many messages were deleted. WARNING: this can potentially break BC (Bogdan Padalko)

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -169,7 +169,7 @@ extern zend_class_entry *amqp_exception_class_entry,
 
 #define DEFAULT_PORT						"5672"		/* default AMQP port */
 #define DEFAULT_HOST						"localhost"
-#define DEFAULT_TIMEOUT						NULL
+#define DEFAULT_TIMEOUT						""
 #define DEFAULT_READ_TIMEOUT				"0"
 #define DEFAULT_WRITE_TIMEOUT				"0"
 #define DEFAULT_CONNECT_TIMEOUT			"0"

--- a/stubs/AMQPExchange.php
+++ b/stubs/AMQPExchange.php
@@ -181,7 +181,8 @@ class AMQPExchange
      *
      * @param integer $flags A bitmask of flags. This call currently only
      *                       considers the following flags:
-     *                       AMQP_DURABLE, AMQP_PASSIVE.
+     *                       AMQP_DURABLE, AMQP_PASSIVE
+     *                       (and AMQP_DURABLE, if librabbitmq version >= 0.5.3)
      *
      * @return boolean True on success or false on failure.
      */

--- a/tests/amqpconnection_construct_ini_timeout_default.phpt
+++ b/tests/amqpconnection_construct_ini_timeout_default.phpt
@@ -1,0 +1,13 @@
+--TEST--
+AMQPConnection constructor with amqp.timeout ini value set in code to it default value
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+ini_set('amqp.timeout', ini_get('amqp.timeout'));
+
+$cnn = new AMQPConnection();
+var_dump($cnn->getReadTimeout());
+?>
+--EXPECTF--
+float(0)

--- a/tests/amqpexchange_declare_existent.phpt
+++ b/tests/amqpexchange_declare_existent.phpt
@@ -35,12 +35,11 @@ try {
 } catch (AMQPChannelException $e) {
     echo $e->getMessage(), PHP_EOL;
 }
-
 ?>
 --EXPECTF--
 Channel id: %d
 Exchange declared: true
-Server channel error: 406, message: PRECONDITION_FAILED - cannot redeclare exchange 'exchange-%d.%d' in vhost '/' with different type, durable, internal or autodelete value
+Server channel error: 406, message: PRECONDITION_FAILED - %s exchange 'exchange-%d.%d' in vhost '/'%s
 Channel connected: false
 Connection connected: true
 Could not create exchange. No channel available.


### PR DESCRIPTION
There was multiple reports from developers that AMQPConnection trigger deprecation warnings, especially when phpunit tests runt with process isolation on.

After some investigation done with the help of @aeryaguzov the code that trigger error was found. PHPUnit backups and then [restore ini settings](https://github.com/sebastianbergmann/phpunit/blob/b8b1d78bf3d7d4d07777d47a36362f700ace8c12/src/Framework/TestCase.php#L822), so `amqp.timeout` are overridden by it original value, i.e. it doesn't change it value in any way.

This PR adds problem demonstration and solution.

It would be nice to have it in next path release (1.4.1).
