### PR TITLE
Add PHP 7.1 to build martrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,45 +21,53 @@ env:
     - TEST_TIMEOUT=120
 
 matrix:
-    include:
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=master
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=v0.8.0
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
-        - php: 7.0
-          env: LIBRABBITMQ_VERSION=v0.7.1
+  allow_failures:
+    - php: 7.1
 
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=master
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=v0.8.0
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=v0.7.1
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
-        - php: 5.6
-          env: LIBRABBITMQ_VERSION=v0.5.2
+  include:
+    - php: 7.1
+      env: LIBRABBITMQ_VERSION=master
+    - php: 7.1
+      env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
 
-        - php: 5.5
-          env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
-        - php: 5.5
-          env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
-        - php: 5.5
-          env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
-        - php: 5.5
-          env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
+    - php: 7.0
+      env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
+    - php: 7.0
+      env: LIBRABBITMQ_VERSION=master
+    - php: 7.0
+      env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
+    - php: 7.0
+      env: LIBRABBITMQ_VERSION=v0.8.0
+    - php: 7.0
+      env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
+    - php: 7.0
+      env: LIBRABBITMQ_VERSION=v0.7.1
+
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=master
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=v0.8.0
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=v0.7.1
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
+    - php: 5.6
+      env: LIBRABBITMQ_VERSION=v0.5.2
+
+    - php: 5.5
+      env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
+    - php: 5.5
+      env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
+    - php: 5.5
+      env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
+    - php: 5.5
+      env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
 
 before_install:
   - sh provision/install_rabbitmq-c.sh ${LIBRABBITMQ_VERSION}

--- a/tests/bug_gh147.phpt
+++ b/tests/bug_gh147.phpt
@@ -41,4 +41,4 @@ echo 'done', PHP_EOL;
 --EXPECTF--
 start
 consuming
-Catchable fatal error: Object of class %s could not be converted to string in %s on line %d
+%s fatal error: Object of class %s could not be converted to string in %s on line %d


### PR DESCRIPTION
Reformat travis config and add PHP 7.1 to build and allow it to fail.

Also provide fix to have green build.