### PR TITLE
add support for pkg-config

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -24,85 +24,111 @@ if test "$PHP_AMQP" != "no"; then
 	dnl # --with-amqp -> check with-path
 
 	SEARCH_FOR="amqp_framing.h"
+	AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
 
-	AC_MSG_CHECKING([for amqp files in default path])
-	if test "$PHP_LIBRABBITMQ_DIR" != "no" && test "$PHP_LIBRABBITMQ_DIR" != "yes"; then
-		for i in $PHP_LIBRABBITMQ_DIR; do
-			if test -r $i/include/$SEARCH_FOR;
-				then
-				AMQP_DIR=$i
-				AC_MSG_RESULT(found in $i)
-				break
-			fi
-		done
+	if test "$PHP_LIBRABBITMQ_DIR" = "yes" -a -x $PKG_CONFIG; then
+		AC_MSG_CHECKING([for amqp using pkg-config])
+
+		if ! $PKG_CONFIG --exists librabbitmq ; then
+			AC_MSG_ERROR([librabbitmq not found])
+		fi
+
+		PHP_AMQP_VERSION=`$PKG_CONFIG librabbitmq --modversion`
+		AC_MSG_RESULT([found version $PHP_AMQP_VERSION])
+
+		if ! $PKG_CONFIG librabbitmq --atleast-version 0.5.2 ; then
+			AC_MSG_ERROR([librabbitmq must be version 0.5.2 or greater])
+		fi
+		if ! $PKG_CONFIG librabbitmq --atleast-version 0.6.0 ; then
+			AC_MSG_WARN([librabbitmq 0.6.0 or greater recommended])
+		fi
+
+		PHP_AMQP_LIBS=`$PKG_CONFIG librabbitmq --libs`
+		PHP_AMQP_INCS=`$PKG_CONFIG librabbitmq --cflags`
+
+	    PHP_EVAL_LIBLINE($PHP_AMQP_LIBS, AMQP_SHARED_LIBADD)
+	    PHP_EVAL_INCLINE($PHP_AMQP_INCS)
+
 	else
-		for i in $PHP_AMQP /usr/local /usr ; do
-			if test -r $i/include/$SEARCH_FOR;
-				then
-				AMQP_DIR=$i
-				AC_MSG_RESULT(found in $i)
-				break
-			fi
-		done
-	fi
+		AC_MSG_CHECKING([for amqp files in default path])
+		if test "$PHP_LIBRABBITMQ_DIR" != "no" && test "$PHP_LIBRABBITMQ_DIR" != "yes"; then
+			for i in $PHP_LIBRABBITMQ_DIR; do
+				if test -r $i/include/$SEARCH_FOR;
+					then
+					AMQP_DIR=$i
+					AC_MSG_RESULT(found in $i)
+					break
+				fi
+			done
+		else
+			for i in $PHP_AMQP /usr/local /usr ; do
+				if test -r $i/include/$SEARCH_FOR;
+					then
+					AMQP_DIR=$i
+					AC_MSG_RESULT(found in $i)
+					break
+				fi
+			done
+		fi
 
-	if test -z "$AMQP_DIR"; then
-		AC_MSG_RESULT([not found])
-		AC_MSG_ERROR([Please reinstall the librabbitmq distribution itself or (re)install librabbitmq development package if it available in your system])
-	fi
+		if test -z "$AMQP_DIR"; then
+			AC_MSG_RESULT([not found])
+			AC_MSG_ERROR([Please reinstall the librabbitmq distribution itself or (re)install librabbitmq development package if it available in your system])
+		fi
 
-	dnl # --with-amqp -> add include path
-	PHP_ADD_INCLUDE($AMQP_DIR/include)
+		dnl # --with-amqp -> add include path
+		PHP_ADD_INCLUDE($AMQP_DIR/include)
 
-	old_CFLAGS=$CFLAGS
-	CFLAGS="-I$AMQP_DIR/include"
+		old_CFLAGS=$CFLAGS
+		CFLAGS="-I$AMQP_DIR/include"
 
