### PR TITLE
Fix stalled connection resource cleanup

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -1056,6 +1056,7 @@ PHP_METHOD(amqp_connection_class, getUsedChannels)
 Get max supported channels number per connection */
 PHP_METHOD(amqp_connection_class, getMaxChannels)
 {
+	PHP5to7_READ_PROP_RV_PARAM_DECL;
 	amqp_connection_object *connection;
 
 	PHP_AMQP_NOPARAMS();
@@ -1063,13 +1064,11 @@ PHP_METHOD(amqp_connection_class, getMaxChannels)
 	/* Get the connection object out of the store */
 	connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (!connection->connection_resource || !connection->connection_resource->is_connected) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection is not connected.");
-
-		RETURN_NULL();
+	if (connection->connection_resource && connection->connection_resource->is_connected) {
+		RETURN_LONG(connection->connection_resource->max_slots);
 	}
 
-	RETURN_LONG(connection->connection_resource->max_slots);
+	PHP_AMQP_RETURN_THIS_PROP("channel_max");
 }
 /* }}} */
 
@@ -1078,6 +1077,7 @@ PHP_METHOD(amqp_connection_class, getMaxChannels)
 Get max supported frame size per connection in bytes */
 PHP_METHOD(amqp_connection_class, getMaxFrameSize)
 {
+	PHP5to7_READ_PROP_RV_PARAM_DECL;
 	amqp_connection_object *connection;
 
 	PHP_AMQP_NOPARAMS();
@@ -1085,13 +1085,11 @@ PHP_METHOD(amqp_connection_class, getMaxFrameSize)
 	/* Get the connection object out of the store */
 	connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (!connection->connection_resource || !connection->connection_resource->is_connected) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection is not connected.");
-
-		RETURN_NULL();
+	if (connection->connection_resource && connection->connection_resource->is_connected) {
+		RETURN_LONG(amqp_get_frame_max(connection->connection_resource->connection_state));
 	}
 
-	RETURN_LONG(amqp_get_frame_max(connection->connection_resource->connection_state));
+	PHP_AMQP_RETURN_THIS_PROP("frame_max");
 }
 /* }}} */
 
@@ -1099,6 +1097,7 @@ PHP_METHOD(amqp_connection_class, getMaxFrameSize)
 Get number of seconds between heartbeats of the connection in seconds */
 PHP_METHOD(amqp_connection_class, getHeartbeatInterval)
 {
+	PHP5to7_READ_PROP_RV_PARAM_DECL;
 	amqp_connection_object *connection;
 
 	PHP_AMQP_NOPARAMS();
@@ -1106,16 +1105,16 @@ PHP_METHOD(amqp_connection_class, getHeartbeatInterval)
 	/* Get the connection object out of the store */
 	connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (!connection->connection_resource || !connection->connection_resource->is_connected) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection is not connected.");
-
-		RETURN_NULL();
+	if (connection->connection_resource != NULL
+		&& connection->connection_resource->is_connected != '\0') {
+		RETURN_LONG(amqp_get_heartbeat(connection->connection_resource->connection_state));
 	}
 
-	RETURN_LONG(amqp_get_heartbeat(connection->connection_resource->connection_state));
+	PHP_AMQP_RETURN_THIS_PROP("heartbeat");
 }
 /* }}} */
 #endif
