### PR TITLE
Set server error code on thrown exception

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -109,6 +109,7 @@ ZEND_DECLARE_MODULE_GLOBALS(amqp);
 static PHP_GINIT_FUNCTION(amqp) /* {{{ */
 {
 	amqp_globals->error_message = NULL;
+	amqp_globals->error_code = 0;
 } /* }}} */
 
 static PHP_MINIT_FUNCTION(amqp) /* {{{ */
@@ -186,6 +187,8 @@ static PHP_RSHUTDOWN_FUNCTION(amqp) /* {{{ */
 		PHP_AMQP_G(error_message) = NULL;
     }
 
+    PHP_AMQP_G(error_code) = 0;
+
     return SUCCESS;
 } /* }}} */
 
@@ -236,6 +239,7 @@ int php_amqp_error_advanced(amqp_rpc_reply_t reply, char **message, amqp_connect
 {
 	assert(connection_resource != NULL);
 
+	PHP_AMQP_G(error_code) = 0;
 	if (*message != NULL) {
 		efree(*message);
 	}
@@ -279,7 +283,7 @@ int php_amqp_error_advanced(amqp_rpc_reply_t reply, char **message, amqp_connect
 }
 
 void php_amqp_zend_throw_exception_short(amqp_rpc_reply_t reply, zend_class_entry *exception_ce TSRMLS_DC) {
-	php_amqp_zend_throw_exception(reply, exception_ce, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+	php_amqp_zend_throw_exception(reply, exception_ce, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 }
 
 void php_amqp_zend_throw_exception(amqp_rpc_reply_t reply, zend_class_entry *exception_ce, const char *message, PHP5to7_param_long_type_t code TSRMLS_DC)

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -374,7 +374,7 @@ static PHP_METHOD(amqp_channel_class, __construct)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
 		/* Prevent double free, it may happens in case case channel resource was already freed due to some hard error. */
@@ -892,7 +892,7 @@ PHP_METHOD(amqp_channel_class, waitForBasicReturn)
 
 			php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 			return;
 		}
@@ -912,7 +912,7 @@ PHP_METHOD(amqp_channel_class, waitForBasicReturn)
 
 			php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 			return;
 		}
@@ -1022,7 +1022,7 @@ PHP_METHOD(amqp_channel_class, waitForConfirm)
 
 			php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_channel_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 			return;
 		}
@@ -1054,7 +1054,7 @@ PHP_METHOD(amqp_channel_class, waitForConfirm)
 
 			php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-			php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+			php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 			return;
 		}

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -636,7 +636,7 @@ static PHP_METHOD(amqp_exchange_class, publish)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_exchange_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_exchange_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -335,7 +335,7 @@ static PHP_METHOD(amqp_queue_class, declareQueue)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}
@@ -547,7 +547,7 @@ static PHP_METHOD(amqp_queue_class, consume)
 
 			php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-			zend_throw_exception(amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+			zend_throw_exception(amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 			return;
 		}
@@ -698,7 +698,7 @@ static PHP_METHOD(amqp_queue_class, ack)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}
@@ -744,7 +744,7 @@ static PHP_METHOD(amqp_queue_class, nack)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}
@@ -789,7 +789,7 @@ static PHP_METHOD(amqp_queue_class, reject)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}
@@ -826,7 +826,7 @@ static PHP_METHOD(amqp_queue_class, purge)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}
@@ -876,7 +876,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}
@@ -982,7 +982,7 @@ static PHP_METHOD(amqp_queue_class, delete)
 
 		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), 0 TSRMLS_CC);
+		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 		return;
 	}

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -342,6 +342,7 @@ struct _amqp_connection_object {
 
 ZEND_BEGIN_MODULE_GLOBALS(amqp)
     char *error_message;
+    PHP5to7_param_long_type_t error_code;
 ZEND_END_MODULE_GLOBALS(amqp)
 
 ZEND_EXTERN_MODULE_GLOBALS(amqp);

--- a/tests/amqpchannel_basicRecover.phpt
+++ b/tests/amqpchannel_basicRecover.phpt
@@ -67,7 +67,7 @@ try {
     });
 
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 $queue_2->cancel();
 //var_dump($connection_2, $channel_2);die;
