### PR TITLE
Remov PHP 5.5 from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 
 matrix:
   allow_failures:
-    - php: next
+    - php: nightly
 
   include:
     - php: nightly
@@ -72,15 +72,6 @@ matrix:
       env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
     - php: 5.6
       env: LIBRABBITMQ_VERSION=v0.5.2
-
-    - php: 5.5
-      env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
-    - php: 5.5
-      env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
-    - php: 5.5
-      env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
-    - php: 5.5
-      env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
 
 before_install:
   - sh provision/install_rabbitmq-c.sh ${LIBRABBITMQ_VERSION}


### PR DESCRIPTION
As PHP 5.5 EOL for a long time (http://php.net/supported-versions.php) and PHP 5.6 provides security fixes only, let's remove PHP 5.5 from travis build matrix at this point to abuse travis infrastructure less. I guess there was changes since we removed 5.3 from which prevents this extension get build in PHP 5.3+, so *it won't have any negative impact on those who haven't adopted more recent PHP versions* for various reasons.