+
 
 /* {{{ proto amqp::isPersistent()
 check whether amqp connection is persistent */

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -71,6 +71,7 @@ static void php_amqp_cleanup_connection_resource(amqp_connection_resource *conne
 
 	PHP5to7_zend_resource_t resource = connection_resource->resource;
 
+	connection_resource->parent->connection_resource = NULL;
 	connection_resource->parent = NULL;
 
 	if (connection_resource->is_dirty) {
@@ -126,8 +127,6 @@ int php_amqp_connect(amqp_connection_object *connection, zend_bool persistent, I
 	if (connection->connection_resource) {
 		/* Clean up old memory allocations which are now invalid (new connection) */
 		php_amqp_cleanup_connection_resource(connection->connection_resource TSRMLS_CC);
-
-		connection->connection_resource = NULL;
 	}
 
 	assert(connection->connection_resource == NULL);
@@ -191,7 +190,6 @@ int php_amqp_connect(amqp_connection_object *connection, zend_bool persistent, I
 			    || php_amqp_set_resource_write_timeout(connection->connection_resource, PHP_AMQP_READ_THIS_PROP_DOUBLE("write_timeout") TSRMLS_CC) == 0) {
 
 				php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-				connection->connection_resource = NULL;
 			   return 0;
 			}
 
@@ -245,7 +243,6 @@ int php_amqp_connect(amqp_connection_object *connection, zend_bool persistent, I
 
 		if (!PHP5to7_ZEND_HASH_STR_UPD_MEM(&EG(persistent_list), connection->connection_resource->resource_key, connection->connection_resource->resource_key_len + 1, new_le, sizeof(PHP5to7_zend_resource_store_t))) {
 			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-			connection->connection_resource = NULL;
 			return 0;
 		}
 	}
@@ -259,7 +256,6 @@ void amqp_connection_free(PHP5to7_obj_free_zend_object *object TSRMLS_DC)
 
 	if (connection->connection_resource) {
 		php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
-		connection->connection_resource = NULL;
 	}
 
 	zend_object_std_dtor(&connection->zo TSRMLS_CC);
@@ -596,7 +592,6 @@ PHP_METHOD(amqp_connection_class, pdisconnect)
 	}
 
 	php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-	connection->connection_resource = NULL;
 
 	RETURN_TRUE;
 }
@@ -627,7 +622,6 @@ PHP_METHOD(amqp_connection_class, disconnect)
 	assert(connection->connection_resource != NULL);
 
 	php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
-	connection->connection_resource = NULL;
 
 	RETURN_TRUE;
 }
@@ -656,7 +650,6 @@ PHP_METHOD(amqp_connection_class, reconnect)
 		}
 
 		php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
-		connection->connection_resource = NULL;
 	}
 
 	RETURN_BOOL(php_amqp_connect(connection, 0, INTERNAL_FUNCTION_PARAM_PASSTHRU));
@@ -686,7 +679,6 @@ PHP_METHOD(amqp_connection_class, preconnect)
 		}
 
 		php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-		connection->connection_resource = NULL;
 	}
 
 	RETURN_BOOL(php_amqp_connect(connection, 1, INTERNAL_FUNCTION_PARAM_PASSTHRU));
@@ -926,7 +918,6 @@ PHP_METHOD(amqp_connection_class, setTimeout)
 		if (php_amqp_set_resource_read_timeout(connection->connection_resource, read_timeout TSRMLS_CC) == 0) {
 
 			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-			connection->connection_resource = NULL;
 
 			RETURN_FALSE;
 		}
@@ -973,7 +964,6 @@ PHP_METHOD(amqp_connection_class, setReadTimeout)
 		if (php_amqp_set_resource_read_timeout(connection->connection_resource, read_timeout TSRMLS_CC) == 0) {
 
 			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-			connection->connection_resource = NULL;
 
 			RETURN_FALSE;
 		}
@@ -1020,7 +1010,6 @@ PHP_METHOD(amqp_connection_class, setWriteTimeout)
 		if (php_amqp_set_resource_write_timeout(connection->connection_resource, write_timeout TSRMLS_CC) == 0) {
 
 			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-			connection->connection_resource = NULL;
 
 			RETURN_FALSE;
 		}

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -121,7 +121,7 @@ static void php_amqp_disconnect(amqp_connection_resource *resource TSRMLS_DC)
 }
 
 
-static void php_amqp_disconnect_force(amqp_connection_resource *resource TSRMLS_DC)
+void php_amqp_disconnect_force(amqp_connection_resource *resource TSRMLS_DC)
 {
 	php_amqp_prepare_for_disconnect(resource TSRMLS_CC);
 	resource->is_dirty = '\1';
@@ -1096,7 +1096,6 @@ PHP_METHOD(amqp_connection_class, getHeartbeatInterval)
 }
 /* }}} */
 #endif