-	AC_CACHE_CHECK(for librabbitmq version, ac_cv_librabbitmq_version, [
-		AC_TRY_RUN([
-			#include "amqp.h"
-			#include <stdio.h>
+		AC_CACHE_CHECK(for librabbitmq version, ac_cv_librabbitmq_version, [
+			AC_TRY_RUN([
+				#include "amqp.h"
+				#include <stdio.h>
 
-			int main ()
-			{
-				FILE *testfile = fopen("conftestval", "w");
+				int main ()
+				{
+					FILE *testfile = fopen("conftestval", "w");
 
-				if (NULL == testfile) {
-					return 1;
+					if (NULL == testfile) {
+						return 1;
+					}
+
+					fprintf(testfile, "%s\n", AMQ_VERSION_STRING);
+					fclose(testfile);
+
+					return 0;
 				}
+			], [ac_cv_librabbitmq_version=`cat ./conftestval`], [ac_cv_librabbitmq_version=NONE], [ac_cv_librabbitmq_version=NONE])
+		])
 
-				fprintf(testfile, "%s\n", AMQ_VERSION_STRING);
-				fclose(testfile);
+		CFLAGS=$old_CFLAGS
 
-				return 0;
-			}
-		], [ac_cv_librabbitmq_version=`cat ./conftestval`], [ac_cv_librabbitmq_version=NONE], [ac_cv_librabbitmq_version=NONE])
-	])
+		if test "$ac_cv_librabbitmq_version" != "NONE"; then
+			ac_IFS=$IFS
+			IFS=.
+			set $ac_cv_librabbitmq_version
+			IFS=$ac_IFS
+			LIBRABBITMQ_API_VERSION=`expr [$]1 \* 1000000 + [$]2 \* 1000 + [$]3`
 
-	CFLAGS=$old_CFLAGS
+			if test "$LIBRABBITMQ_API_VERSION" -lt 5001 ; then
+				 AC_MSG_ERROR([librabbitmq must be version 0.5.2 or greater, $ac_cv_librabbitmq_version version given instead])
+			fi
 
-	if test "$ac_cv_librabbitmq_version" != "NONE"; then
-		ac_IFS=$IFS
-		IFS=.
-		set $ac_cv_librabbitmq_version
-		IFS=$ac_IFS
-		LIBRABBITMQ_API_VERSION=`expr [$]1 \* 1000000 + [$]2 \* 1000 + [$]3`
-
-		if test "$LIBRABBITMQ_API_VERSION" -lt 5001 ; then
-			 AC_MSG_ERROR([librabbitmq must be version 0.5.2 or greater, $ac_cv_librabbitmq_version version given instead])
+			if test "$LIBRABBITMQ_API_VERSION" -lt 6000 ; then
+				 AC_MSG_WARN([librabbitmq 0.6.0 or greater recommended, current version is $ac_cv_librabbitmq_version])
+			fi
+		else
+			AC_MSG_ERROR([could not determine librabbitmq version])
 		fi
 
-		if test "$LIBRABBITMQ_API_VERSION" -lt 6000 ; then
-			 AC_MSG_WARN([librabbitmq 0.6.0 or greater recommended, current version is $ac_cv_librabbitmq_version])
-		fi
-	else
-		AC_MSG_ERROR([could not determine librabbitmq version])
+		dnl # --with-amqp -> check for lib and symbol presence
+		LIBNAME=rabbitmq
+		LIBSYMBOL=rabbitmq
+
+		PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $AMQP_DIR/$PHP_LIBDIR, AMQP_SHARED_LIBADD)
 	fi
-
-	dnl # --with-amqp -> check for lib and symbol presence
-	LIBNAME=rabbitmq
-	LIBSYMBOL=rabbitmq
-
-	PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $AMQP_DIR/$PHP_LIBDIR, AMQP_SHARED_LIBADD)
 	PHP_SUBST(AMQP_SHARED_LIBADD)
 
 	if test -z "$TRAVIS" ; then

--- a/config.m4
+++ b/config.m4
@@ -80,7 +80,7 @@ if test "$PHP_AMQP" != "no"; then
 		PHP_ADD_INCLUDE($AMQP_DIR/include)
 
 		old_CFLAGS=$CFLAGS
-		CFLAGS="-I$AMQP_DIR/include"
+		CFLAGS="$CFLAGS -I$AMQP_DIR/include"
 
 		AC_CACHE_CHECK(for librabbitmq version, ac_cv_librabbitmq_version, [
 			AC_TRY_RUN([


### PR DESCRIPTION
Since fe6920b4d107a2f73514f0a99d8233d20931d240 configure fails

    checking for amqp files in default path... found in /usr
    checking for librabbitmq version... NONE
    configure: error: could not determine librabbitmq version

In config.log

    configure:4058: cc -o conftest -I/usr/include  -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld conftest.c  >&5
    /usr/bin/ld: /tmp/ccggcfRK.o: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
    /tmp/ccggcfRK.o: error adding symbols: Bad value
    collect2: error: ld returned 1 exit status

Adding "-fPIC" to CFLAGS indeed work.

This PR is about using librabbitmq.pc (provided in standard upstream installation) which seems much more simple (and shoud manage all cases, as pkg-config output is usally reliable, else it is an upstream bug)

P.S. only the 1st part of the commit is relevant, everything else is only "indent"