### PR TITLE
Add AMQPChannel::close() method

### DIFF
--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -429,6 +429,22 @@ static PHP_METHOD(amqp_channel_class, isConnected)
 }
 /* }}} */
 
+/* {{{ proto bool AMQPChannel::close()
+Close amqp channel */
+static PHP_METHOD(amqp_channel_class, close)
+{
+    amqp_channel_resource *channel_resource;
+
+    PHP_AMQP_NOPARAMS();
+
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
+
+    if(channel_resource && channel_resource->is_connected) {
+        php_amqp_close_channel(channel_resource TSRMLS_CC);
+    }
+}
+/* }}} */
+
 /* {{{ proto bool amqp::getChannelId()
 get amqp channel ID */
 static PHP_METHOD(amqp_channel_class, getChannelId)
@@ -1054,6 +1070,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_isConnected, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_close, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_channel_class_getChannelId, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
@@ -1117,6 +1136,7 @@ ZEND_END_ARG_INFO()
 zend_function_entry amqp_channel_class_functions[] = {
 		PHP_ME(amqp_channel_class, __construct, 	arginfo_amqp_channel_class__construct,		ZEND_ACC_PUBLIC)
 		PHP_ME(amqp_channel_class, isConnected, 	arginfo_amqp_channel_class_isConnected,		ZEND_ACC_PUBLIC)
+		PHP_ME(amqp_channel_class, close,       	arginfo_amqp_channel_class_close,			ZEND_ACC_PUBLIC)
 
 		PHP_ME(amqp_channel_class, getChannelId,    arginfo_amqp_channel_class_getChannelId,    ZEND_ACC_PUBLIC)
 

--- a/stubs/AMQPChannel.php
+++ b/stubs/AMQPChannel.php
@@ -42,6 +42,13 @@ class AMQPChannel
     }
 
     /**
+     * Closes the channel.
+     */
+    public function close()
+    {
+    }
+
+    /**
      * Return internal channel ID
      *
      * @return integer

--- a/tests/amqpchannel_close.phpt
+++ b/tests/amqpchannel_close.phpt
@@ -1,0 +1,60 @@
+--TEST--
+AMQPChannel::close
+--SKIPIF--
+<?php
+if (!extension_loaded("amqp")) {
+    print "skip";
+}
+?>
+--FILE--
+<?php
+$time = microtime(true);
+
+$connection_1 = new AMQPConnection();
+$connection_1->connect();
+
+$channel_1 = new AMQPChannel($connection_1);
+$channel_1->setPrefetchCount(5);
+
+$exchange_1 = new AMQPExchange($channel_1);
+$exchange_1->setType(AMQP_EX_TYPE_TOPIC);
+$exchange_1->setName('test_' . $time);
+$exchange_1->setFlags(AMQP_AUTODELETE);
+$exchange_1->declareExchange();
+
+$queue_1 = new AMQPQueue($channel_1);
+$queue_1->setName('test_' . $time);
+$queue_1->setFlags(AMQP_DURABLE);
+$queue_1->declareQueue();
+
+$queue_1->bind($exchange_1->getName(), 'test');
+
+$messages_count = 0;
+
+while ($messages_count++ < 3) {
+    $exchange_1->publish('test message #' . $messages_count, 'test');
+}
+
+$msg = $queue_1->get();
+echo $msg->getBody(), PHP_EOL;
+
+echo 'connected: ', var_export($channel_1->isConnected(), true), PHP_EOL;
+$channel_1->close();
+echo 'connected: ', var_export($channel_1->isConnected(), true), PHP_EOL;
+
+try {
+  $queue_1->get();
+} catch (AMQPChannelException $e) {
+    echo get_class($e) . ': ' . $e->getMessage(), PHP_EOL;
+}
+
+$channel_1->close();
+echo 'connected: ', var_export($channel_1->isConnected(), true), PHP_EOL;
+
+?>
+--EXPECT--
+test message #1
+connected: true
+connected: false
+AMQPChannelException: Could not get messages from queue. No channel available.
+connected: false


### PR DESCRIPTION
This PR adds `AMQPChannel::close()` method. No BC changes or whatsoever.

This method was discussed many times in issues, the latest one could be found [here](https://github.com/pdezwart/php-amqp/issues/229).