-
 
 /* {{{ proto amqp::isPersistent()
 check whether amqp connection is persistent */

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -1054,7 +1054,6 @@ PHP_METHOD(amqp_connection_class, getMaxChannels)
 }
 /* }}} */
 
-#if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH > 52
 /* {{{ proto amqp::getMaxFrameSize()
 Get max supported frame size per connection in bytes */
 PHP_METHOD(amqp_connection_class, getMaxFrameSize)
@@ -1067,9 +1066,11 @@ PHP_METHOD(amqp_connection_class, getMaxFrameSize)
 	/* Get the connection object out of the store */
 	connection = PHP_AMQP_GET_CONNECTION(getThis());
 
+#if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH > 52
 	if (connection->connection_resource && connection->connection_resource->is_connected) {
 		RETURN_LONG(amqp_get_frame_max(connection->connection_resource->connection_state));
 	}
+#endif
 
 	PHP_AMQP_RETURN_THIS_PROP("frame_max");
 }
@@ -1087,15 +1088,16 @@ PHP_METHOD(amqp_connection_class, getHeartbeatInterval)
 	/* Get the connection object out of the store */
 	connection = PHP_AMQP_GET_CONNECTION(getThis());
 
+#if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH > 52
 	if (connection->connection_resource != NULL
 		&& connection->connection_resource->is_connected != '\0') {
 		RETURN_LONG(amqp_get_heartbeat(connection->connection_resource->connection_state));
 	}
+#endif
 
 	PHP_AMQP_RETURN_THIS_PROP("heartbeat");
 }
 /* }}} */
-#endif
 
 /* {{{ proto amqp::isPersistent()
 check whether amqp connection is persistent */
@@ -1200,13 +1202,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getMaxChannels, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
-#if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH > 52
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getMaxFrameSize, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getHeartbeatInterval, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_isPersistent, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
@@ -1249,10 +1249,9 @@ zend_function_entry amqp_connection_class_functions[] = {
 		PHP_ME(amqp_connection_class, getUsedChannels, arginfo_amqp_connection_class_getUsedChannels,	ZEND_ACC_PUBLIC)
 		PHP_ME(amqp_connection_class, getMaxChannels,  arginfo_amqp_connection_class_getMaxChannels,	ZEND_ACC_PUBLIC)
 		PHP_ME(amqp_connection_class, isPersistent, 	arginfo_amqp_connection_class_isPersistent,		ZEND_ACC_PUBLIC)
-#if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH > 52
 		PHP_ME(amqp_connection_class, getHeartbeatInterval,  arginfo_amqp_connection_class_getHeartbeatInterval,	ZEND_ACC_PUBLIC)
 		PHP_ME(amqp_connection_class, getMaxFrameSize,  arginfo_amqp_connection_class_getMaxFrameSize,	ZEND_ACC_PUBLIC)
-#endif
+
 		{NULL, NULL, NULL}	/* Must be the last line in amqp_functions[] */
 };
 

--- a/amqp_connection.h
+++ b/amqp_connection.h
@@ -63,10 +63,8 @@ PHP_METHOD(amqp_connection_class, setWriteTimeout);
 
 PHP_METHOD(amqp_connection_class, getUsedChannels);
 PHP_METHOD(amqp_connection_class, getMaxChannels);
-#if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH > 52
 PHP_METHOD(amqp_connection_class, getHeartbeatInterval);
 PHP_METHOD(amqp_connection_class, getMaxFrameSize);
-#endif
 PHP_METHOD(amqp_connection_class, isPersistent);
 
 PHP_MINIT_FUNCTION(amqp_connection);

--- a/amqp_connection.h
+++ b/amqp_connection.h
@@ -26,6 +26,7 @@
 extern zend_class_entry *amqp_connection_class_entry;
 
 int php_amqp_connect(amqp_connection_object *amqp_connection, zend_bool persistent, INTERNAL_FUNCTION_PARAMETERS);
