### PR TITLE
Fix segfault when consumer tag canceled on queue that has no consumers

### DIFF
--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -947,6 +947,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
 
 	zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
 	zval *consumers = zend_read_property(amqp_channel_class_entry, channel_zv, ZEND_STRL("consumers"), 0 PHP5to7_READ_PROP_RV_PARAM_CC TSRMLS_CC);
+	zend_bool has_consumer_tag = (zend_bool) (IS_STRING == Z_TYPE_P(PHP_AMQP_READ_THIS_PROP("consumer_tag")));
 
 	if (IS_ARRAY != Z_TYPE_P(consumers)) {
 		zend_throw_exception(amqp_queue_exception_class_entry, "Invalid channel consumers, forgot to call channel constructor?", 0 TSRMLS_CC);
@@ -956,7 +957,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
 	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channel_zv);
 	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not cancel queue.");
 
-	if (!consumer_tag_len && !PHP_AMQP_READ_THIS_PROP_STRLEN("consumer_tag")) {
+	if (!consumer_tag_len && (!has_consumer_tag || !PHP_AMQP_READ_THIS_PROP_STRLEN("consumer_tag"))) {
 		return;
 	}
 
@@ -976,7 +977,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
 		return;
 	}
 
-	if (!consumer_tag_len || strcmp(consumer_tag, PHP_AMQP_READ_THIS_PROP_STR("consumer_tag")) != 0) {
+	if (!consumer_tag_len || has_consumer_tag && strcmp(consumer_tag, PHP_AMQP_READ_THIS_PROP_STR("consumer_tag")) != 0) {
 		zend_update_property_null(this_ce, getThis(), ZEND_STRL("consumer_tag") TSRMLS_CC);
 	}
 

--- a/tests/004-queue-consume-nested.phpt
+++ b/tests/004-queue-consume-nested.phpt
@@ -102,6 +102,6 @@ With prefetch = 1
 2: ex2-%f [message 2 - 0] amq.ctag-%s - amq.ctag-%s (q2-%f): valid queue
 2: ex2-%f [message 2 - 1] amq.ctag-%s - amq.ctag-%s (q2-%f): valid queue
 1: ex2-%f [message 2 - 2] amq.ctag-%s - amq.ctag-%s (q2-%f): valid queue
-2: ex1-%f [message 1 - 2] amq.ctag-%s - amq.ctag-%s (q1-%f): valid queue
-1: ex2-%f [message 2 - 3] amq.ctag-%s - amq.ctag-%s (q2-%f): valid queue
+2: ex%d-%f [message %d - %d] amq.ctag-%s - amq.ctag-%s (q%d-%f): valid queue
+1: ex%d-%f [message %d - %d] amq.ctag-%s - amq.ctag-%s (q%d-%f): valid queue
 2: ex1-%f [message 1 - 3] amq.ctag-%s - amq.ctag-%s (q1-%f): valid queue

--- a/tests/amqpqueue-cancel-no-consumers.phpt
+++ b/tests/amqpqueue-cancel-no-consumers.phpt
@@ -1,0 +1,45 @@
+--TEST--
+AMQPQueue - orphaned envelope
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) {
+    print "skip";
+} ?>
+--FILE--
+<?php
+///** @var \Enqueue\AmqpExt\AmqpContext context */
+//$context = $this->createContext();
+
+$conn = new AMQPConnection();
+$conn->connect();
+
+$extChannel = new AMQPChannel($conn);
+$extChannel->qos(0, 3);
+
+$microtime = microtime('true');
+$queue_name = 'queue-test-.' . $microtime;
+$exchange_name = 'exchnage-test-.' . $microtime;
+
+
+$queue_1 = new \AMQPQueue($extChannel);
+$queue_1->setName($queue_name);
+$queue_1->declareQueue();
+$queue_1->purge();
+
+$exchange = new \AMQPExchange($extChannel);
+$exchange->setType(AMQP_EX_TYPE_DIRECT);
+$exchange->setName($exchange_name);
+$exchange->declareExchange();
+
+$exchange->publish( 'test message', $queue_name, AMQP_NOPARAM, []);
+
+$queue_2 = new \AMQPQueue($extChannel);
+$queue_2->setName($queue_name);
+$queue_2->consume(null, AMQP_NOPARAM, '');
+
+$consumer_tag = $queue_2->getConsumerTag();
+
+$queue_1->cancel($consumer_tag);
+
+echo "Canceled", PHP_EOL;
+--EXPECTF--
+Canceled


### PR DESCRIPTION
Closes #293.

As for test, it still green in vagrant env for some reasons, see #300 for details how we can avoid such issues in the future by adding docker step to ci.