### PR TITLE
Fix AMQPConnection::setPort() writes to wrong property

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -843,7 +843,7 @@ PHP_METHOD(amqp_connection_class, setPort)
 		return;
 	}
 
-	zend_update_property_long(this_ce, getThis(), ZEND_STRL("read_timeout"), port TSRMLS_CC);
+	zend_update_property_long(this_ce, getThis(), ZEND_STRL("port"), port TSRMLS_CC);
 
 	RETURN_TRUE;
 }

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -125,6 +125,9 @@ PHP_METHOD(amqp_queue_class, setName)
 
 	/* Set the queue name */
 	zend_update_property_stringl(this_ce, getThis(), ZEND_STRL("name"), name, name_len TSRMLS_CC);
+
+	/* BC */
+	RETURN_TRUE;
 }
 /* }}} */
 

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -71,7 +71,8 @@ extern zend_module_entry amqp_module_entry;
 #define PHP_AMQP_EXCHANGE_FLAGS     (AMQP_PASSIVE | AMQP_DURABLE | AMQP_AUTODELETE | AMQP_INTERNAL)
 
 /* passive, durable, exclusive, auto-delete, no-wait (see https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.declare) */
-#define PHP_AMQP_QUEUE_FLAGS        (AMQP_PASSIVE | AMQP_DURABLE | AMQP_EXCLUSIVE | AMQP_AUTODELETE | AMQP_EXCLUSIVE)
+/* We don't support no-wait flag */
+#define PHP_AMQP_QUEUE_FLAGS        (AMQP_PASSIVE | AMQP_DURABLE | AMQP_EXCLUSIVE | AMQP_AUTODELETE)
 
 #define AMQP_EX_TYPE_DIRECT		"direct"
 #define AMQP_EX_TYPE_FANOUT		"fanout"

--- a/tests/amqpconnection_setPort_int.phpt
+++ b/tests/amqpconnection_setPort_int.phpt
@@ -5,7 +5,9 @@ AMQPConnection constructor
 --FILE--
 <?php
 $cnn = new AMQPConnection();
-echo $cnn->setPort(12345);
+echo var_export($cnn->setPort(12345), true), PHP_EOL;
+echo $cnn->getPort(), PHP_EOL;
 ?>
 --EXPECT--
-1
+true
+12345


### PR DESCRIPTION
Fixes https://github.com/pdezwart/php-amqp/issues/188.

This is simple copy-paste garbage cleanup after refactoring.

No BC breaking, no extra requirements.