+void php_amqp_disconnect_force(amqp_connection_resource *resource TSRMLS_DC);
 
 PHP_METHOD(amqp_connection_class, __construct);
 PHP_METHOD(amqp_connection_class, isConnected);

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -464,10 +464,6 @@ static void connection_resource_destructor(amqp_connection_resource *resource, i
 	signal(SIGPIPE, old_handler);
 #endif
 
-	if (resource->resource_key_len) {
-		pefree(resource->resource_key, persistent);
-	}
-
 	pefree(resource, persistent);
 }
 

--- a/config.m4
+++ b/config.m4
@@ -10,10 +10,10 @@ dnl If your extension references something external, use with:
 
 dnl Make sure that the comment is aligned:
 PHP_ARG_WITH(amqp, for amqp support,
-[  --with-amqp             Include amqp support])
+[	--with-amqp						 Include amqp support])
 
-PHP_ARG_WITH(librabbitmq-dir,  for amqp,
-[  --with-librabbitmq-dir[=DIR]   Set the path to librabbitmq install prefix.], yes)
+PHP_ARG_WITH(librabbitmq-dir,	for amqp,
+[	--with-librabbitmq-dir[=DIR]	 Set the path to librabbitmq install prefix.], yes)
 
 
 if test "$PHP_AMQP" != "no"; then
@@ -52,13 +52,58 @@ if test "$PHP_AMQP" != "no"; then
 	fi
 
 	dnl # --with-amqp -> add include path
-
 	PHP_ADD_INCLUDE($AMQP_DIR/include)
 
-	dnl # --with-amqp -> check for lib and symbol presence
+	old_CFLAGS=$CFLAGS
+	CFLAGS="-I$AMQP_DIR/include"
 
+	AC_CACHE_CHECK(for librabbitmq version, ac_cv_librabbitmq_version, [
+		AC_TRY_RUN([
+			#include "amqp.h"
+			#include <stdio.h>
+
+			int main ()
+			{
+				FILE *testfile = fopen("conftestval", "w");
+
+				if (NULL == testfile) {
+					return 1;
+				}
+
+				fprintf(testfile, "%s\n", AMQ_VERSION_STRING);
+				fclose(testfile);
+
+				return 0;
+			}
+		], [ac_cv_librabbitmq_version=`cat ./conftestval`], [ac_cv_librabbitmq_version=NONE], [ac_cv_librabbitmq_version=NONE])
+	])
+
+	CFLAGS=$old_CFLAGS
+
+	if test "$ac_cv_librabbitmq_version" != "NONE"; then
+		ac_IFS=$IFS
+		IFS=.
+		set $ac_cv_librabbitmq_version
+		IFS=$ac_IFS
+		LIBRABBITMQ_API_VERSION=`expr [$]1 \* 1000000 + [$]2 \* 1000 + [$]3`
+
+		if test "$LIBRABBITMQ_API_VERSION" -lt 5001 ; then
+			 AC_MSG_ERROR([librabbitmq must be version 0.5.2 or greater, $ac_cv_librabbitmq_version version given instead])
+		fi
+
+		if test "$LIBRABBITMQ_API_VERSION" -lt 6000 ; then
+			 AC_MSG_WARN([librabbitmq 0.6.0 or greater recommended, current version is $ac_cv_librabbitmq_version])
+		fi
+	else
+		AC_MSG_ERROR([could not determine librabbitmq version])
+	fi
+
+	dnl # --with-amqp -> check for lib and symbol presence
 	LIBNAME=rabbitmq
 	LIBSYMBOL=rabbitmq
+
+	PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $AMQP_DIR/$PHP_LIBDIR, AMQP_SHARED_LIBADD)
+	PHP_SUBST(AMQP_SHARED_LIBADD)
 
 	if test -z "$TRAVIS" ; then
 		type git &>/dev/null
@@ -79,9 +124,6 @@ if test "$PHP_AMQP" != "no"; then
 			AC_MSG_NOTICE([git not installed. Cannot obtain php_amqp version tag. Install git.])
 		fi
 	fi