@@ -91,7 +91,7 @@ try {
     });
 
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 
@@ -102,11 +102,11 @@ consumed test message #2 (original)
 consumed test message #8 (original)
 consumed test message #9 (original)
 consumed test message #10 (original)
-AMQPQueueException: Consumer timeout exceed
+AMQPQueueException(0): Consumer timeout exceed
 redelivered
 consumed test message #3 (redelivered)
 consumed test message #4 (redelivered)
 consumed test message #5 (redelivered)
 consumed test message #6 (redelivered)
 consumed test message #7 (redelivered)
-AMQPQueueException: Consumer timeout exceed
+AMQPQueueException(0): Consumer timeout exceed

--- a/tests/amqpchannel_close.phpt
+++ b/tests/amqpchannel_close.phpt
@@ -45,7 +45,7 @@ echo 'connected: ', var_export($channel_1->isConnected(), true), PHP_EOL;
 try {
   $queue_1->get();
 } catch (AMQPChannelException $e) {
-    echo get_class($e) . ': ' . $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): " . $e->getMessage(), PHP_EOL;
 }
 
 $channel_1->close();
@@ -56,5 +56,5 @@ echo 'connected: ', var_export($channel_1->isConnected(), true), PHP_EOL;
 test message #1
 connected: true
 connected: false
-AMQPChannelException: Could not get messages from queue. No channel available.
+AMQPChannelException(0): Could not get messages from queue. No channel available.
 connected: false

--- a/tests/amqpchannel_confirmSelect.phpt
+++ b/tests/amqpchannel_confirmSelect.phpt
@@ -19,7 +19,7 @@ echo 'confirm.select: OK', PHP_EOL;
 try {
     $ch->startTransaction();
 } catch (Exception $e) {
-    echo get_class($e), ': ' . $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): " . $e->getMessage(), PHP_EOL;
 }
 
 $ch = new AMQPChannel($cnn);
@@ -29,13 +29,13 @@ echo 'transaction.start: OK', PHP_EOL;
 try {
     $ch->confirmSelect();
 } catch (Exception $e) {
-    echo get_class($e), ': ' . $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): " . $e->getMessage(), PHP_EOL;
 }
 
 
 ?>
 --EXPECT--
 confirm.select: OK
-AMQPChannelException: Server channel error: 406, message: PRECONDITION_FAILED - cannot switch from confirm to tx mode
+AMQPChannelException(406): Server channel error: 406, message: PRECONDITION_FAILED - cannot switch from confirm to tx mode
 transaction.start: OK
-AMQPChannelException: Server channel error: 406, message: PRECONDITION_FAILED - cannot switch from tx to confirm mode
+AMQPChannelException(406): Server channel error: 406, message: PRECONDITION_FAILED - cannot switch from tx to confirm mode

