### PR TITLE
Fix explicit null-string for $routing_key in Queue::bind() and Exchange::publish()

### DIFF
--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -439,7 +439,7 @@ static PHP_METHOD(amqp_exchange_class, publish)
 
 	amqp_basic_properties_t props;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|sla/",
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s!la/",
 							  &msg, &msg_len,
 							  &key_name, &key_len,
 							  &flags,

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -368,7 +368,7 @@ static PHP_METHOD(amqp_queue_class, bind)
 
 	amqp_table_t *arguments = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|sa",
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s!a",
 							  &exchange_name, &exchange_name_len,
 							  &keyname, &keyname_len,
 							  &zvalArguments) == FAILURE) {

--- a/tests/amqpexchange_publish_null_routing_key.phpt
+++ b/tests/amqpexchange_publish_null_routing_key.phpt
@@ -1,0 +1,20 @@
+--TEST--
+AMQPExchange publish with null routing key
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+$ex = new AMQPExchange($ch);
+$ex->setName("exchange-" . microtime(true));
+$ex->setType(AMQP_EX_TYPE_FANOUT);
+$ex->declareExchange();
+echo $ex->publish('message', null) ? 'true' : 'false';
+$ex->delete();
+?>
+--EXPECT--
+true

--- a/tests/amqpqueue_bind_null_routing_key.phpt
+++ b/tests/amqpqueue_bind_null_routing_key.phpt
@@ -1,0 +1,26 @@
+--TEST--
+AMQPQueue
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+$ex = new AMQPExchange($ch);
+$ex->setName('exchange-' . microtime(true));
+$ex->setType(AMQP_EX_TYPE_DIRECT);
+$ex->declareExchange();
+
+$queue = new AMQPQueue($ch);
+$queue->setName("queue-" . microtime(true));
+$queue->declareQueue();
+echo $queue->bind($ex->getName(), null) ? 'true' : 'false';
+
+$queue->delete();
+$ex->delete();
+?>
+--EXPECT--
+true


### PR DESCRIPTION
`Exchange::publish()` and `Queue::bind()` according to their interfaces use `null` value as a default value for `$routing_key`. And all is OK if use just:

`$exchange->publish($msg);`

But, if we use smth like this:

`$exchange->publish($msg, null, $flag, $attrs); // explicit null value for a $routing_key`

we'll get:

> PHP Fatal error:  Uncaught TypeError: AMQPExchange::publish() expects parameter 2 to be string, null given in ...

And in a case when we extend Exchange or Queue their methods looks like:

```
class Exchange extends \AMQPExchange
{
    public function publish($msg, $routingKey = null, ...)
    {
        parent::publish($msg, $routingKey, ...);// bug, we'll get TypeError here if someone calls child-method only with $msg
    }
}
```

Env:
PHP 7.3.2
Zend Engine v.3.3.2
PHP-AMQP v.1.9.4-1