### PR TITLE
Pass params by value in AMQPConnection::__construct()

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -329,10 +329,11 @@ static PHP_METHOD(amqp_connection_class, __construct)
 		return;
 	}
 
+	SEPARATE_ARRAY(ini_arr);
+
 	/* Pull the login out of the $params array */
 	zdata = NULL;
 	if (ini_arr && PHP5to7_ZEND_HASH_FIND(HASH_OF(ini_arr), "login", sizeof("login"), zdata)) {
-		// TODO: check whether we need separate zval
 		convert_to_string(PHP5to7_MAYBE_DEREF(zdata));
 	}
 	/* Validate the given login */

--- a/tests/amqpconnection_construct_params_by_value.phpt
+++ b/tests/amqpconnection_construct_params_by_value.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Params are passed by value in AMQPConnection::__construct()
+
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) die("Skip: ext/amqp must be installed."); ?>
+
+--FILE--
+<?php
+
+$params = [
+    'host'            => 'localhost',
+    'port'            => 5432,
+    'login'           => 'login',
+    'password'        => 'password',
+    'read_timeout'    => 10,
+    'write_timeout'   => 10,
+    'connect_timeout' => 10
+];
+
+$conn = new \AMQPConnection($params);
+
+echo gettype($params['host']) . PHP_EOL;
+echo gettype($params['port']) . PHP_EOL;
+echo gettype($params['login']) . PHP_EOL;
+echo gettype($params['password']) . PHP_EOL;
+
+echo gettype($params['read_timeout']) . PHP_EOL;
+echo gettype($params['write_timeout']) . PHP_EOL;
+echo gettype($params['connect_timeout']) . PHP_EOL;
+
+--EXPECT--
+string
+integer
+string
+string
+integer
+integer
+integer


### PR DESCRIPTION
Inside AMQPConnection::__construct() type of params (read, write and connect timeouts) passed within an array is implicitly changed (convert_to_double()). Separating an array will help to avoid this problem and will prevent possible accidental changes of values in the future.