### PR TITLE
Fixes and memleaks plumbing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - LIBRABBITMQ_VERSION=v0.4.0
 
 before_script:
+  - sh -c "php -i"
   - sh -c "git clone git://github.com/alanxz/rabbitmq-c.git"
   - sh -c "cd rabbitmq-c && git checkout ${LIBRABBITMQ_VERSION}"
   - sh -c "cd rabbitmq-c && git submodule init && git submodule update"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Object-oriented PHP bindings for the AMQP C library (https://github.com/alanxz/r
 
  Additional tools are pre-installed to make development process as simple as possible:
 
- - valgrind is ready to help find memory-related problems if you `export TEST_PHP_ARGS=m` before running tests
+ - valgrind is ready to help find memory-related problems if you `export TEST_PHP_ARGS=-m` before running tests
  - [phpbrew](https://github.com/phpbrew/phpbrew) waits to help you test extension on various PHP versions.
    `phpbrew install 5.6 +debug+default+fpm` is a nice start. To switch to some version just use `phpbrew switch <version>`.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "trusty64"
-  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  #config.vm.box = "trusty64"
+  config.vm.box = "utopic64"
+  #config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/utopic/current/utopic-server-cloudimg-amd64-vagrant-disk1.box"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/amqp.c
+++ b/amqp.c
@@ -471,15 +471,15 @@ zend_function_entry amqp_connection_class_functions[] = {
 	PHP_ME(amqp_connection_class, getTimeout, 	arginfo_amqp_connection_class_getTimeout,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_connection_class, setTimeout, 	arginfo_amqp_connection_class_setTimeout,	ZEND_ACC_PUBLIC)
 
-    PHP_ME(amqp_connection_class, getReadTimeout, 	arginfo_amqp_connection_class_getReadTimeout,	ZEND_ACC_PUBLIC)
-    PHP_ME(amqp_connection_class, setReadTimeout, 	arginfo_amqp_connection_class_setReadTimeout,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_connection_class, getReadTimeout, 	arginfo_amqp_connection_class_getReadTimeout,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_connection_class, setReadTimeout, 	arginfo_amqp_connection_class_setReadTimeout,	ZEND_ACC_PUBLIC)
 
-    PHP_ME(amqp_connection_class, getWriteTimeout, 	arginfo_amqp_connection_class_getWriteTimeout,	ZEND_ACC_PUBLIC)
-    PHP_ME(amqp_connection_class, setWriteTimeout, 	arginfo_amqp_connection_class_setWriteTimeout,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_connection_class, getWriteTimeout, 	arginfo_amqp_connection_class_getWriteTimeout,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_connection_class, setWriteTimeout, 	arginfo_amqp_connection_class_setWriteTimeout,	ZEND_ACC_PUBLIC)
 
-    PHP_ME(amqp_connection_class, getUsedChannels, arginfo_amqp_connection_class_getUsedChannels,	ZEND_ACC_PUBLIC)
-    PHP_ME(amqp_connection_class, getMaxChannels,  arginfo_amqp_connection_class_getMaxChannels,	ZEND_ACC_PUBLIC)
-    PHP_ME(amqp_connection_class, isPersistent, 	arginfo_amqp_connection_class_isPersistent,		ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_connection_class, getUsedChannels, arginfo_amqp_connection_class_getUsedChannels,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_connection_class, getMaxChannels,  arginfo_amqp_connection_class_getMaxChannels,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_connection_class, isPersistent, 	arginfo_amqp_connection_class_isPersistent,		ZEND_ACC_PUBLIC)
 
 	{NULL, NULL, NULL}	/* Must be the last line in amqp_functions[] */
 };

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -120,11 +120,12 @@ void php_amqp_close_channel(amqp_channel_object *channel TSRMLS_DC)
 		if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 			PHP_AMQP_INIT_ERROR_MESSAGE();
 
-			php_amqp_error(res, message, connection, channel TSRMLS_CC);
+			php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+			PHP_AMQP_DESTROY_ERROR_MESSAGE();
 			return;
 		}
 
@@ -230,11 +231,12 @@ PHP_METHOD(amqp_channel_class, __construct)
 
 		PHP_AMQP_INIT_ERROR_MESSAGE();
 
-		php_amqp_error(res, message, connection, channel TSRMLS_CC);
+		php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+		PHP_AMQP_DESTROY_ERROR_MESSAGE();
 		return;
 	}
 
