### PR TITLE
fix build with old gcc

### DIFF
--- a/php_amqp.h
+++ b/php_amqp.h
@@ -118,7 +118,7 @@ typedef struct _amqp_channel_object {
 #endif
 } amqp_channel_object;
 
-typedef struct _amqp_connection_resource {
+struct _amqp_connection_resource {
 	zend_bool is_connected;
 	zend_bool is_persistent;
 	zend_bool is_dirty;
@@ -131,9 +131,9 @@ typedef struct _amqp_connection_resource {
 	PHP5to7_param_str_len_type_t resource_key_len;
 	amqp_connection_state_t connection_state;
 	amqp_socket_t *socket;
-} amqp_connection_resource;
+};
 
-typedef struct _amqp_connection_object {
+struct _amqp_connection_object {
 #if PHP_MAJOR_VERSION >= 7
 	amqp_connection_resource *connection_resource;
 	zend_object zo;
@@ -141,7 +141,7 @@ typedef struct _amqp_connection_object {
 	zend_object zo;
 	amqp_connection_resource *connection_resource;
 #endif
-} amqp_connection_object;
+};
 
 #define DEFAULT_PORT						"5672"		/* default AMQP port */
 #define DEFAULT_HOST						"localhost"


### PR DESCRIPTION
ON RHEL-6, with gcc 4.4.7

     In file included from /builddir/build/BUILD/php-pecl-amqp-1.7.0/NTS/amqp_connection_resource.c:54:
     /builddir/build/BUILD/php-pecl-amqp-1.7.0/NTS/php_amqp.h:134: error: redefinition of typedef 'amqp_connection_resource'
     /builddir/build/BUILD/php-pecl-amqp-1.7.0/NTS/php_amqp.h:100: note: previous declaration of 'amqp_connection_resource' was here
     /builddir/build/BUILD/php-pecl-amqp-1.7.0/NTS/php_amqp.h:144: error: redefinition of typedef 'amqp_connection_object'
     /builddir/build/BUILD/php-pecl-amqp-1.7.0/NTS/php_amqp.h:101: note: previous declaration of 'amqp_connection_object' was here
     make: *** [amqp_connection_resource.lo] Error 1
