### PR TITLE
Remove obsoleted and non-supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,6 @@ matrix:
           env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
         - php: 7.0
           env: LIBRABBITMQ_VERSION=v0.7.1
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=v0.5.2
 
         - php: 5.6
           env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
@@ -63,24 +59,6 @@ matrix:
         - php: 5.5
           env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
         - php: 5.5
-          env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
-
-        - php: 5.4
-          env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
-        - php: 5.4
-          env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
-        - php: 5.4
-          env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
-        - php: 5.4
-          env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
-
-        - php: 5.3
-          env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
-        - php: 5.3
-          env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
-        - php: 5.3
-          env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
-        - php: 5.3
           env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
 
 before_install:


### PR DESCRIPTION
In this PR we get rid of non-supported PHP 5.3 and 5.4. While we don't drop support of it in code, extension can potentially work on them.

Also librabbitmq 0.5.2 removed from PHP 7.0 build matrix as it way too old and in distros and  package repositories (remirepo on rhel and ondrej on ubuntu), it makes no sense to test against it.

At this time we run 28 (!) build, which is a bit too high. With this changes we reduce number to 18. 