### PR TITLE
add downstream info (Fedora + EPEL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Object-oriented PHP bindings for the AMQP C library (https://github.com/alanxz/r
  
  Some systems has php-amqp extension in their repo or available via external repositories, so it is MAY be the preferable
  way to install.
- 
+
+ RPM packages are available in Fedora and EPEL (for RHEL and CentOS) official repositories,
+ see [php-pecl-amqp](https://apps.fedoraproject.org/packages/php-pecl-amqp)
+
  If you want to stay on the bleeding edge and have the latest version, install it from
  [PECL](http://pecl.php.net/package/amqp) or compile from sources
  (follow [PHP official docs instruction](http://us1.php.net/manual/en/install.pecl.phpize.php)).


### PR DESCRIPTION
As "installation" refer to "some systems has php-amqp extension", worth to give explicit link when exists, especially when the name is not "php-amqp" (perhaps, only for official repositories)

Notice: even it package name is php-pecl-amqp (per Fedora Guidelines, "yum/dnf install php-amqp" works)