### PR TITLE
Drop PHP 5.2 support in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.2
   - 5.3
   - 5.4
   - 5.5


### PR DESCRIPTION
Recently PHP 5.2 support was removed from travis (see https://github.com/travis-ci/travis-ci/issues/3152 issue), so [builds against 5.2 fails now](https://travis-ci.org/pdezwart/php-amqp/jobs/49616792).

As [5.2 is totally outdated](http://php.net/supported-versions.php) (5.3 too, but not as much as 5.2) and wast majority of modern tools doesn't work well with it neither provide support for it we may also drop it support, at least in CI environment without any problems for end-users. I also don't know any repo (in centos or debian, ubuntu) that provide packages for PHP 5.2, so if anyone will goes into some troubles we'll get a report.