@@ -259,11 +261,12 @@ PHP_METHOD(amqp_channel_class, __construct)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		PHP_AMQP_INIT_ERROR_MESSAGE();
 
-		php_amqp_error(res, message, connection, channel TSRMLS_CC);
+		php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+		PHP_AMQP_DESTROY_ERROR_MESSAGE();
 		return;
 	}
 
@@ -351,11 +354,12 @@ PHP_METHOD(amqp_channel_class, setPrefetchCount)
 		if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 			PHP_AMQP_INIT_ERROR_MESSAGE();
 
-			php_amqp_error(res, message, connection, channel TSRMLS_CC);
+			php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+			PHP_AMQP_DESTROY_ERROR_MESSAGE();
 			return;
 		}
 
@@ -422,11 +426,12 @@ PHP_METHOD(amqp_channel_class, setPrefetchSize)
 		if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 			PHP_AMQP_INIT_ERROR_MESSAGE();
 
-			php_amqp_error(res, message, connection, channel TSRMLS_CC);
+			php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+			PHP_AMQP_DESTROY_ERROR_MESSAGE();
 			return;
 		}
 
@@ -501,11 +506,12 @@ PHP_METHOD(amqp_channel_class, qos)
 		if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 			PHP_AMQP_INIT_ERROR_MESSAGE();
 
-			php_amqp_error(res, message, connection, channel TSRMLS_CC);
+			php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+			PHP_AMQP_DESTROY_ERROR_MESSAGE();
 			return;
 		}
 
@@ -548,11 +554,12 @@ PHP_METHOD(amqp_channel_class, startTransaction)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		PHP_AMQP_INIT_ERROR_MESSAGE();
 
-		php_amqp_error(res, message, connection, channel TSRMLS_CC);
+		php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+		PHP_AMQP_DESTROY_ERROR_MESSAGE();
 		return;
 	}
 
@@ -594,11 +601,12 @@ PHP_METHOD(amqp_channel_class, commitTransaction)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		PHP_AMQP_INIT_ERROR_MESSAGE();
 
-		php_amqp_error(res, message, connection, channel TSRMLS_CC);
+		php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+		PHP_AMQP_DESTROY_ERROR_MESSAGE();
 		return;
 	}
 
@@ -639,11 +647,12 @@ PHP_METHOD(amqp_channel_class, rollbackTransaction)
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
 		PHP_AMQP_INIT_ERROR_MESSAGE();
 
-		php_amqp_error(res, message, connection, channel TSRMLS_CC);
+		php_amqp_error(res, PHP_AMQP_ERROR_MESSAGE_PTR, connection, channel TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, *message, 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_ERROR_MESSAGE, 0 TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
+		PHP_AMQP_DESTROY_ERROR_MESSAGE();
 		return;
 	}
 

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -136,18 +136,15 @@ void php_amqp_close_channel(amqp_channel_object *channel TSRMLS_DC)
 void amqp_channel_dtor(void *object TSRMLS_DC)
 {
 	amqp_channel_object *channel = (amqp_channel_object*)object;
-	amqp_connection_object *connection;
-
-	connection = AMQP_GET_CONNECTION(channel);
 
 	if (channel->is_connected) {
 		php_amqp_close_channel(channel TSRMLS_CC);
 	}
 
-	assert(connection != NULL);
-
-	/* Destroy the connection storage */
-	zval_ptr_dtor(&channel->connection);
+	if (channel->connection != NULL) {
+		/* Destroy the connection storage */
+		zval_ptr_dtor(&channel->connection);
+	}
 
 	zend_object_std_dtor(&channel->zo TSRMLS_CC);
 
@@ -241,7 +238,8 @@ PHP_METHOD(amqp_channel_class, __construct)
 		return;
 	}
 
