### PR TITLE
Document the known problems with AMQP_MANDATORY

### DIFF
--- a/stubs/AMQP.php
+++ b/stubs/AMQP.php
@@ -66,11 +66,16 @@ define('AMQP_IFUNUSED', 512);
 
 /**
  * When publishing a message, the message must be routed to a valid queue. If it is not, an error will be returned.
+ * Note: This flag does not currently work in pecl-amqp, and WILL cause undefined behavior if you use it.
+ * @link https://bugs.php.net/bug.php?id=62786
+ * @link https://github.com/pdezwart/php-amqp/issues/23
  */
 define('AMQP_MANDATORY', 1024);
 
 /**
- * When publishing a message, mark this message for immediate processing by the broker. (High priority message.)
+ * When publishing a message, the message must be routed to a valid queue with an available consumer. If it is not, an
+ * error will be thrown. If this flag is not set, the server will queue the message, but with no guarantee that it will
+ * ever be consumed.
  */
 define('AMQP_IMMEDIATE', 2048);
 

--- a/stubs/AMQPExchange.php
+++ b/stubs/AMQPExchange.php
@@ -160,7 +160,11 @@ class AMQPExchange
      * @param string  $routing_key The optional routing key to which to
      *                             publish to.
      * @param integer $flags       One or more of AMQP_MANDATORY and
-     *                             AMQP_IMMEDIATE.
+     *                             AMQP_IMMEDIATE. Note: AMQP_MANDATORY does
+     *                             not currently work and WILL cause undefined
+     *                             behavior if you use it. See
+     *                             https://bugs.php.net/bug.php?id=62786 and
+     *                             https://github.com/pdezwart/php-amqp/issues/23
      * @param array   $attributes  One of content_type, content_encoding,
      *                             message_id, user_id, app_id, delivery_mode,
      *                             priority, timestamp, expiration, type


### PR DESCRIPTION
Hi all! First, thanks for this great extension.

I spent a lot of time today trying to debug why i got a ```Library error: (unknown error)``` when I attempted to ```consume()``` from a queue after publishing a message with the ```AMQP_MANDATORY``` flag set. I referenced the built-in stubs in PhpStorm that only told me this flag was available, and shortly explained what it was supposed to do - so i assumed it was implemented and working fine in php-amqp.

After an extensive search, I found [bugs.php.net/62786](https://bugs.php.net/bug.php?id=62786) and #23. Since I'm guessing this won't be solved any time soon, I went ahead and documented the problems with this flag.

Please correct me if I did something wrong. If this gets merged, I'll send a pull-request to [JetBrains/phpstorm-stubs](https://github.com/JetBrains/phpstorm-stubs) so that they'll update their amqp.php stub.