### PR TITLE
Replace obsolete AC_TRY_RUN with AC_RUN_IFELSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -93,7 +93,7 @@ if test "$PHP_AMQP" != "no"; then
 		CFLAGS="$CFLAGS -I$AMQP_DIR/include"
 
 		AC_CACHE_CHECK(for librabbitmq version, ac_cv_librabbitmq_version, [
-			AC_TRY_RUN([
+			AC_RUN_IFELSE([AC_LANG_SOURCE([[
 				#include "amqp.h"
 				#include <stdio.h>
 
@@ -110,7 +110,7 @@ if test "$PHP_AMQP" != "no"; then
 
 					return 0;
 				}
-			], [ac_cv_librabbitmq_version=`cat ./conftestval`], [ac_cv_librabbitmq_version=NONE], [ac_cv_librabbitmq_version=NONE])
+			]])],[ac_cv_librabbitmq_version=`cat ./conftestval`],[ac_cv_librabbitmq_version=NONE],[ac_cv_librabbitmq_version=NONE])
 		])
 
 		CFLAGS=$old_CFLAGS


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the `AC_TRY_RUN` in 2001 in version 2.50:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.3

It should be replaced with the current `AC_RUN_IFELSE` instead.

PHP 5.3 required Autoconf 2.13 (released in 1999) or newer, since PHP 5.4 the autoconf 2.59 (released in 2003) or newer was required, and since PHP 7.2, autoconf 2.64 (released in 2008) or newer is required.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible with at least PHP versions 5.4 and up, on some systems even with PHP 5.3.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/AC_005fFOO_005fIFELSE-vs-AC_005fTRY_005fFOO.html

This patch was created with autoupdate script.

Thanks.