### PR TITLE
Removed alias for declare as declare is a directive in php

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -511,8 +511,6 @@ zend_function_entry amqp_queue_class_functions[] = {
 	PHP_ME(amqp_queue_class, getChannel,		arginfo_amqp_queue_class_getChannel,		ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_queue_class, getConnection,		arginfo_amqp_queue_class_getConnection,		ZEND_ACC_PUBLIC)
 
-	PHP_MALIAS(amqp_queue_class, declare, declareQueue, arginfo_amqp_queue_class_declareQueue,	ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
-
 	{NULL, NULL, NULL}	/* Must be the last line in amqp_functions[] */
 };
 
@@ -540,8 +538,6 @@ zend_function_entry amqp_exchange_class_functions[] = {
 
 	PHP_ME(amqp_exchange_class, getChannel,		arginfo_amqp_exchange_class_getChannel,		ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_exchange_class, getConnection,	arginfo_amqp_exchange_class_getConnection,	ZEND_ACC_PUBLIC)
-
-	PHP_MALIAS(amqp_exchange_class, declare, declareExchange, arginfo_amqp_exchange_class_declareExchange, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 
 	{NULL, NULL, NULL}	/* Must be the last line in amqp_functions[] */
 };


### PR DESCRIPTION
While trying to use the AMQP extension with Symfony2 DI, because proxies are used when declaring a service as lazy, we get the following error:

```HP Parse error:  syntax error, unexpected 'declare' (T_DECLARE), expecting identifier (T_STRING) in...```

The commit fixes the issue.