-	assert (r->channel_id == channel->channel_id);
+	/* r->channel_id is a 16-bit channel number insibe amqp_bytes_t, assertion below will without converting to uint16_t*/
+	/* assert (r->channel_id == channel->channel_id);*/
 	php_amqp_maybe_release_buffers_on_channel(connection, channel);
 
 	channel->is_connected = '\1';

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -502,11 +502,10 @@ PHP_METHOD(amqp_connection_class, __construct)
 		}
 	} else {
 
-		assert(DEFAULT_TIMEOUT == NULL);
+		assert(DEFAULT_TIMEOUT != NULL);
 		if (strcmp(DEFAULT_TIMEOUT, INI_STR("amqp.timeout")) != 0) {
 			php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "INI setting 'amqp.timeout' is deprecated; use 'amqp.read_timeout' instead");
 
-			assert(DEFAULT_READ_TIMEOUT != NULL);
 			if (strcmp(DEFAULT_READ_TIMEOUT, INI_STR("amqp.read_timeout")) == 0) {
 				connection->read_timeout = INI_FLT("amqp.timeout");
 			} else {

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -118,7 +118,7 @@ HashTable *amqp_connection_object_get_debug_info(zval *object, int *is_temp TSRM
 
 	if (connection && connection->connection_resource) {
 		ZVAL_RESOURCE(value, connection->connection_resource->resource_id);
-        zend_list_addref(connection->connection_resource->resource_id);
+		zend_list_addref(connection->connection_resource->resource_id);
 	} else {
 		ZVAL_NULL(value);
 	}
@@ -242,7 +242,7 @@ int php_amqp_connect(amqp_connection_object *connection, int persistent TSRMLS_D
 	if (persistent) {
 		zend_rsrc_list_entry *le;
 		/* Look for an established resource */
-    	key_len = spprintf(&key, 0, "amqp_conn_res_%s_%d_%s_%s_%s", connection->host, connection->port, connection->vhost, connection->login, connection->password);
+		key_len = spprintf(&key, 0, "amqp_conn_res_%s_%d_%s_%s_%s", connection->host, connection->port, connection->vhost, connection->login, connection->password);
 
 		if (zend_hash_find(&EG(persistent_list), key, key_len + 1, (void **)&le) == SUCCESS) {
 			efree(key);

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -221,8 +221,8 @@ amqp_channel_t php_amqp_connection_resource_get_available_channel_id(amqp_connec
 
 	/* Check if there are any open slots */
 	if (resource->used_slots >= PHP_AMQP_MAX_CHANNELS + 1) {
-    	return 0;
-    }
+		return 0;
+	}
 
 	amqp_channel_t slot;
 
@@ -274,11 +274,11 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_object
 	struct timeval *tv_ptr = &tv;
 
 	char *std_datetime;
-    amqp_table_entry_t client_properties_entries[5];
-    amqp_table_t       client_properties_table;
+	amqp_table_entry_t client_properties_entries[5];
+	amqp_table_t       client_properties_table;
 
-    amqp_table_entry_t custom_properties_entries[1];
-    amqp_table_t       custom_properties_table;
+	amqp_table_entry_t custom_properties_entries[1];
+	amqp_table_t       custom_properties_table;
 
 	amqp_connection_resource *resource;
 
@@ -350,8 +350,8 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_object
 	client_properties_entries[4].value.kind        = AMQP_FIELD_KIND_UTF8;
 	client_properties_entries[4].value.value.bytes = amqp_cstring_bytes(std_datetime);
 
-    client_properties_table.entries = client_properties_entries;
-    client_properties_table.num_entries = sizeof(client_properties_entries) / sizeof(amqp_table_entry_t);
+	client_properties_table.entries = client_properties_entries;
+	client_properties_table.num_entries = sizeof(client_properties_entries) / sizeof(amqp_table_entry_t);
 
 	custom_properties_entries[0].key               = amqp_cstring_bytes("client");
 	custom_properties_entries[0].value.kind        = AMQP_FIELD_KIND_TABLE;
@@ -377,12 +377,16 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_object
 	efree(std_datetime);
 
 	if (res.reply_type != AMQP_RESPONSE_NORMAL) {
-		PHP_AMQP_INIT_ERROR_MESSAGE();
+		char *message, *long_message;
 
-		php_amqp_connection_resource_error(res, message, resource, 0 TSRMLS_CC);
+		php_amqp_connection_resource_error(res, &message, resource, 0 TSRMLS_CC);
 
-		strcat(*message, " - Potential login failure.");
-		zend_throw_exception(amqp_connection_exception_class_entry, *message, 0 TSRMLS_CC);
+		spprintf(&long_message, 0, "%s - Potential login failure.", message);
+		zend_throw_exception(amqp_connection_exception_class_entry, long_message, 0 TSRMLS_CC);
+
+		efree(message);
+		efree(long_message);
+
 		/* https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf
 		 *
 		 * 2.2.4 The Connection Class:

--- a/amqp_envelope.c
+++ b/amqp_envelope.c
@@ -579,11 +579,8 @@ PHP_METHOD(amqp_envelope_class, getHeaders)
 	/* Get the envelope object out of the store */
 	envelope = (amqp_envelope_object *)zend_object_store_get_object(id TSRMLS_CC);
 
-	*return_value = *envelope->headers;
-	zval_copy_ctor(return_value);
-
-	/* Increment the ref count */
-	Z_ADDREF_P(envelope->headers);
+	zval_dtor(return_value);
+	MAKE_COPY_ZVAL(&envelope->headers, return_value);
 }
 /* }}} */
 

--- a/amqp_object_store.c
+++ b/amqp_object_store.c
@@ -8,6 +8,10 @@
 
 void *amqp_object_store_get_valid_object(const zval *zobject TSRMLS_DC)
 {
+	if(zobject == NULL) {
+		return NULL;
+	}
+
 	zend_object_handle handle;
 	zend_object_store_bucket bucket;
 

--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
  <notes>
 X.Y.Z Release:
     * Add support for nested arguments values (Bogdan Padalko)
-    * Add auto_delete and internal flags support for AMQPExchange::declare (requires rabbitmq (Bogdan Padalko)
+    * Add auto_delete and internal flags support for AMQPExchange::declare (librabbitmq version > 0.5.2 required) (Bogdan Padalko)
     * Fix persistence support (Bogdan Padalko)
     * Add AMQPExchange::unbind method and fix AMQPExchange::bind method. WARNING: this can potentially break BC
     * Add support to consume messages from multiple queues (Bogdan Padalko)

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -189,7 +189,7 @@ extern zend_class_entry *amqp_exception_class_entry,
 #define DEFAULT_TIMEOUT						""
 #define DEFAULT_READ_TIMEOUT				"0"
 #define DEFAULT_WRITE_TIMEOUT				"0"
-#define DEFAULT_CONNECT_TIMEOUT			"0"
+#define DEFAULT_CONNECT_TIMEOUT				"0"
 #define DEFAULT_VHOST						"/"
 #define DEFAULT_LOGIN						"guest"
 #define DEFAULT_PASSWORD					"guest"
@@ -292,9 +292,14 @@ extern zend_class_entry *amqp_exception_class_entry,
 		AMQP_VERIFY_CONNECTION_ERROR(error, "No connection available.") \
 	} \
 
+#define PHP_AMQP_ERROR_MESSAGE_PTR  &php_amqp_internal_error_message
+#define PHP_AMQP_ERROR_MESSAGE       php_amqp_internal_error_message
+
 #define PHP_AMQP_INIT_ERROR_MESSAGE()\
-	char __internal_message[256]; \
-	char ** message = (char **) &__internal_message; \
+	char *PHP_AMQP_ERROR_MESSAGE = NULL;
+
+#define PHP_AMQP_DESTROY_ERROR_MESSAGE()\
+	if (PHP_AMQP_ERROR_MESSAGE != NULL) { efree(PHP_AMQP_ERROR_MESSAGE); }
 
 #if ZEND_MODULE_API_NO >= 20100000
 	#define AMQP_OBJECT_PROPERTIES_INIT(obj, ce) object_properties_init(&obj, ce);
@@ -322,7 +327,7 @@ typedef struct _amqp_connection_resource {
 	zend_bool is_connected;
 	int resource_id;
 	amqp_channel_t used_slots;
-    amqp_channel_object **slots;
+	amqp_channel_object **slots;
 	char *resource_key;
 	int resource_key_len;
 	amqp_connection_state_t connection_state;
@@ -334,13 +339,9 @@ typedef struct _amqp_connection_object {
 	char is_connected;
 	char is_persistent;
 	char *login;
-	int login_len;
 	char *password;
-	int password_len;
 	char *host;
-	int host_len;
 	char *vhost;
-	int vhost_len;
 	int port;
 	double read_timeout;
 	double write_timeout;

--- a/tests/amqpexchange_declare_existent.phpt
+++ b/tests/amqpexchange_declare_existent.phpt
@@ -23,6 +23,7 @@ try {
     $ex->setName($exchangge_name);
     $ex->setType(AMQP_EX_TYPE_TOPIC);
     $ex->declareExchange();
+    echo 'exchange ', $ex->getName(), ' declared', PHP_EOL;
 } catch (AMQPException $e) {
     echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
 }

--- a/tests/amqpexchange_publish_with_properties.phpt
+++ b/tests/amqpexchange_publish_with_properties.phpt
@@ -58,25 +58,48 @@ echo 'Message attributes are ', $attrs == $attrs_control ? 'the same' : 'not the
 
 $msg = $q->get(AMQP_AUTOACK);
 
-function dump_message(AMQPEnvelope $msg) {
+function dump_message($msg) {
+    if (!$msg) {
+        var_dump($msg);
+        return;
+    }
+
     echo get_class($msg), PHP_EOL;
+    echo "    getBody:", PHP_EOL, "        ";
     var_dump($msg->getBody());
+    echo "    getContentType:", PHP_EOL, "        ";
     var_dump($msg->getContentType());
+    echo "    getRoutingKey:", PHP_EOL, "        ";
     var_dump($msg->getRoutingKey());
+    echo "    getDeliveryTag:", PHP_EOL, "        ";
     var_dump($msg->getDeliveryTag());
+    echo "    getDeliveryMode:", PHP_EOL, "        ";
     var_dump($msg->getDeliveryMode());
+    echo "    getExchangeName:", PHP_EOL, "        ";
     var_dump($msg->getExchangeName());
+    echo "    isRedelivery:", PHP_EOL, "        ";
     var_dump($msg->isRedelivery());
+    echo "    getContentEncoding:", PHP_EOL, "        ";
     var_dump($msg->getContentEncoding());
+    echo "    getType:", PHP_EOL, "        ";
     var_dump($msg->getType());
+    echo "    getTimeStamp:", PHP_EOL, "        ";
     var_dump($msg->getTimeStamp());
+    echo "    getPriority:", PHP_EOL, "        ";
     var_dump($msg->getPriority());
+    echo "    getExpiration:", PHP_EOL, "        ";
     var_dump($msg->getExpiration());
+    echo "    getUserId:", PHP_EOL, "        ";
     var_dump($msg->getUserId());
+    echo "    getAppId:", PHP_EOL, "        ";
     var_dump($msg->getAppId());
+    echo "    getMessageId:", PHP_EOL, "        ";
     var_dump($msg->getMessageId());
+    echo "    getReplyTo:", PHP_EOL, "        ";
     var_dump($msg->getReplyTo());
+    echo "    getCorrelationId:", PHP_EOL, "        ";
     var_dump($msg->getCorrelationId());
+    echo "    getHeaders:", PHP_EOL, "        ";
     var_dump($msg->getHeaders());
 }
 
@@ -91,22 +114,40 @@ $q->delete();
 true
 Message attributes are the same
 AMQPEnvelope
-string(7) "message"
-string(1) "1"
-string(11) "routing.key"
-int(1)
-int(1)
-string(%d) "exchange-%f"
-bool(false)
-string(1) "2"
-string(1) "7"
-int(123)
-int(2)
-string(9) "100000000"
-string(0) ""
-string(1) "5"
-string(1) "3"
-string(1) "8"
-string(1) "9"
-array(0) {
+    getBody:
+        string(7) "message"
+    getContentType:
+        string(1) "1"
+    getRoutingKey:
+        string(11) "routing.key"
+    getDeliveryTag:
+        int(1)
+    getDeliveryMode:
+        int(1)
+    getExchangeName:
+        string(%d) "exchange-%f"
+    isRedelivery:
+        bool(false)
+    getContentEncoding:
+        string(1) "2"
+    getType:
+        string(1) "7"
+    getTimeStamp:
+        int(123)
+    getPriority:
+        int(2)
+    getExpiration:
+        string(9) "100000000"
+    getUserId:
+        string(0) ""
+    getAppId:
+        string(1) "5"
+    getMessageId:
+        string(1) "3"
+    getReplyTo:
+        string(1) "8"
+    getCorrelationId:
+        string(1) "9"
+    getHeaders:
+        array(0) {
 }

--- a/tests/amqpexchange_publish_with_properties_ignore_unsupported_header_values.phpt
+++ b/tests/amqpexchange_publish_with_properties_ignore_unsupported_header_values.phpt
@@ -17,7 +17,7 @@ $ex->declareExchange();
 $attrs = array(
     'headers' => array(
         'null'     => null,
-        'object'   => new DateTime(),
+        'object'   => new stdClass(),
         'resource' => fopen(__FILE__, 'r'),
     ),
 );

--- a/tests/amqpqueue_consume_basic.phpt
+++ b/tests/amqpqueue_consume_basic.phpt
@@ -30,26 +30,49 @@ $ex->publish('message3', 'routing.3', AMQP_DURABLE); // this is wrong way to mak
 
 $count = 0;
 
-function dump_message(AMQPEnvelope $msg) {
-  echo get_class($msg), PHP_EOL;
-  var_dump($msg->getBody());
-  var_dump($msg->getContentType());
-  var_dump($msg->getRoutingKey());
-  var_dump($msg->getDeliveryTag());
-  var_dump($msg->getDeliveryMode());
-  var_dump($msg->getExchangeName());
-  var_dump($msg->isRedelivery());
-  var_dump($msg->getContentEncoding());
-  var_dump($msg->getType());
-  var_dump($msg->getTimeStamp());
-  var_dump($msg->getPriority());
-  var_dump($msg->getExpiration());
-  var_dump($msg->getUserId());
-  var_dump($msg->getAppId());
-  var_dump($msg->getMessageId());
-  var_dump($msg->getReplyTo());
-  var_dump($msg->getCorrelationId());
-  var_dump($msg->getHeaders());
+function dump_message($msg) {
+    if (!$msg) {
+        var_dump($msg);
+        return;
+    }
+
+    echo get_class($msg), PHP_EOL;
+    echo "    getBody:", PHP_EOL, "        ";
+    var_dump($msg->getBody());
+    echo "    getContentType:", PHP_EOL, "        ";
+    var_dump($msg->getContentType());
+    echo "    getRoutingKey:", PHP_EOL, "        ";
+    var_dump($msg->getRoutingKey());
+    echo "    getDeliveryTag:", PHP_EOL, "        ";
+    var_dump($msg->getDeliveryTag());
+    echo "    getDeliveryMode:", PHP_EOL, "        ";
+    var_dump($msg->getDeliveryMode());
+    echo "    getExchangeName:", PHP_EOL, "        ";
+    var_dump($msg->getExchangeName());
+    echo "    isRedelivery:", PHP_EOL, "        ";
+    var_dump($msg->isRedelivery());
+    echo "    getContentEncoding:", PHP_EOL, "        ";
+    var_dump($msg->getContentEncoding());
+    echo "    getType:", PHP_EOL, "        ";
+    var_dump($msg->getType());
+    echo "    getTimeStamp:", PHP_EOL, "        ";
+    var_dump($msg->getTimeStamp());
+    echo "    getPriority:", PHP_EOL, "        ";
+    var_dump($msg->getPriority());
+    echo "    getExpiration:", PHP_EOL, "        ";
+    var_dump($msg->getExpiration());
+    echo "    getUserId:", PHP_EOL, "        ";
+    var_dump($msg->getUserId());
+    echo "    getAppId:", PHP_EOL, "        ";
+    var_dump($msg->getAppId());
+    echo "    getMessageId:", PHP_EOL, "        ";
+    var_dump($msg->getMessageId());
+    echo "    getReplyTo:", PHP_EOL, "        ";
+    var_dump($msg->getReplyTo());
+    echo "    getCorrelationId:", PHP_EOL, "        ";
+    var_dump($msg->getCorrelationId());
+    echo "    getHeaders:", PHP_EOL, "        ";
+    var_dump($msg->getHeaders());
 }
 
 function consumeThings($message, $queue) {
@@ -78,46 +101,82 @@ $ex->delete();
 --EXPECTF--
 call #0
 AMQPEnvelope
-string(8) "message1"
-string(10) "plain/test"
-string(9) "routing.1"
-int(1)
-int(0)
-string(%d) "exchange-%f"
-bool(false)
-string(0) ""
-string(0) ""
-int(0)
-int(0)
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-array(1) {
+    getBody:
+        string(8) "message1"
+    getContentType:
+        string(10) "plain/test"
+    getRoutingKey:
+        string(9) "routing.1"
+    getDeliveryTag:
+        int(1)
+    getDeliveryMode:
+        int(0)
+    getExchangeName:
+        string(%d) "exchange-%f"
+    isRedelivery:
+        bool(false)
+    getContentEncoding:
+        string(0) ""
+    getType:
+        string(0) ""
+    getTimeStamp:
+        int(0)
+    getPriority:
+        int(0)
+    getExpiration:
+        string(0) ""
+    getUserId:
+        string(0) ""
+    getAppId:
+        string(0) ""
+    getMessageId:
+        string(0) ""
+    getReplyTo:
+        string(0) ""
+    getCorrelationId:
+        string(0) ""
+    getHeaders:
+        array(1) {
   ["foo"]=>
   string(3) "bar"
 }
 
 call #1
 AMQPEnvelope
-string(8) "message2"
-string(10) "text/plain"
-string(9) "routing.2"
-int(2)
-int(2)
-string(%d) "exchange-%f"
-bool(false)
-string(0) ""
-string(0) ""
-int(0)
-int(0)
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-array(0) {
+    getBody:
+        string(8) "message2"
+    getContentType:
+        string(10) "text/plain"
+    getRoutingKey:
+        string(9) "routing.2"
+    getDeliveryTag:
+        int(2)
+    getDeliveryMode:
+        int(2)
+    getExchangeName:
+        string(%d) "exchange-%f"
+    isRedelivery:
+        bool(false)
+    getContentEncoding:
+        string(0) ""
+    getType:
+        string(0) ""
+    getTimeStamp:
+        int(0)
+    getPriority:
+        int(0)
+    getExpiration:
+        string(0) ""
+    getUserId:
+        string(0) ""
+    getAppId:
+        string(0) ""
+    getMessageId:
+        string(0) ""
+    getReplyTo:
+        string(0) ""
+    getCorrelationId:
+        string(0) ""
+    getHeaders:
+        array(0) {
 }

--- a/tests/amqpqueue_get_basic.phpt
+++ b/tests/amqpqueue_get_basic.phpt
@@ -28,30 +28,48 @@ $ex->publish('message2', 'routing.2', AMQP_DURABLE);
 $ex->publish('message3', 'routing.3');
 
 function dump_message($msg) {
-  if (!$msg) {
-    var_dump($msg);
-    return;
-  }
+    if (!$msg) {
+        var_dump($msg);
+        return;
+    }
 
-  echo get_class($msg), PHP_EOL;
-  var_dump($msg->getBody());
-  var_dump($msg->getContentType());
-  var_dump($msg->getRoutingKey());
-  var_dump($msg->getDeliveryTag());
-  var_dump($msg->getDeliveryMode());
-  var_dump($msg->getExchangeName());
-  var_dump($msg->isRedelivery());
-  var_dump($msg->getContentEncoding());
-  var_dump($msg->getType());
-  var_dump($msg->getTimeStamp());
-  var_dump($msg->getPriority());
-  var_dump($msg->getExpiration());
-  var_dump($msg->getUserId());
-  var_dump($msg->getAppId());
-  var_dump($msg->getMessageId());
-  var_dump($msg->getReplyTo());
-  var_dump($msg->getCorrelationId());
-  var_dump($msg->getHeaders());
+    echo get_class($msg), PHP_EOL;
+    echo "    getBody:", PHP_EOL, "        ";
+    var_dump($msg->getBody());
+    echo "    getContentType:", PHP_EOL, "        ";
+    var_dump($msg->getContentType());
+    echo "    getRoutingKey:", PHP_EOL, "        ";
+    var_dump($msg->getRoutingKey());
+    echo "    getDeliveryTag:", PHP_EOL, "        ";
+    var_dump($msg->getDeliveryTag());
+    echo "    getDeliveryMode:", PHP_EOL, "        ";
+    var_dump($msg->getDeliveryMode());
+    echo "    getExchangeName:", PHP_EOL, "        ";
+    var_dump($msg->getExchangeName());
+    echo "    isRedelivery:", PHP_EOL, "        ";
+    var_dump($msg->isRedelivery());
+    echo "    getContentEncoding:", PHP_EOL, "        ";
+    var_dump($msg->getContentEncoding());
+    echo "    getType:", PHP_EOL, "        ";
+    var_dump($msg->getType());
+    echo "    getTimeStamp:", PHP_EOL, "        ";
+    var_dump($msg->getTimeStamp());
+    echo "    getPriority:", PHP_EOL, "        ";
+    var_dump($msg->getPriority());
+    echo "    getExpiration:", PHP_EOL, "        ";
+    var_dump($msg->getExpiration());
+    echo "    getUserId:", PHP_EOL, "        ";
+    var_dump($msg->getUserId());
+    echo "    getAppId:", PHP_EOL, "        ";
+    var_dump($msg->getAppId());
+    echo "    getMessageId:", PHP_EOL, "        ";
+    var_dump($msg->getMessageId());
+    echo "    getReplyTo:", PHP_EOL, "        ";
+    var_dump($msg->getReplyTo());
+    echo "    getCorrelationId:", PHP_EOL, "        ";
+    var_dump($msg->getCorrelationId());
+    echo "    getHeaders:", PHP_EOL, "        ";
+    var_dump($msg->getHeaders());
 }
 
 for ($i = 0; $i < 4; $i++) {
@@ -66,70 +84,124 @@ for ($i = 0; $i < 4; $i++) {
 --EXPECTF--
 call #0
 AMQPEnvelope
-string(8) "message1"
-string(10) "plain/test"
-string(9) "routing.1"
-int(1)
-int(0)
-string(%d) "exchange-%f"
-bool(false)
-string(0) ""
-string(0) ""
-int(0)
-int(0)
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-array(1) {
+    getBody:
+        string(8) "message1"
+    getContentType:
+        string(10) "plain/test"
+    getRoutingKey:
+        string(9) "routing.1"
+    getDeliveryTag:
+        int(1)
+    getDeliveryMode:
+        int(0)
+    getExchangeName:
+        string(%d) "exchange-%f"
+    isRedelivery:
+        bool(false)
+    getContentEncoding:
+        string(0) ""
+    getType:
+        string(0) ""
+    getTimeStamp:
+        int(0)
+    getPriority:
+        int(0)
+    getExpiration:
+        string(0) ""
+    getUserId:
+        string(0) ""
+    getAppId:
+        string(0) ""
+    getMessageId:
+        string(0) ""
+    getReplyTo:
+        string(0) ""
+    getCorrelationId:
+        string(0) ""
+    getHeaders:
+        array(1) {
   ["foo"]=>
   string(3) "bar"
 }
 
 call #1
 AMQPEnvelope
-string(8) "message2"
-string(10) "text/plain"
-string(9) "routing.2"
-int(2)
-int(0)
-string(%d) "exchange-%f"
-bool(false)
-string(0) ""
-string(0) ""
-int(0)
-int(0)
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-array(0) {
+    getBody:
+        string(8) "message2"
+    getContentType:
+        string(10) "text/plain"
+    getRoutingKey:
+        string(9) "routing.2"
+    getDeliveryTag:
+        int(2)
+    getDeliveryMode:
+        int(0)
+    getExchangeName:
+        string(%d) "exchange-%f"
+    isRedelivery:
+        bool(false)
+    getContentEncoding:
+        string(0) ""
+    getType:
+        string(0) ""
+    getTimeStamp:
+        int(0)
+    getPriority:
+        int(0)
+    getExpiration:
+        string(0) ""
+    getUserId:
+        string(0) ""
+    getAppId:
+        string(0) ""
+    getMessageId:
+        string(0) ""
+    getReplyTo:
+        string(0) ""
+    getCorrelationId:
+        string(0) ""
+    getHeaders:
+        array(0) {
 }
 
 call #2
 AMQPEnvelope
-string(8) "message3"
-string(10) "text/plain"
-string(9) "routing.3"
-int(3)
-int(0)
-string(%d) "exchange-%f"
-bool(false)
-string(0) ""
-string(0) ""
-int(0)
-int(0)
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-array(0) {
+    getBody:
+        string(8) "message3"
+    getContentType:
+        string(10) "text/plain"
+    getRoutingKey:
+        string(9) "routing.3"
+    getDeliveryTag:
+        int(3)
+    getDeliveryMode:
+        int(0)
+    getExchangeName:
+        string(%d) "exchange-%f"
+    isRedelivery:
+        bool(false)
+    getContentEncoding:
+        string(0) ""
+    getType:
+        string(0) ""
+    getTimeStamp:
+        int(0)
+    getPriority:
+        int(0)
+    getExpiration:
+        string(0) ""
+    getUserId:
+        string(0) ""
+    getAppId:
+        string(0) ""
+    getMessageId:
+        string(0) ""
+    getReplyTo:
+        string(0) ""
+    getCorrelationId:
+        string(0) ""
+    getHeaders:
+        array(0) {
 }
 
 call #3


### PR DESCRIPTION
 - Fix segfault when NULL passed to AMQPChannel constructor (`new AMQPChannel(null);` will cause segmentation fault instead of fatal error)`. This may happens when undefined or unitialized variable passed instead of proper `AMQPConnection` object.
 - Plumb numerous memleaks introduced in previous PR (mainly, by me). Sorry for that.
 - Various formating and typo fixes, unused variable removal.