### PR TITLE
Fix invalid delivery mode returned by AMQPEnvelop::getDeliveryMode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ tests/*.out
 tests/*.php
 tests/*.sh
 tests/*.mem
+!tests/_test_helpers.php
 php_test_results_*
 tmp-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 5.6
   - 7.0
 
+sudo: false
+
 services:
   - rabbitmq
 
@@ -17,15 +19,15 @@ matrix:
   allow_failures:
     - php: 7.0
 
-install:
-  - sudo apt-get update
-  - sudo apt-get -qq --fix-missing install valgrind
-
-  - wget -qO - http://www.rabbitmq.com/rabbitmq-signing-key-public.asc | sudo apt-key add -
-  - sudo add-apt-repository 'deb http://www.rabbitmq.com/debian/ testing main'
-  - sudo apt-get update
-  - sudo apt-get install --only-upgrade -y rabbitmq-server
-  - sudo service rabbitmq-server restart
+#install:
+#  - sudo apt-get update
+#  - sudo apt-get -qq --fix-missing install valgrind
+#
+#  - wget -qO - http://www.rabbitmq.com/rabbitmq-signing-key-public.asc | sudo apt-key add -
+#  - sudo add-apt-repository 'deb http://www.rabbitmq.com/debian/ testing main'
+#  - sudo apt-get update
+#  - sudo apt-get install --only-upgrade -y rabbitmq-server
+#  - sudo service rabbitmq-server restart
 
 env:
   global:
@@ -39,20 +41,27 @@ env:
     - LIBRABBITMQ_VERSION=master
     - LIBRABBITMQ_VERSION=v0.6.0 TEST_PHP_ARGS=-m
     - LIBRABBITMQ_VERSION=v0.6.0
+    - LIBRABBITMQ_VERSION=v0.7.0 TEST_PHP_ARGS=-m
+    - LIBRABBITMQ_VERSION=v0.7.0
 
-before_script:
-  - sh -c "php -i"
-  - sh -c "git clone git://github.com/alanxz/rabbitmq-c.git"
-  - sh -c "cd rabbitmq-c && git checkout ${LIBRABBITMQ_VERSION}"
-  - sh -c "cd rabbitmq-c && git submodule init && git submodule update"
-  - sh -c "cd rabbitmq-c && autoreconf -i && ./configure && make && sudo make install"
-  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then phpize && ./configure && make ; fi
+
+before_install:
+#  - sh -c "php -i"
+  - sh provision/install_rabbitmq-c.sh ${LIBRABBITMQ_VERSION}
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then phpize && ./configure  --with-librabbitmq-dir=$HOME/rabbitmq-c && make ; fi
+
+install:
+
 
 script:
   - sh -c "make test | tee result.txt"
   - sh test-report.sh
 
 addons:
+  apt:
+    packages:
+      - valgrind
+
   coverity_scan:
     project:
       name: "pinepain/php-amqp"

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -295,6 +295,8 @@ void convert_amqp_envelope_to_zval(amqp_envelope_t *amqp_envelope, zval *envelop
 
 	if (p->_flags & AMQP_BASIC_DELIVERY_MODE_FLAG) {
 		AMQP_SET_LONG_PROPERTY(envelope->delivery_mode, p->delivery_mode);
+	} else {
+		AMQP_SET_LONG_PROPERTY(envelope->delivery_mode, AMQP_DELIVERY_NONPERSISTENT);
 	}
 
 	if (p->_flags & AMQP_BASIC_PRIORITY_FLAG) {

--- a/provision/install_rabbitmq-c.sh
+++ b/provision/install_rabbitmq-c.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+echo Installing rabbitmq-c ...
+
+
+LIBRABBITMQ_VERSION=$1
+
+cd $HOME
+
+if [ ! -d "$HOME/rabbitmq-c" ]; then
+  git clone git://github.com/alanxz/rabbitmq-c.git
+else
+  echo 'Using cached directory.';
+  cd $HOME/rabbitmq-c
+  git fetch
+fi
+
+cd $HOME/rabbitmq-c
+git checkout ${LIBRABBITMQ_VERSION}
+
+git submodule init && git submodule update
+autoreconf -i && ./configure --prefix=$HOME/rabbitmq-c && make && make install

--- a/tests/_test_helpers.php
+++ b/tests/_test_helpers.php
@@ -1,0 +1,53 @@
+<?php
+
+function dump_message($msg) {
+    if (!$msg) {
+        var_dump($msg);
+        return false;
+    }
+
+    echo get_class($msg), PHP_EOL;
+    echo "    getBody:", PHP_EOL, "        ";
+    var_dump($msg->getBody());
+    echo "    getContentType:", PHP_EOL, "        ";
+    var_dump($msg->getContentType());
+    echo "    getRoutingKey:", PHP_EOL, "        ";
+    var_dump($msg->getRoutingKey());
+    echo "    getDeliveryTag:", PHP_EOL, "        ";
+    var_dump($msg->getDeliveryTag());
+    echo "    getDeliveryMode:", PHP_EOL, "        ";
+    var_dump($msg->getDeliveryMode());
+    echo "    getExchangeName:", PHP_EOL, "        ";
+    var_dump($msg->getExchangeName());
+    echo "    isRedelivery:", PHP_EOL, "        ";
+    var_dump($msg->isRedelivery());
+    echo "    getContentEncoding:", PHP_EOL, "        ";
+    var_dump($msg->getContentEncoding());
+    echo "    getType:", PHP_EOL, "        ";
+    var_dump($msg->getType());
+    echo "    getTimeStamp:", PHP_EOL, "        ";
+    var_dump($msg->getTimeStamp());
+    echo "    getPriority:", PHP_EOL, "        ";
+    var_dump($msg->getPriority());
+    echo "    getExpiration:", PHP_EOL, "        ";
+    var_dump($msg->getExpiration());
+    echo "    getUserId:", PHP_EOL, "        ";
+    var_dump($msg->getUserId());
+    echo "    getAppId:", PHP_EOL, "        ";
+    var_dump($msg->getAppId());
+    echo "    getMessageId:", PHP_EOL, "        ";
+    var_dump($msg->getMessageId());
+    echo "    getReplyTo:", PHP_EOL, "        ";
+    var_dump($msg->getReplyTo());
+    echo "    getCorrelationId:", PHP_EOL, "        ";
+    var_dump($msg->getCorrelationId());
+    echo "    getHeaders:", PHP_EOL, "        ";
+    var_dump($msg->getHeaders());
+
+    return false;
+}
+
+function consumeThings($message, $queue) {
+    var_dump($message);
+    return false;
+}

--- a/tests/amqpenvelope_get_accessors.phpt
+++ b/tests/amqpenvelope_get_accessors.phpt
@@ -4,12 +4,14 @@ AMQPEnvelope test get*() accessors
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
 <?php
+require '_test_helpers.php';
+
 $cnn = new AMQPConnection();
 $cnn->connect();
 $ch = new AMQPChannel($cnn);
 // Declare a new exchange
 $ex = new AMQPExchange($ch);
-$ex->setName('exchange1');
+$ex->setName('exchange-'.microtime(true));
 $ex->setType(AMQP_EX_TYPE_FANOUT);
 $ex->declareExchange();
 // Create a new queue
@@ -20,50 +22,46 @@ $q->declareQueue();
 $q->bind($ex->getName(), 'routing.*');
 // Publish a message to the exchange with a routing key
 $ex->publish('message', 'routing.1');
-function consumeThings($message, $queue) {
-	var_dump($message->getBody());
-	var_dump($message->getRoutingKey());
-	var_dump($message->getDeliveryTag());
-	var_dump($message->getDeliveryMode());
-	var_dump($message->getExchangeName());
-	var_dump($message->isRedelivery());
-	var_dump($message->getContentType());
-	var_dump($message->getContentEncoding());
-	var_dump($message->getType());
-	var_dump($message->getTimestamp());
-	var_dump($message->getPriority());
-	var_dump($message->getExpiration());
-	var_dump($message->getUserId());
-	var_dump($message->getAppId());
-	var_dump($message->getMessageId());
-	var_dump($message->getReplyTo());
-	var_dump($message->getCorrelationId());
-	var_dump($message->getHeaders());
-	var_dump($message->getHeader("header"));
 
-	return false;
-}
 // Read from the queue
-$q->consume("consumeThings");
+$q->consume('dump_message');
 ?>
---EXPECT--
-string(7) "message"
-string(9) "routing.1"
-int(1)
-int(0)
-string(9) "exchange1"
-bool(false)
-string(10) "text/plain"
-string(0) ""
-string(0) ""
-int(0)
-int(0)
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-string(0) ""
-array(0) {
+--EXPECTF--
+AMQPEnvelope
+    getBody:
+        string(7) "message"
+    getContentType:
+        string(10) "text/plain"
+    getRoutingKey:
+        string(9) "routing.1"
+    getDeliveryTag:
+        int(1)
+    getDeliveryMode:
+        int(1)
+    getExchangeName:
+        string(%d) "exchange-%f"
+    isRedelivery:
+        bool(false)
+    getContentEncoding:
+        string(0) ""
+    getType:
+        string(0) ""
+    getTimeStamp:
+        int(0)
+    getPriority:
+        int(0)
+    getExpiration:
+        string(0) ""
+    getUserId:
+        string(0) ""
+    getAppId:
+        string(0) ""
+    getMessageId:
+        string(0) ""
+    getReplyTo:
+        string(0) ""
+    getCorrelationId:
+        string(0) ""
+    getHeaders:
+        array(0) {
 }
-bool(false)

--- a/tests/amqpenvelope_var_dump.phpt
+++ b/tests/amqpenvelope_var_dump.phpt
@@ -7,6 +7,8 @@ if (!extension_loaded("amqp") || version_compare(PHP_VERSION, '5.3', '<')) {
 }
 --FILE--
 <?php
+require '_test_helpers.php';
+
 $cnn = new AMQPConnection();
 $cnn->connect();
 $ch = new AMQPChannel($cnn);
@@ -24,10 +26,7 @@ $q->bind($ex->getName(), 'routing.*');
 // Publish a message to the exchange with a routing key
 $ex->publish('message', 'routing.1');
 $ex->publish('message', 'routing.1', AMQP_NOPARAM, array("headers" => array("test" => "passed")));
-function consumeThings($message, $queue) {
-	var_dump($message);
-	return false;
-}
+
 // Read from the queue
 $q->consume("consumeThings");
 $q->consume("consumeThings");
@@ -43,7 +42,7 @@ object(AMQPEnvelope)#5 (18) {
   ["delivery_tag"]=>
   int(1)
   ["delivery_mode"]=>
-  int(0)
+  int(1)
   ["exchange_name"]=>
   string(9) "exchange1"
   ["is_redelivery"]=>
@@ -82,7 +81,7 @@ object(AMQPEnvelope)#5 (18) {
   ["delivery_tag"]=>
   int(2)
   ["delivery_mode"]=>
-  int(0)
+  int(1)
   ["exchange_name"]=>
   string(9) "exchange1"
   ["is_redelivery"]=>

--- a/tests/amqpexchange_publish_with_properties.phpt
+++ b/tests/amqpexchange_publish_with_properties.phpt
@@ -4,6 +4,8 @@ AMQPExchange publish with properties
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
 <?php
+require '_test_helpers.php';
+
 $cnn = new AMQPConnection();
 $cnn->connect();
 
@@ -58,50 +60,6 @@ echo 'Message attributes are ', $attrs == $attrs_control ? 'the same' : 'not the
 
 $msg = $q->get(AMQP_AUTOACK);
 
-function dump_message($msg) {
-    if (!$msg) {
-        var_dump($msg);
-        return;
-    }
-
-    echo get_class($msg), PHP_EOL;
-    echo "    getBody:", PHP_EOL, "        ";
-    var_dump($msg->getBody());
-    echo "    getContentType:", PHP_EOL, "        ";
-    var_dump($msg->getContentType());
-    echo "    getRoutingKey:", PHP_EOL, "        ";
-    var_dump($msg->getRoutingKey());
-    echo "    getDeliveryTag:", PHP_EOL, "        ";
-    var_dump($msg->getDeliveryTag());
-    echo "    getDeliveryMode:", PHP_EOL, "        ";
-    var_dump($msg->getDeliveryMode());
-    echo "    getExchangeName:", PHP_EOL, "        ";
-    var_dump($msg->getExchangeName());
-    echo "    isRedelivery:", PHP_EOL, "        ";
-    var_dump($msg->isRedelivery());
-    echo "    getContentEncoding:", PHP_EOL, "        ";
-    var_dump($msg->getContentEncoding());
-    echo "    getType:", PHP_EOL, "        ";
-    var_dump($msg->getType());
-    echo "    getTimeStamp:", PHP_EOL, "        ";
-    var_dump($msg->getTimeStamp());
-    echo "    getPriority:", PHP_EOL, "        ";
-    var_dump($msg->getPriority());
-    echo "    getExpiration:", PHP_EOL, "        ";
-    var_dump($msg->getExpiration());
-    echo "    getUserId:", PHP_EOL, "        ";
-    var_dump($msg->getUserId());
-    echo "    getAppId:", PHP_EOL, "        ";
-    var_dump($msg->getAppId());
-    echo "    getMessageId:", PHP_EOL, "        ";
-    var_dump($msg->getMessageId());
-    echo "    getReplyTo:", PHP_EOL, "        ";
-    var_dump($msg->getReplyTo());
-    echo "    getCorrelationId:", PHP_EOL, "        ";
-    var_dump($msg->getCorrelationId());
-    echo "    getHeaders:", PHP_EOL, "        ";
-    var_dump($msg->getHeaders());
-}
 
 dump_message($msg);
 

--- a/tests/amqpqueue_consume_basic.phpt
+++ b/tests/amqpqueue_consume_basic.phpt
@@ -4,6 +4,8 @@ AMQPQueue::consume basic
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
 <?php
+require '_test_helpers.php';
+
 $cnn = new AMQPConnection();
 $cnn->connect();
 
@@ -30,52 +32,7 @@ $ex->publish('message3', 'routing.3', AMQP_DURABLE); // this is wrong way to mak
 
 $count = 0;
 
-function dump_message($msg) {
-    if (!$msg) {
-        var_dump($msg);
-        return;
-    }
-
-    echo get_class($msg), PHP_EOL;
-    echo "    getBody:", PHP_EOL, "        ";
-    var_dump($msg->getBody());
-    echo "    getContentType:", PHP_EOL, "        ";
-    var_dump($msg->getContentType());
-    echo "    getRoutingKey:", PHP_EOL, "        ";
-    var_dump($msg->getRoutingKey());
-    echo "    getDeliveryTag:", PHP_EOL, "        ";
-    var_dump($msg->getDeliveryTag());
-    echo "    getDeliveryMode:", PHP_EOL, "        ";
-    var_dump($msg->getDeliveryMode());
-    echo "    getExchangeName:", PHP_EOL, "        ";
-    var_dump($msg->getExchangeName());
-    echo "    isRedelivery:", PHP_EOL, "        ";
-    var_dump($msg->isRedelivery());
-    echo "    getContentEncoding:", PHP_EOL, "        ";
-    var_dump($msg->getContentEncoding());
-    echo "    getType:", PHP_EOL, "        ";
-    var_dump($msg->getType());
-    echo "    getTimeStamp:", PHP_EOL, "        ";
-    var_dump($msg->getTimeStamp());
-    echo "    getPriority:", PHP_EOL, "        ";
-    var_dump($msg->getPriority());
-    echo "    getExpiration:", PHP_EOL, "        ";
-    var_dump($msg->getExpiration());
-    echo "    getUserId:", PHP_EOL, "        ";
-    var_dump($msg->getUserId());
-    echo "    getAppId:", PHP_EOL, "        ";
-    var_dump($msg->getAppId());
-    echo "    getMessageId:", PHP_EOL, "        ";
-    var_dump($msg->getMessageId());
-    echo "    getReplyTo:", PHP_EOL, "        ";
-    var_dump($msg->getReplyTo());
-    echo "    getCorrelationId:", PHP_EOL, "        ";
-    var_dump($msg->getCorrelationId());
-    echo "    getHeaders:", PHP_EOL, "        ";
-    var_dump($msg->getHeaders());
-}
-
-function consumeThings($message, $queue) {
+function consumeThingsTwoTimes($message, $queue) {
 	global $count;
 
     echo "call #$count", PHP_EOL;
@@ -92,7 +49,7 @@ function consumeThings($message, $queue) {
 }
 
 // Read from the queue
-$q->consume("consumeThings", AMQP_AUTOACK);
+$q->consume("consumeThingsTwoTimes", AMQP_AUTOACK);
 
 $q->delete();
 $ex->delete();
@@ -110,7 +67,7 @@ AMQPEnvelope
     getDeliveryTag:
         int(1)
     getDeliveryMode:
-        int(0)
+        int(1)
     getExchangeName:
         string(%d) "exchange-%f"
     isRedelivery:

--- a/tests/amqpqueue_get_basic.phpt
+++ b/tests/amqpqueue_get_basic.phpt
@@ -4,6 +4,8 @@ AMQPQueue::get basic
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
 <?php
+require '_test_helpers.php';
+
 $cnn = new AMQPConnection();
 $cnn->connect();
 
@@ -27,51 +29,6 @@ $ex->publish('message1', 'routing.1', AMQP_NOPARAM, array('content_type' => 'pla
 $ex->publish('message2', 'routing.2', AMQP_DURABLE);
 $ex->publish('message3', 'routing.3');
 
-function dump_message($msg) {
-    if (!$msg) {
-        var_dump($msg);
-        return;
-    }
-
-    echo get_class($msg), PHP_EOL;
-    echo "    getBody:", PHP_EOL, "        ";
-    var_dump($msg->getBody());
-    echo "    getContentType:", PHP_EOL, "        ";
-    var_dump($msg->getContentType());
-    echo "    getRoutingKey:", PHP_EOL, "        ";
-    var_dump($msg->getRoutingKey());
-    echo "    getDeliveryTag:", PHP_EOL, "        ";
-    var_dump($msg->getDeliveryTag());
-    echo "    getDeliveryMode:", PHP_EOL, "        ";
-    var_dump($msg->getDeliveryMode());
-    echo "    getExchangeName:", PHP_EOL, "        ";
-    var_dump($msg->getExchangeName());
-    echo "    isRedelivery:", PHP_EOL, "        ";
-    var_dump($msg->isRedelivery());
-    echo "    getContentEncoding:", PHP_EOL, "        ";
-    var_dump($msg->getContentEncoding());
-    echo "    getType:", PHP_EOL, "        ";
-    var_dump($msg->getType());
-    echo "    getTimeStamp:", PHP_EOL, "        ";
-    var_dump($msg->getTimeStamp());
-    echo "    getPriority:", PHP_EOL, "        ";
-    var_dump($msg->getPriority());
-    echo "    getExpiration:", PHP_EOL, "        ";
-    var_dump($msg->getExpiration());
-    echo "    getUserId:", PHP_EOL, "        ";
-    var_dump($msg->getUserId());
-    echo "    getAppId:", PHP_EOL, "        ";
-    var_dump($msg->getAppId());
-    echo "    getMessageId:", PHP_EOL, "        ";
-    var_dump($msg->getMessageId());
-    echo "    getReplyTo:", PHP_EOL, "        ";
-    var_dump($msg->getReplyTo());
-    echo "    getCorrelationId:", PHP_EOL, "        ";
-    var_dump($msg->getCorrelationId());
-    echo "    getHeaders:", PHP_EOL, "        ";
-    var_dump($msg->getHeaders());
-}
-
 for ($i = 0; $i < 4; $i++) {
     echo "call #$i", PHP_EOL;
 	// Read from the queue
@@ -93,7 +50,7 @@ AMQPEnvelope
     getDeliveryTag:
         int(1)
     getDeliveryMode:
-        int(0)
+        int(1)
     getExchangeName:
         string(%d) "exchange-%f"
     isRedelivery:
@@ -135,7 +92,7 @@ AMQPEnvelope
     getDeliveryTag:
         int(2)
     getDeliveryMode:
-        int(0)
+        int(1)
     getExchangeName:
         string(%d) "exchange-%f"
     isRedelivery:
@@ -175,7 +132,7 @@ AMQPEnvelope
     getDeliveryTag:
         int(3)
     getDeliveryMode:
-        int(0)
+        int(1)
     getExchangeName:
         string(%d) "exchange-%f"
     isRedelivery:

--- a/tests/amqpqueue_nested_headers.phpt
+++ b/tests/amqpqueue_nested_headers.phpt
@@ -51,7 +51,13 @@ sleep(1);
 // Now read from the error queue:
 $msg = $errorQ->get(AMQP_AUTOACK);
 
-var_dump($msg->getHeader('x-death'));
+$header = $msg->getHeader('x-death');
+
+echo isset($header['count']) ? 'with' : 'without', ' count ', PHP_EOL;
+
+unset($header['count']);
+
+var_dump($header);
 
 $ex->delete();
 $q->delete();
@@ -59,11 +65,10 @@ $errorXchange->delete();
 $errorQ->delete();
 ?>
 --EXPECTF--
+%s
 array(1) {
   [0]=>
-  array(6) {
-    ["count"]=>
-    int(1)
+  array(5) {
     ["reason"]=>
     string(8) "rejected"
     ["queue"]=>


### PR DESCRIPTION
This PR:

 - Fix issue #170: invalid delivery mode `0` returned by `AMQPEnvelop::getDeliveryMode()` when no `delivery_mode` message property set (that means that delivery mode is 1 - transient).
 - Add support for [new Travis container-based infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/).
 - Add [rabbitmq-c v0.7.0](https://github.com/alanxz/rabbitmq-c/releases/tag/v0.7.0) to build matrix.

This changes are BC compatible (though it is highly recommended to test integration before update to newer php-amqp version that will include this changes, as always, actually).