### PR TITLE
Separate queue and exchange args

### DIFF
--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -269,7 +269,7 @@ static PHP_METHOD(amqp_exchange_class, setArguments)
 {
 	zval *zvalArguments;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &zvalArguments) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/", &zvalArguments) == FAILURE) {
 		return;
 	}
 

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -246,7 +246,7 @@ static PHP_METHOD(amqp_queue_class, setArguments)
 {
 	zval *zvalArguments;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &zvalArguments) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/", &zvalArguments) == FAILURE) {
 		return;
 	}
 

--- a/tests/amqpexchange_attributes.phpt
+++ b/tests/amqpexchange_attributes.phpt
@@ -15,7 +15,11 @@ $ch = new AMQPChannel($cnn);
 
 $ex = new AMQPExchange($ch);
 
-$ex->setArguments(array('existent' => 'value', 'false' => false));
+$ex->setArguments($arr = array('existent' => 'value', 'false' => false));
+
+echo 'Initial args: ', count($arr), ', exchange args: ', count($ex->getArguments()), PHP_EOL;
+$ex->setArgument('foo', 'bar');
+echo 'Initial args: ', count($arr), ', exchange args: ', count($ex->getArguments()), PHP_EOL;
 
 foreach (array('existent', 'false', 'nonexistent') as $key) {
     echo "$key: ", var_export($ex->hasArgument($key), true), ', ', var_export($ex->getArgument($key)), PHP_EOL;
@@ -23,6 +27,8 @@ foreach (array('existent', 'false', 'nonexistent') as $key) {
 
 ?>
 --EXPECT--
+Initial args: 2, exchange args: 2
+Initial args: 2, exchange args: 3
 existent: true, 'value'
 false: true, false
 nonexistent: false, false

--- a/tests/amqpqueue_attributes.phpt
+++ b/tests/amqpqueue_attributes.phpt
@@ -11,7 +11,11 @@ $ch = new AMQPChannel($cnn);
 
 $q = new AMQPQueue($ch);
 
-$q->setArguments(array('existent' => 'value', 'false' => false));
+$q->setArguments($arr = array('existent' => 'value', 'false' => false));
+
+echo 'Initial args: ', count($arr), ', queue args: ', count($q->getArguments()), PHP_EOL;
+$q->setArgument('foo', 'bar');
+echo 'Initial args: ', count($arr), ', queue args: ', count($q->getArguments()), PHP_EOL;
 
 foreach (array('existent', 'false', 'nonexistent') as $key) {
     echo "$key: ", var_export($q->hasArgument($key), true), ', ', var_export($q->getArgument($key)), PHP_EOL;
@@ -19,6 +23,8 @@ foreach (array('existent', 'false', 'nonexistent') as $key) {
 
 ?>
 --EXPECT--
+Initial args: 2, queue args: 2
+Initial args: 2, queue args: 3
 existent: true, 'value'
 false: true, false
 nonexistent: false, false


### PR DESCRIPTION
It came up that mutable arguments array was not separated so all changes on arguments done via `{AMQPQueue,AMQPExchange}::setArgument()` methods reflected on original array.

Before PHP 7.1.2 opcache was disabled in CLI, so it somehow worked, but with opcache the problem just became visible: we were mutating immutable arrays (arrays which content is fully deterministic at compile time, read [PHP 7 performance improvements (5/5): Immutable arrays](https://blog.blackfire.io/php-7-performance-improvements-immutable-arrays.html) for more details).  



Fixes #280