### PR TITLE
Fix segfault when catchable fatal error happens in consumer, closes #147

### DIFF
--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -98,10 +98,12 @@ void php_amqp_close_channel(amqp_channel_object *channel TSRMLS_DC)
 	/* Pull out and verify the connection */
 	connection = AMQP_GET_CONNECTION(channel);
 
-	assert(connection != NULL);
-
-	/* First, remove it from active channels table to prevent recursion in case of connection error */
-	php_amqp_connection_resource_unregister_channel(connection->connection_resource, channel->channel_id);
+	if (connection != NULL) {
+        /* First, remove it from active channels table to prevent recursion in case of connection error */
+        php_amqp_connection_resource_unregister_channel(connection->connection_resource, channel->channel_id);
+	} else {
+	    channel->is_connected = '\0';
+	}
 
 	if (!channel->is_connected) {
 		/* Nothing to do more - channel was previously marked as closed, possibly, due to channel-level error */

--- a/tests/bug_gh147.phpt
+++ b/tests/bug_gh147.phpt
@@ -1,0 +1,44 @@
+--TEST--
+#147 Segfault when catchable fatal error happens in consumer
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$time = microtime(true);
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$channel = new AMQPChannel($connection);
+$channel->setPrefetchCount(2);
+
+$exchange = new AMQPExchange($channel);
+$exchange->setType(AMQP_EX_TYPE_TOPIC);
+$exchange->setName('test_' . $time);
+$exchange->setFlags(AMQP_AUTODELETE);
+$exchange->declareExchange();
+
+$queue = new AMQPQueue($channel);
+$queue->setName('test_' . $time);
+$queue->declareQueue();
+
+$queue->bind($exchange->getName(), 'test');
+
+$exchange->publish('test message', 'test');
+
+echo 'start', PHP_EOL;
+$queue->consume(function(AMQPEnvelope $e) use (&$consume) {
+    echo 'consuming';
+    $e . 'should fail';
+
+    return false;
+});
+
+echo 'done', PHP_EOL;
+
+
+?>
+--EXPECTF--
+start
+consuming
+Catchable fatal error: Object of class %s could not be converted to string in %s on line %d


### PR DESCRIPTION
This PR should be included in 1.6.0 release as it fix quite critical issue.