### PR TITLE
Add cmake addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ script:
 addons:
   apt:
     packages:
+      - cmake
       - valgrind
 
 notifications:


### PR DESCRIPTION
`cmake` is not installed by default anymore.