### PR TITLE
fix for 7.3

### DIFF
--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -101,7 +101,11 @@ static void php_amqp_destroy_fci(zend_fcall_info *fci) {
     if (fci->size > 0) {
         zval_ptr_dtor(&fci->function_name);
         if (fci->object != NULL) {
+#if PHP_VERSION_ID >= 70300
+            GC_DELREF(fci->object);
+#else
             GC_REFCOUNT(fci->object)--;
+#endif
         }
         fci->size = 0;
     }
@@ -112,7 +116,11 @@ static void php_amqp_duplicate_fci(zend_fcall_info *source) {
 
         zval_add_ref(&source->function_name);
         if (source->object != NULL) {
+#if PHP_VERSION_ID >= 70300
+            GC_ADDREF(source->object);
+#else
             GC_REFCOUNT(source->object)++;
+#endif
         }
     }
 }


### PR DESCRIPTION
From UPGRADING.INTERNALS
```
  f. GC_REFCOUNT() is turned into inline function and can't be modified direcly.
     All reference-counting operations should be done through corresponding
     macros GC_SET_REFCOUNT(), GC_ADDREF() and GC_DELREF().

     GC_REFCOUNT(p)++ should be changed into GC_ADDREF(p),
     GC_REFCOUNT(p)-- into GC_DELREF(p),
     GC_REFCOUNT(p) = 1 into GC_SET_REFCOUNT(p, 1).

```
