### PR TITLE
Update vagrant & travis provision.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ matrix:
       env: LIBRABBITMQ_VERSION=v0.5.2 TEST_PHP_ARGS=-m
 
 before_install:
-  - sh provision/install_rabbitmq-c.sh ${LIBRABBITMQ_VERSION}
-  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then phpize && ./configure  --with-librabbitmq-dir=$HOME/rabbitmq-c && make ; fi
+  - sudo ./provision/install_rabbitmq-c.sh ${LIBRABBITMQ_VERSION}
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then phpize && ./configure && make ; fi
 
 install:
 

--- a/provision/install_rabbitmq-c.sh
+++ b/provision/install_rabbitmq-c.sh
@@ -2,23 +2,27 @@
 
 set -e
 
-echo Installing rabbitmq-c ...
-
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 LIBRABBITMQ_VERSION" >&2
+  exit 1
+fi
 
 LIBRABBITMQ_VERSION=$1
 
-cd $HOME
+echo "Installing rabbitmq-c ..."
 
 if [ ! -d "$HOME/rabbitmq-c" ]; then
+  cd $HOME
   git clone git://github.com/alanxz/rabbitmq-c.git
+  cd $HOME/rabbitmq-c
 else
   echo 'Using cached directory.';
   cd $HOME/rabbitmq-c
   git fetch
 fi
 
-cd $HOME/rabbitmq-c
 git checkout ${LIBRABBITMQ_VERSION}
 
-git submodule init && git submodule update
-autoreconf -i && ./configure --prefix=$HOME/rabbitmq-c && make && make install
+mkdir build && cd build
+cmake ..
+cmake --build . --target install

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -69,7 +69,7 @@ sudo service nginx restart
 sudo cp -f /usr/share/nginx/html/index.html /var/www/html/index-nginx.html
 
 # Install and configure RabbitMQ
-wget -qO - http://www.rabbitmq.com/rabbitmq-signing-key-public.asc | sudo apt-key add -
+wget -qO - https://www.rabbitmq.com/rabbitmq-release-signing-key.asc | sudo apt-key add -
 sudo add-apt-repository 'deb http://www.rabbitmq.com/debian/ testing main'
 sudo apt-get update
 #sudo apt-get install --only-upgrade -y rabbitmq-server
@@ -81,7 +81,11 @@ sudo service rabbitmq-server restart
 # Note: it may be good idea to checkout latest stable rabbitmq-c version, but master branch for dev reasons also good
 cd ~
 git clone -q git://github.com/alanxz/rabbitmq-c.git
-cd rabbitmq-c && autoreconf -i && ./configure && make && sudo make install
+cd rabbitmq-c
+sudo apt-get install -y cmake
+mkdir build && cd build
+cmake ..
+sudo cmake --build . --target install
 # or install packaged version:
 #sudo apt-get install -y librabbitmq1 librabbitmq-dev librabbitmq-dbg
 


### PR DESCRIPTION
Support of autoreconf have been removed from rabbitmq-c. Use cmake instead.