-
-	PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $AMQP_DIR/$PHP_LIBDIR, AMQP_SHARED_LIBADD)
-	PHP_SUBST(AMQP_SHARED_LIBADD)
 
 	AMQP_SOURCES="amqp.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_connection_resource.c amqp_channel.c amqp_envelope.c"
 

--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@ if (PHP_AMQP != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("amqp.h", "CFLAGS_AMQP", PHP_PHP_BUILD + "\\include;" + PHP_AMQP) &&
 		CHECK_LIB("rabbinmq_a.lib;rabbitmq.lib;rabbitmq.1.lib", "amqp", PHP_PHP_BUILD + "\\lib;" + PHP_AMQP)) {
 //		ADD_FLAG("CFLAGS_AMQP", "/D HAVE_AMQP_GETSOCKOPT");
-		EXTENSION('amqp', 'amqp.c amqp_exchange.c amqp_queue.c amqp_connection_resource.c amqp_connection.c amqp_channel.c amqp_envelope.c amqp_object_store.c');
+		EXTENSION('amqp', 'amqp.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_connection_resource.c amqp_channel.c amqp_envelope.c');
 		AC_DEFINE('HAVE_AMQP', 1);
 	} else {
 		WARNING("amqp not enabled; libraries and headers not found");

--- a/php5_support.h
+++ b/php5_support.h
@@ -47,7 +47,8 @@ typedef zval* PHP5to7_zval_t;
 #define PHP5to7_ZEND_HASH_DEL(ht, key, len) zend_hash_del_key_or_index((ht), (key), (uint)(len), 0, HASH_DEL_KEY);
 #define PHP5to7_ZEND_HASH_ADD(ht, key, len, pData, nDataSize) (zend_hash_add((ht), (key), (uint)(len), &(pData), nDataSize, NULL) != FAILURE)
 #define PHP5to7_ZEND_HASH_STR_UPD_MEM(ht, key, len, pData, nDataSize) PHP5to7_ZEND_HASH_ADD((ht), (key), (len), (pData), (nDataSize))
-#define PHP5to7_ZEND_HASH_STR_FIND_PTR(ht, str, len, res) PHP5to7_ZEND_HASH_FIND((ht), (str), (len), (res))
+#define PHP5to7_ZEND_HASH_STR_FIND_PTR(ht, key, len, res) PHP5to7_ZEND_HASH_FIND((ht), (key), (len), (res))
+#define PHP5to7_ZEND_HASH_STR_DEL(ht, key, len) PHP5to7_ZEND_HASH_DEL((ht), (key), (len))
 
 #define PHP5to7_SET_FCI_RETVAL_PTR(fci, pzv) (fci).retval_ptr_ptr = &(pzv);
 #define PHP5to7_CHECK_FCI_RETVAL_PTR(fci) ((fci).retval_ptr_ptr && *(fci).retval_ptr_ptr)

--- a/php7_support.h
+++ b/php7_support.h
@@ -46,7 +46,8 @@ typedef zval PHP5to7_zval_t;
 #define PHP5to7_ZEND_HASH_DEL(ht, key, len) zend_hash_str_del_ind((ht), (key), (uint)(len - 1))
 #define PHP5to7_ZEND_HASH_ADD(ht, key, len, pData, nDataSize) zend_hash_str_add((ht), (key), (uint)(len - 1), (pData))
 #define PHP5to7_ZEND_HASH_STR_UPD_MEM(ht, key, len, pData, nDataSize) zend_hash_str_update_mem((ht), (key), (size_t)(len), &(pData), (nDataSize))
-#define PHP5to7_ZEND_HASH_STR_FIND_PTR(ht, str, len, res) ((res = zend_hash_str_find_ptr((ht), (key), (size_t)(len))) != NULL)
+#define PHP5to7_ZEND_HASH_STR_FIND_PTR(ht, key, len, res) ((res = zend_hash_str_find_ptr((ht), (key), (size_t)(len))) != NULL)
+#define PHP5to7_ZEND_HASH_STR_DEL(ht, key, len) zend_hash_str_del_ind((ht), (key), (uint)(len))
 
 #define PHP5to7_SET_FCI_RETVAL_PTR(fci, pzv) (fci).retval = (pzv);
 #define PHP5to7_CHECK_FCI_RETVAL_PTR(fci) ((fci).retval)

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -233,8 +233,7 @@ struct _amqp_connection_object {
 #endif
 
 
-#define PHP_AMQP_GET_CHANNEL_RESOURCE(obj) (PHP_AMQP_GET_CHANNEL(obj))->channel_resource
-
+#define PHP_AMQP_GET_CHANNEL_RESOURCE(obj) (IS_OBJECT == Z_TYPE_P(obj) ? (PHP_AMQP_GET_CHANNEL(obj))->channel_resource : NULL)
 
 #define PHP_AMQP_VERIFY_CONNECTION_ERROR(error, reason) \
 		char verify_connection_error_tmp[255]; \

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -128,8 +128,6 @@ struct _amqp_connection_resource {
 	amqp_channel_t max_slots;
 	amqp_channel_t used_slots;
 	amqp_channel_resource **slots;
-	char *resource_key;
-	PHP5to7_param_str_len_type_t resource_key_len;
 	amqp_connection_state_t connection_state;
 	amqp_socket_t *socket;
 };

--- a/stubs/AMQPConnection.php
+++ b/stubs/AMQPConnection.php
@@ -312,7 +312,10 @@ class AMQPConnection
     /**
      * Get the maximum number of channels the connection can handle.
      *
-     * @return int|null
+     * When connection is connected, effective connection value returned, which is normally the same as original
+     * correspondent value passed to constructor, otherwise original value passed to constructor returned.
+     *
+     * @return int
      */
     public function getMaxChannels()
     {
@@ -321,7 +324,10 @@ class AMQPConnection
     /**
      * Get max supported frame size per connection in bytes.
      *
-     * @return int|null
+     * When connection is connected, effective connection value returned, which is normally the same as original
+     * correspondent value passed to constructor, otherwise original value passed to constructor returned.
+     *
+     * @return int
      */
     public function getMaxFrameSize()
     {
@@ -330,7 +336,10 @@ class AMQPConnection
     /**
      * Get number of seconds between heartbeats of the connection in seconds.
      *
-     * @return int|null
+     * When connection is connected, effective connection value returned, which is normally the same as original
+     * correspondent value passed to constructor, otherwise original value passed to constructor returned.
+     *
+     * @return int
      */
     public function getHeartbeatInterval()
     {
@@ -339,7 +348,9 @@ class AMQPConnection
     /**
      * Whether connection persistent.
      *
-     * @return bool|null
+     * When connection is not connected, boolean false always returned
+     *
+     * @return bool
      */
     public function isPersistent()
     {

--- a/tests/amqpchannel_multi_channel_connection.phpt
+++ b/tests/amqpchannel_multi_channel_connection.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Multiple AMQPChannels per AMQPConnection
+AMQPConnection - multiple AMQPChannels per AMQPConnection
 --SKIPIF--
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--

--- a/tests/amqpconnection_connection_getters.phpt
+++ b/tests/amqpconnection_connection_getters.phpt
@@ -1,0 +1,89 @@
+--TEST--
+AMQPConnection - connection-specific getters
+--SKIPIF--
+<?php
+if (!extension_loaded("amqp") || version_compare(PHP_VERSION, '5.3', '<')) {
+  print "skip";
+}
+?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'channel_max: ', var_export($cnn->getMaxChannels(), true), PHP_EOL;
+echo 'frame_max: ', var_export($cnn->getMaxFrameSize(), true), PHP_EOL;
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo PHP_EOL;
+
+$cnn->connect();
+
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'channel_max: ', var_export($cnn->getMaxChannels(), true), PHP_EOL;
+echo 'frame_max: ', var_export($cnn->getMaxFrameSize(), true), PHP_EOL;
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo PHP_EOL;
+
+$cnn->disconnect();
+
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'channel_max: ', var_export($cnn->getMaxChannels(), true), PHP_EOL;
+echo 'frame_max: ', var_export($cnn->getMaxFrameSize(), true), PHP_EOL;
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo PHP_EOL;
+
+
+$cnn = new AMQPConnection(array('channel_max' => '10', 'frame_max' => 10240, 'heartbeat' => 10));
+
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'channel_max: ', var_export($cnn->getMaxChannels(), true), PHP_EOL;
+echo 'frame_max: ', var_export($cnn->getMaxFrameSize(), true), PHP_EOL;
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo PHP_EOL;
+
+$cnn->connect();
+
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'channel_max: ', var_export($cnn->getMaxChannels(), true), PHP_EOL;
+echo 'frame_max: ', var_export($cnn->getMaxFrameSize(), true), PHP_EOL;
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo PHP_EOL;
+
+$cnn->disconnect();
+
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'channel_max: ', var_export($cnn->getMaxChannels(), true), PHP_EOL;
+echo 'frame_max: ', var_export($cnn->getMaxFrameSize(), true), PHP_EOL;
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo PHP_EOL;
+?>
+--EXPECT--
+connected: false
+channel_max: 256
+frame_max: 131072
+heartbeat: 0
+
+connected: true
+channel_max: 256
+frame_max: 131072
+heartbeat: 0
+
+connected: false
+channel_max: 256
+frame_max: 131072
+heartbeat: 0
+
+connected: false
+channel_max: 10
+frame_max: 10240
+heartbeat: 10
+
+connected: true
+channel_max: 10
+frame_max: 10240
+heartbeat: 10
+
+connected: false
+channel_max: 10
+frame_max: 10240
+heartbeat: 10

--- a/tests/amqpconnection_heartbeat.phpt
+++ b/tests/amqpconnection_heartbeat.phpt
@@ -1,5 +1,5 @@
 --TEST--
-AMQPConnection heartbeats support
+AMQPConnection - heartbeats support
 --SKIPIF--
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
@@ -9,41 +9,29 @@ $credentials = array('heartbeat' => $heartbeat);
 $cnn = new AMQPConnection($credentials);
 $cnn->connect();
 
-var_dump($cnn);
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
 
-sleep($heartbeat*10);
+sleep($heartbeat*5);
 
 try {
-$ch = new AMQPChannel($cnn);
-
+    $ch = new AMQPChannel($cnn);
+    echo 'channel created', PHP_EOL;
 } catch (AMQPException $e) {
   echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
 }
 
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
+
 ?>
 --EXPECTF--
-object(AMQPConnection)#1 (11) {
-  ["login":"AMQPConnection":private]=>
-  string(5) "guest"
-  ["password":"AMQPConnection":private]=>
-  string(5) "guest"
-  ["host":"AMQPConnection":private]=>
-  string(9) "localhost"
-  ["vhost":"AMQPConnection":private]=>
-  string(1) "/"
-  ["port":"AMQPConnection":private]=>
-  %s(5672)
-  ["read_timeout":"AMQPConnection":private]=>
-  %s(0)
-  ["write_timeout":"AMQPConnection":private]=>
-  %s(0)
-  ["connect_timeout":"AMQPConnection":private]=>
-  %s(0)
-  ["channel_max":"AMQPConnection":private]=>
-  %s(256)
-  ["frame_max":"AMQPConnection":private]=>
-  %s(131072)
-  ["heartbeat":"AMQPConnection":private]=>
-  %s(2)
-}
+heartbeat: 2
+connected: true
+persistent: false
 AMQPException: Library error: a socket error occurred
+heartbeat: 2
+connected: false
+persistent: false

--- a/tests/amqpconnection_heartbeat_with_persistent.phpt
+++ b/tests/amqpconnection_heartbeat_with_persistent.phpt
@@ -1,0 +1,92 @@
+--TEST--
+AMQPConnection - heartbeats support with persistent connections
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$heartbeat = 2;
+$credentials = array('heartbeat' => $heartbeat);
+
+$cnn = new AMQPConnection($credentials);
+
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
+echo PHP_EOL;
+
+$cnn->pconnect();
+
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
+echo PHP_EOL;
+
+sleep($heartbeat*5);
+
+try {
+    $ch = new AMQPChannel($cnn);
+    echo 'channel created', PHP_EOL;
+} catch (AMQPException $e) {
+    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+}
+
+echo PHP_EOL;
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
+echo PHP_EOL;
+
+$cnn = new AMQPConnection($credentials);
+$cnn->pconnect();
+
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
+echo PHP_EOL;
+
+
+$ch = new AMQPChannel($cnn);
+echo 'channel created', PHP_EOL;
+echo PHP_EOL;
+
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
+echo PHP_EOL;
+
+$cnn->pdisconnect();
+
+echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
+echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
+echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
+echo PHP_EOL;
+
+?>
+--EXPECTF--
+heartbeat: 2
+connected: false
+persistent: false
+
+heartbeat: 2
+connected: true
+persistent: true
+
+AMQPException: Library error: a socket error occurred
+
+heartbeat: 2
+connected: false
+persistent: false
+
+heartbeat: 2
+connected: true
+persistent: true
+
+channel created
+
+heartbeat: 2
+connected: true
+persistent: true
+
+heartbeat: 2
+connected: false
+persistent: false

--- a/tests/amqpexchange_declare_with_stalled_reference.phpt
+++ b/tests/amqpexchange_declare_with_stalled_reference.phpt
@@ -1,0 +1,40 @@
+--TEST--
+AMQPExchange - declare with stalled reference
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+class ConnectionMock extends  AMQPConnection {
+    public function __construct(array $credentials = array())
+    {
+    }
+}
+
+class ChannelMock extends AMQPChannel {
+    public function __construct(AMQPConnection $amqp_connection)
+    {
+    }
+}
+
+class ExchangeMock extends \AMQPExchange
+{
+    public function __construct(AMQPChannel $amqp_channel)
+    {
+    }
+}
+
+$cnn = new ConnectionMock();
+$ch = new ChannelMock($cnn);
+
+$e = new ExchangeMock($ch);
+
+
+try {
+    $e->declareExchange();
+} catch (\Exception $e) {
+    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+AMQPChannelException: Could not declare exchange. Stale reference to the channel object.

--- a/tests/amqpqueue_declare_with_stalled_reference.phpt
+++ b/tests/amqpqueue_declare_with_stalled_reference.phpt
@@ -1,0 +1,40 @@
+--TEST--
+AMQPQueue - declare with stalled reference
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+class ConnectionMock extends  AMQPConnection {
+    public function __construct(array $credentials = array())
+    {
+    }
+}
+
+class ChannelMock extends AMQPChannel {
+    public function __construct(AMQPConnection $amqp_connection)
+    {
+    }
+}
+
+class QueueMock extends \AMQPQueue
+{
+    public function __construct(AMQPChannel $amqp_channel)
+    {
+    }
+}
+
+$cnn = new ConnectionMock();
+$ch = new ChannelMock($cnn);
+
+$e = new QueueMock($ch);
+
+
+try {
+    $e->declareQueue();
+} catch (\Exception $e) {
+    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+AMQPChannelException: Could not declare queue. Stale reference to the channel object.


### PR DESCRIPTION
This PR:

 - add zval type check when reading `channel` property during channel resource fetching which caused segfaults;
 - fix stalled connection cleanup which caused `Library error` and prevent new persistent connection creation;
 - fix API breaking due to missed `AMQPConnection::getHeartbeatInterval() and  AMQPConnection::getMaxFrameSize` methods when rabbitmq-c < 0.6.0 used;
 - show effective value for frame size and heartbeat value when connection established, otherwise provided value to constructor or default one used;
 - remove deleted source file from win build config;
 - add compiled librabbitmq version early check.

This changeset doesn't break BC but it extend existent API usage.