--- a/tests/amqpconnection_connect_login_failure.phpt
+++ b/tests/amqpconnection_connect_login_failure.phpt
@@ -20,7 +20,7 @@ try {
     $cnn->connect();
     echo 'Connected', PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 //
 echo ($cnn->isConnected() ? 'connected' : 'disconnected'), PHP_EOL;
@@ -29,5 +29,5 @@ echo ($cnn->isConnected() ? 'connected' : 'disconnected'), PHP_EOL;
 ?>
 --EXPECTF--
 disconnected
-AMQPConnectionException: %s error: %s - Potential login failure.
+AMQPConnectionException(%d): %s error: %s - Potential login failure.
 disconnected

--- a/tests/amqpconnection_heartbeat.phpt
+++ b/tests/amqpconnection_heartbeat.phpt
@@ -19,7 +19,7 @@ try {
     $ch = new AMQPChannel($cnn);
     echo 'channel created', PHP_EOL;
 } catch (AMQPException $e) {
-  echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+  echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
@@ -31,7 +31,7 @@ echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
 heartbeat: 2
 connected: true
 persistent: false
-AMQPException: Library error: a socket error occurred
+AMQPException(0): Library error: a socket error occurred
 heartbeat: 2
 connected: false
 persistent: false

--- a/tests/amqpconnection_heartbeat_with_persistent.phpt
+++ b/tests/amqpconnection_heartbeat_with_persistent.phpt
@@ -27,7 +27,7 @@ try {
     $ch = new AMQPChannel($cnn);
     echo 'channel created', PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 echo PHP_EOL;
@@ -71,7 +71,7 @@ heartbeat: 2
 connected: true
 persistent: true
 
-AMQPException: Library error: a socket error occurred
+AMQPException(0): Library error: a socket error occurred
 
 heartbeat: 2
 connected: false

--- a/tests/amqpconnection_persistent_in_use.phpt
+++ b/tests/amqpconnection_persistent_in_use.phpt
@@ -18,7 +18,7 @@ try {
     $cnn2->pconnect();
     echo 'reused', PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 echo $cnn->isConnected() ? 'true' : 'false', PHP_EOL;
 
@@ -28,5 +28,5 @@ AMQPConnection
 true
 
 AMQPConnection
-AMQPConnectionException: There are already established persistent connection to the same resource.
+AMQPConnectionException(0): There are already established persistent connection to the same resource.
 true

--- a/tests/amqpconnection_toomanychannels.phpt
+++ b/tests/amqpconnection_toomanychannels.phpt
@@ -20,10 +20,10 @@ try {
 	new AMQPChannel($cnn);
 	echo "Bad\n";
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 ?>
 --EXPECT--
 Good
-AMQPChannelException: Could not create channel. Connection has no open channel slots remaining.
+AMQPChannelException(0): Could not create channel. Connection has no open channel slots remaining.

--- a/tests/amqpexchange_declare_existent.phpt
+++ b/tests/amqpexchange_declare_existent.phpt
@@ -25,7 +25,7 @@ try {
     $ex->declareExchange();
     echo 'exchange ', $ex->getName(), ' declared', PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 echo "Channel connected: ", $ch->isConnected() ? "true" : "false", PHP_EOL;
@@ -35,13 +35,13 @@ try {
     $ex = new AMQPExchange($ch);
     echo "New exchange class created", PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 ?>
 --EXPECTF--
 Channel id: 1
 Exchange declared: true
-AMQPExchangeException: Server channel error: 406, message: PRECONDITION_FAILED - %s exchange 'exchange-%f' in vhost '/'%s
+AMQPExchangeException(406): Server channel error: 406, message: PRECONDITION_FAILED - %s exchange 'exchange-%f' in vhost '/'%s
 Channel connected: false
 Connection connected: true
-AMQPChannelException: Could not create exchange. No channel available.
+AMQPChannelException(0): Could not create exchange. No channel available.

--- a/tests/amqpexchange_declare_with_stalled_reference.phpt
+++ b/tests/amqpexchange_declare_with_stalled_reference.phpt
@@ -32,9 +32,9 @@ $e = new ExchangeMock($ch);
 try {
     $e->declareExchange();
 } catch (\Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 ?>
 --EXPECT--
-AMQPChannelException: Could not declare exchange. Stale reference to the channel object.
+AMQPChannelException(0): Could not declare exchange. Stale reference to the channel object.

--- a/tests/amqpexchange_declare_without_name.phpt
+++ b/tests/amqpexchange_declare_without_name.phpt
@@ -17,8 +17,8 @@ try {
     $ex->declareExchange();
     echo 'Exchange declared', PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 ?>
 --EXPECTF--
-AMQPExchangeException: Could not declare exchange. Exchanges must have a name.
+AMQPExchangeException(0): Could not declare exchange. Exchanges must have a name.

--- a/tests/amqpexchange_declare_without_type.phpt
+++ b/tests/amqpexchange_declare_without_type.phpt
@@ -18,8 +18,8 @@ try {
     $ex->declareExchange();
     echo 'Exchange declared', PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 ?>
 --EXPECTF--
-AMQPExchangeException: Could not declare exchange. Exchanges must have a type.
+AMQPExchangeException(0): Could not declare exchange. Exchanges must have a type.

--- a/tests/amqpexchange_delete_default_exchange.phpt
+++ b/tests/amqpexchange_delete_default_exchange.phpt
@@ -17,7 +17,7 @@ $ex = new AMQPExchange($ch);
 try {
     $ex->delete();
 } catch (AMQPExchangeException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 echo "Channel connected: ", $ch->isConnected() ? "true" : "false", PHP_EOL;
@@ -25,6 +25,6 @@ echo "Connection connected: ", $cnn->isConnected() ? "true" : "false", PHP_EOL;
 ?>
 --EXPECT--
 Channel id: 1
-AMQPExchangeException: Server channel error: 403, message: ACCESS_REFUSED - operation not permitted on the default exchange
+AMQPExchangeException(403): Server channel error: 403, message: ACCESS_REFUSED - operation not permitted on the default exchange
 Channel connected: false
 Connection connected: true

--- a/tests/amqpexchange_invalid_type.phpt
+++ b/tests/amqpexchange_invalid_type.phpt
@@ -19,7 +19,7 @@ echo "Connection ", $cnn->isConnected() ? 'connected' : 'disconnected', PHP_EOL;
 try {
 	$ex->declareExchange();
 } catch (AMQPException $e) {
-	echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+	echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 echo "Channel ", $ch->isConnected() ? 'connected' : 'disconnected', PHP_EOL;
@@ -29,6 +29,6 @@ echo "Connection ", $cnn->isConnected() ? 'connected' : 'disconnected', PHP_EOL;
 --EXPECT--
 Channel connected
 Connection connected
-AMQPConnectionException: Server connection error: 503, message: COMMAND_INVALID - unknown exchange type 'invalid_exchange_type'
+AMQPConnectionException(503): Server connection error: 503, message: COMMAND_INVALID - unknown exchange type 'invalid_exchange_type'
 Channel disconnected
 Connection disconnected

--- a/tests/amqpexchange_publish_confirms.phpt
+++ b/tests/amqpexchange_publish_confirms.phpt
@@ -25,7 +25,7 @@ $ch->confirmSelect();
 try {
     $ch->waitForConfirm(1);
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 
@@ -42,19 +42,19 @@ echo $ex1->publish('message 1', 'routing.key', AMQP_MANDATORY) ? 'true' : 'false
 try {
     $ch->waitForConfirm();
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 try {
     $ch->waitForConfirm();
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 try {
     $ch->waitForConfirm(1);
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 
@@ -83,7 +83,7 @@ $ch->setConfirmCallback(function ($delivery_tag, $multiple) use(&$cnt) {
 try {
     $ch->waitForConfirm();
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 $ex1->delete();
@@ -95,12 +95,12 @@ echo $ex2->publish('message 2', 'routing.key') ? 'true' : 'false', PHP_EOL;
 try {
     $ch->waitForConfirm(1);
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 ?>
 --EXPECTF--
-AMQPQueueException: Wait timeout exceed
+AMQPQueueException(0): Wait timeout exceed
 true
 true
 Unhandled basic.ack method from server received. Use AMQPChannel::setConfirmCallback() to process it.
@@ -124,4 +124,4 @@ array(2) {
   bool(false)
 }
 true
-AMQPChannelException: Server channel error: 404, message: NOT_FOUND - no exchange 'exchange-nonexistent-%f' in vhost '/'
+AMQPChannelException(404): Server channel error: 404, message: NOT_FOUND - no exchange 'exchange-nonexistent-%f' in vhost '/'

--- a/tests/amqpexchange_publish_confirms_consume.phpt
+++ b/tests/amqpexchange_publish_confirms_consume.phpt
@@ -44,7 +44,7 @@ try {
         return false;
     });
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 echo $ex->publish('message 2', 'routing.key', AMQP_MANDATORY) ? 'true' : 'false', PHP_EOL;
@@ -72,7 +72,7 @@ try {
         return false;
     });
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 
@@ -84,7 +84,7 @@ true
 bool(false)
 Unhandled basic.return method from server received. Use AMQPChannel::setBasicReturnCallback() to process it.
 Unhandled basic.ack method from server received. Use AMQPChannel::setConfirmCallback() to process it.
-AMQPQueueException: Consumer timeout exceed
+AMQPQueueException(0): Consumer timeout exceed
 true
 Message returned: NO_ROUTE, message body:message 2
 Message acked
@@ -94,4 +94,4 @@ array(2) {
   [1]=>
   bool(false)
 }
-AMQPQueueException: Consumer timeout exceed
+AMQPQueueException(0): Consumer timeout exceed

--- a/tests/amqpexchange_publish_mandatory.phpt
+++ b/tests/amqpexchange_publish_mandatory.phpt
@@ -26,7 +26,7 @@ $ch = new AMQPChannel($cnn);
 try {
     $ch->waitForBasicReturn(1);
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 
@@ -51,7 +51,7 @@ var_dump($msg);
 try {
     $ch->waitForBasicReturn();
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 /* callback(int $reply_code, string $reply_text, string $exchange, string $routing_key, AMQPBasicProperties $properties, string $body); */
@@ -64,7 +64,7 @@ $ch->setReturnCallback(function ($reply_code, $reply_text, $exchange, $routing_k
 try {
     $ch->waitForBasicReturn();
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 
@@ -74,7 +74,7 @@ $q->delete();
 $ex->delete();
 ?>
 --EXPECTF--
-AMQPQueueException: Wait timeout exceed
+AMQPQueueException(0): Wait timeout exceed
 true
 true
 bool(false)

--- a/tests/amqpexchange_publish_mandatory_consume.phpt
+++ b/tests/amqpexchange_publish_mandatory_consume.phpt
@@ -44,7 +44,7 @@ try {
         return false;
     });
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 echo $ex->publish('message 2', 'routing.key', AMQP_MANDATORY) ? 'true' : 'false', PHP_EOL;
@@ -62,7 +62,7 @@ try {
         return false;
     });
 } catch(Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(). PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(). PHP_EOL;
 }
 
 
@@ -75,7 +75,7 @@ $ex->delete();
 true
 bool(false)
 Unhandled basic.return method from server received. Use AMQPChannel::setBasicReturnCallback() to process it.
-AMQPQueueException: Consumer timeout exceed
+AMQPQueueException(0): Consumer timeout exceed
 true
 Message returned
 array(6) {
@@ -122,4 +122,4 @@ array(6) {
   [5]=>
   string(9) "message 2"
 }
-AMQPQueueException: Consumer timeout exceed
+AMQPQueueException(0): Consumer timeout exceed

--- a/tests/amqpexchange_publish_mandatory_multiple_channels_pitfal.phpt
+++ b/tests/amqpexchange_publish_mandatory_multiple_channels_pitfal.phpt
@@ -22,7 +22,7 @@ $ch1 = new AMQPChannel($cnn);
 try {
     $ch1->waitForBasicReturn(1);
 } catch (Exception $e) {
-    echo get_class($e), ': ', $e->getMessage() . PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage() . PHP_EOL;
 }
 
 $ch2 = new AMQPChannel($cnn);
@@ -30,7 +30,7 @@ $ch2 = new AMQPChannel($cnn);
 try {
     $ch2->waitForBasicReturn(1);
 } catch (Exception $e) {
-    echo get_class($e), ': ', $e->getMessage() . PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage() . PHP_EOL;
 }
 
 
@@ -65,7 +65,7 @@ var_dump($msg);
 try {
     $ch1->waitForBasicReturn();
 } catch (Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 // This error happens because on a channel 1 we are expecting only messages withing channel 1, but inside current
@@ -75,10 +75,10 @@ echo 'Connection active: ', ($cnn->isConnected() ? 'yes' : 'no');
 
 ?>
 --EXPECTF--
-AMQPQueueException: Wait timeout exceed
-AMQPQueueException: Wait timeout exceed
+AMQPQueueException(0): Wait timeout exceed
+AMQPQueueException(0): Wait timeout exceed
 true
 true
 bool(false)
-AMQPException: Library error: unexpected method received
+AMQPException(0): Library error: unexpected method received
 Connection active: no

--- a/tests/amqpexchange_publish_with_properties_user_id_failure.phpt
+++ b/tests/amqpexchange_publish_with_properties_user_id_failure.phpt
@@ -21,7 +21,7 @@ try {
     // NOTE: basic.publish is asynchronous, so ...
     echo $ex->publish('message', 'routing.key', AMQP_NOPARAM, array('user_id' => 'unknown-' . microtime(true))) ? 'true' : 'false', PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 echo "Channel ", $ch->isConnected() ? 'connected' : 'disconnected', PHP_EOL;
@@ -36,7 +36,7 @@ try {
 
     echo "Queue declared", PHP_EOL;
 } catch (AMQPException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 echo "Channel ", $ch->isConnected() ? 'connected' : 'disconnected', PHP_EOL;
@@ -49,6 +49,6 @@ Connection connected
 true
 Channel connected
 Connection connected
-AMQPQueueException: Server channel error: 406, message: PRECONDITION_FAILED - user_id property set to 'unknown-%f' but authenticated user was 'guest'
+AMQPQueueException(406): Server channel error: 406, message: PRECONDITION_FAILED - user_id property set to 'unknown-%f' but authenticated user was 'guest'
 Channel disconnected
 Connection connected

--- a/tests/amqpqueue_consume_nonexistent.phpt
+++ b/tests/amqpqueue_consume_nonexistent.phpt
@@ -26,9 +26,9 @@ $q->setName('nonexistent-' . microtime(true));
 try {
 	$q->consume('noop');
 } catch (Exception $e) {
-	echo get_class($e), ': ', $e->getMessage();
+	echo get_class($e), "({$e->getCode()}): ", $e->getMessage();
 }
 
 ?>
 --EXPECTF--
-AMQPQueueException: Server channel error: 404, message: NOT_FOUND - no queue 'nonexistent-%f' in vhost '/'
+AMQPQueueException(404): Server channel error: 404, message: NOT_FOUND - no queue 'nonexistent-%f' in vhost '/'

--- a/tests/amqpqueue_consume_timeout.phpt
+++ b/tests/amqpqueue_consume_timeout.phpt
@@ -18,7 +18,7 @@ $start = microtime(true);
 try {
 	$queue->consume('nop');
 } catch (AMQPException $e) {
-	echo get_class($e), ': ', $e->getMessage();
+	echo get_class($e), "({$e->getCode()}): ", $e->getMessage();
 	echo PHP_EOL;
 }
 $end = microtime(true);
@@ -34,7 +34,7 @@ echo abs($error) <= $limit ? 'timings OK' : 'timings failed'; // error should be
 $queue->delete();
 ?>
 --EXPECTF--
-AMQPQueueException: Consumer timeout exceed
+AMQPQueueException(0): Consumer timeout exceed
 timeout: %f
 takes: %f
 error: %f

--- a/tests/amqpqueue_declare_with_stalled_reference.phpt
+++ b/tests/amqpqueue_declare_with_stalled_reference.phpt
@@ -32,9 +32,9 @@ $e = new QueueMock($ch);
 try {
     $e->declareQueue();
 } catch (\Exception $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 
 ?>
 --EXPECT--
-AMQPChannelException: Could not declare queue. Stale reference to the channel object.
+AMQPChannelException(0): Could not declare queue. Stale reference to the channel object.

--- a/tests/amqpqueue_get_nonexistent.phpt
+++ b/tests/amqpqueue_get_nonexistent.phpt
@@ -24,9 +24,9 @@ $q->setName('nonexistent-' . microtime(true));
 try {
   $q->get();
 } catch (Exception $e) {
-  echo get_class($e), ': ', $e->getMessage();
+  echo get_class($e), "({$e->getCode()}): ", $e->getMessage();
 }
 
 ?>
 --EXPECTF--
-AMQPQueueException: Server channel error: 404, message: NOT_FOUND - no queue 'nonexistent-%f' in vhost '/'
+AMQPQueueException(404): Server channel error: 404, message: NOT_FOUND - no queue 'nonexistent-%f' in vhost '/'

--- a/tests/bug_19840.phpt
+++ b/tests/bug_19840.phpt
@@ -15,8 +15,8 @@ try {
 	$conn->connect();
     echo "No exception thrown\n";
 } catch (Exception $e) {
-    echo get_class($e), ': ', $e->getMessage();
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage();
 }
 ?>
 --EXPECT--
-AMQPConnectionException: Socket error: could not connect to host.
+AMQPConnectionException(0): Socket error: could not connect to host.

--- a/tests/bug_61533.phpt
+++ b/tests/bug_61533.phpt
@@ -16,7 +16,7 @@ try {
     error_reporting(error_reporting() & ~E_WARNING);
     $queue = new AMQPQueue($conn);
 } catch (TypeError $e) {
-    echo get_class($e), ': ', $e->getMessage(), '.', PHP_EOL; // we pad exception message with dot to make EXPETF be the same on PHP 5 and PHP 7
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), '.', PHP_EOL; // we pad exception message with dot to make EXPETF be the same on PHP 5 and PHP 7
 }
 
 ?>

--- a/tests/bug_gh53.phpt
+++ b/tests/bug_gh53.phpt
@@ -20,7 +20,7 @@ try {
     $channel->setPrefetchSize(1024);
 
 } catch (AMQPConnectionException $e) {
-    echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
+    echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 var_dump($channel->isConnected());
 var_dump($connection->isConnected());
@@ -28,15 +28,13 @@ var_dump($channel->getPrefetchSize());
 var_dump($channel->getPrefetchCount());
 
 ?>
-==DONE==
 --EXPECTF--
 int(0)
 int(3)
 int(0)
 int(10)
-AMQPConnectionException: Server connection error: 540, message: NOT_IMPLEMENTED - prefetch_size!=0 (%d)
+AMQPConnectionException(540): Server connection error: 540, message: NOT_IMPLEMENTED - prefetch_size!=0 (%d)
 bool(false)
 bool(false)
 int(0)
 int(10)
-==DONE==

--- a/tests/bug_gh72-2.phpt
+++ b/tests/bug_gh72-2.phpt
@@ -13,10 +13,8 @@ $exchange = new AMQPExchange($channel);
 try {
 	$exchange->setName(str_repeat('a', 256));
 } catch (AMQPExchangeException $e) {
-	var_dump($e->getMessage());
+	echo get_class($e), "({$e->getCode()}): ", $e->getMessage(), PHP_EOL;
 }
 ?>
-==DONE==
 --EXPECT--
-string(67) "Invalid exchange name given, must be less than 255 characters long."
-==DONE==
+AMQPExchangeException(0): Invalid exchange name given, must be less than 255 characters long.


### PR DESCRIPTION
This PR pass AMQP server error code to thrown exceptions (when applicable) so it is now aavailable as`Exception::getCode()`.

This PR tends to be BC safe. Exception codes was not in use before so it's safe to start using them now. However, users should first run tests before upgrading just in case they relied on zero exception codes.