### PR TITLE
Fix #355: Compile failure on php 7.4

### DIFF
--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -424,7 +424,7 @@ void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
                             PHP5to7_ADD_NEXT_INDEX_STRINGL_DUP(
                                     PHP5to7_MAYBE_PTR(value),
                                     entry->value.value.array.entries[j].value.bytes.bytes,
-                                    (uint) entry->value.value.array.entries[j].value.bytes.len
+                                    (unsigned) entry->value.value.array.entries[j].value.bytes.len
                             );
                             break;
                         case AMQP_FIELD_KIND_TABLE: {
@@ -507,7 +507,7 @@ void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
         }
 
         if (has_value) {
-            char *key = estrndup(entry->key.bytes, (uint) entry->key.len);
+            char *key = estrndup(entry->key.bytes, (unsigned) entry->key.len);
             add_assoc_zval(result, key, PHP5to7_MAYBE_PTR(value));
             efree(key);
         } else {

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -244,7 +244,7 @@ static PHP_METHOD(amqp_exchange_class, hasArgument)
 		return;
 	}
 
-	if (!PHP5to7_ZEND_HASH_FIND(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (uint)(key_len + 1), tmp)) {
+	if (!PHP5to7_ZEND_HASH_FIND(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (unsigned)(key_len + 1), tmp)) {
 		RETURN_FALSE;
 	}
 
@@ -296,13 +296,13 @@ static PHP_METHOD(amqp_exchange_class, setArgument)
 
 	switch (Z_TYPE_P(value)) {
 		case IS_NULL:
-			PHP5to7_ZEND_HASH_DEL(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (uint) (key_len + 1));
+			PHP5to7_ZEND_HASH_DEL(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (unsigned) (key_len + 1));
 			break;
 		PHP5to7_CASE_IS_BOOL:
 		case IS_LONG:
 		case IS_DOUBLE:
 		case IS_STRING:
-			PHP5to7_ZEND_HASH_ADD(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (uint) (key_len + 1), value, sizeof(zval *));
+			PHP5to7_ZEND_HASH_ADD(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (unsigned) (key_len + 1), value, sizeof(zval *));
 			Z_TRY_ADDREF_P(value);
 			break;
 		default:

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -200,7 +200,7 @@ static PHP_METHOD(amqp_queue_class, getArgument)
 		return;
 	}
 
-	if (!PHP5to7_ZEND_HASH_FIND(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (uint)(key_len + 1), tmp)) {
+	if (!PHP5to7_ZEND_HASH_FIND(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (unsigned)(key_len + 1), tmp)) {
 		RETURN_FALSE;
 	}
 
@@ -221,7 +221,7 @@ static PHP_METHOD(amqp_queue_class, hasArgument)
 		return;
 	}
 
-	if (!PHP5to7_ZEND_HASH_FIND(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (uint)(key_len + 1), tmp)) {
+	if (!PHP5to7_ZEND_HASH_FIND(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (unsigned)(key_len + 1), tmp)) {
 		RETURN_FALSE;
 	}
 
@@ -274,13 +274,13 @@ static PHP_METHOD(amqp_queue_class, setArgument)
 
 	switch (Z_TYPE_P(value)) {
 		case IS_NULL:
-			PHP5to7_ZEND_HASH_DEL(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (uint) (key_len + 1));
+			PHP5to7_ZEND_HASH_DEL(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (unsigned) (key_len + 1));
 			break;
 		PHP5to7_CASE_IS_BOOL:
 		case IS_LONG:
 		case IS_DOUBLE:
 		case IS_STRING:
-			PHP5to7_ZEND_HASH_ADD(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (uint) (key_len + 1), value, sizeof(zval *));
+			PHP5to7_ZEND_HASH_ADD(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, (unsigned) (key_len + 1), value, sizeof(zval *));
 			Z_TRY_ADDREF_P(value);
 			break;
 		default:
@@ -565,7 +565,7 @@ static PHP_METHOD(amqp_queue_class, consume)
 		}
 
 		char *key;
-		key = estrndup((char *) r->consumer_tag.bytes, (uint) r->consumer_tag.len);
+		key = estrndup((char *) r->consumer_tag.bytes, (unsigned) r->consumer_tag.len);
 
 		if (PHP5to7_ZEND_HASH_FIND(Z_ARRVAL_P(consumers), (const char *) key, PHP5to7_ZEND_HASH_STRLEN(r->consumer_tag.len), consumer_tag_zv)) {
 			// This should never happen as AMQP server guarantees that consumer tag is unique within channel
@@ -683,7 +683,7 @@ static PHP_METHOD(amqp_queue_class, consume)
 		}
 
 		char *key;
-		key = estrndup((char *)envelope.consumer_tag.bytes, (uint) envelope.consumer_tag.len);
+		key = estrndup((char *)envelope.consumer_tag.bytes, (unsigned) envelope.consumer_tag.len);
 
 		if (!PHP5to7_ZEND_HASH_FIND(Z_ARRVAL_P(consumers), key, PHP5to7_ZEND_HASH_STRLEN(envelope.consumer_tag.len), current_queue_zv)) {
 			PHP5to7_zval_t exception PHP5to7_MAYBE_SET_TO_NULL;
@@ -982,7 +982,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
 	}
 
     char *key;
-    key = estrndup((char *)r->consumer_tag.bytes, (uint) r->consumer_tag.len);
+    key = estrndup((char *)r->consumer_tag.bytes, (unsigned) r->consumer_tag.len);
     PHP5to7_ZEND_HASH_DEL(Z_ARRVAL_P(consumers), (const char *) key, PHP5to7_ZEND_HASH_STRLEN(r->consumer_tag.len));
     efree(key);
 

--- a/amqp_type.c
+++ b/amqp_type.c
@@ -82,9 +82,9 @@ void php_amqp_type_internal_convert_zval_array(zval *php_array, amqp_field_value
 	PHP5to7_ZEND_REAL_HASH_KEY_T *real_key;
 
 	char *key;
-	uint key_len;
+	unsigned key_len;
 
-	ulong index;
+	zend_ulong index;
 	ht = Z_ARRVAL_P(php_array);
 
 	zend_bool is_amqp_array = 1;
@@ -117,9 +117,9 @@ void php_amqp_type_internal_convert_zval_to_amqp_table(zval *php_array, amqp_tab
 	PHP5to7_ZEND_REAL_HASH_KEY_T *real_key;
 
 	char *key;
-	uint key_len;
+	unsigned key_len;
 
-	ulong index;
+	zend_ulong index;
 
 
 	ht = Z_ARRVAL_P(php_array);
@@ -180,9 +180,9 @@ void php_amqp_type_internal_convert_zval_to_amqp_array(zval *zvalArguments, amqp
 	PHP5to7_ZEND_REAL_HASH_KEY_T *real_key;
 
 	char *key;
-	uint key_len;
+	unsigned key_len;
 
-	ulong index;
+	zend_ulong index;
 
 	char type[16];
 
@@ -232,7 +232,7 @@ zend_bool php_amqp_type_internal_convert_php_to_amqp_field_value(zval *value, am
 			if (Z_STRLEN_P(value)) {
 				amqp_bytes_t bytes;
 				bytes.len = (size_t) Z_STRLEN_P(value);
-				bytes.bytes = estrndup(Z_STRVAL_P(value), (uint) Z_STRLEN_P(value));
+				bytes.bytes = estrndup(Z_STRVAL_P(value), (unsigned) Z_STRLEN_P(value));
 
 				field->value.bytes = bytes;
 			} else {

--- a/php5_support.h
+++ b/php5_support.h
@@ -42,14 +42,14 @@ typedef zval* PHP5to7_zval_t;
 
 #define PHP5to7_ZVAL_STRINGL_DUP(z, s, l) ZVAL_STRINGL((z), (s), (l), 1)
 
-#define PHP5to7_ADD_NEXT_INDEX_STRINGL_DUP(arg, str, length) add_next_index_stringl((arg), (str), (uint)(length), 1)
+#define PHP5to7_ADD_NEXT_INDEX_STRINGL_DUP(arg, str, length) add_next_index_stringl((arg), (str), (unsigned)(length), 1)
 
 #define PHP5to7_ZEND_HASH_FIND(ht, str, len, res) \
-        (zend_hash_find((ht), (str), (uint)(len), (void **) &(res)) != FAILURE)
+        (zend_hash_find((ht), (str), (unsigned)(len), (void **) &(res)) != FAILURE)
 
-#define PHP5to7_ZEND_HASH_STRLEN(len) (uint)((len) + 1)
-#define PHP5to7_ZEND_HASH_DEL(ht, key, len) zend_hash_del_key_or_index((ht), (key), (uint)(len), 0, HASH_DEL_KEY);
-#define PHP5to7_ZEND_HASH_ADD(ht, key, len, pData, nDataSize) (zend_hash_add((ht), (key), (uint)(len), &(pData), nDataSize, NULL) != FAILURE)
+#define PHP5to7_ZEND_HASH_STRLEN(len) (unsigned)((len) + 1)
+#define PHP5to7_ZEND_HASH_DEL(ht, key, len) zend_hash_del_key_or_index((ht), (key), (unsigned)(len), 0, HASH_DEL_KEY);
+#define PHP5to7_ZEND_HASH_ADD(ht, key, len, pData, nDataSize) (zend_hash_add((ht), (key), (unsigned)(len), &(pData), nDataSize, NULL) != FAILURE)
 #define PHP5to7_ZEND_HASH_STR_UPD_MEM(ht, key, len, pData, nDataSize) PHP5to7_ZEND_HASH_ADD((ht), (key), (len), (pData), (nDataSize))
 #define PHP5to7_ZEND_HASH_STR_FIND_PTR(ht, key, len, res) PHP5to7_ZEND_HASH_FIND((ht), (key), (len), (res))
 #define PHP5to7_ZEND_HASH_STR_DEL(ht, key, len) PHP5to7_ZEND_HASH_DEL((ht), (key), (len))

--- a/php7_support.h
+++ b/php7_support.h
@@ -47,11 +47,11 @@ typedef zval PHP5to7_zval_t;
 		((res = zend_hash_str_find((ht), (str), (size_t)(len - 1))) != NULL)
 
 #define PHP5to7_ZEND_HASH_STRLEN(len) (PHP5to7_param_str_len_type_t)((len) + 1)
-#define PHP5to7_ZEND_HASH_DEL(ht, key, len) zend_hash_str_del_ind((ht), (key), (uint)(len - 1))
-#define PHP5to7_ZEND_HASH_ADD(ht, key, len, pData, nDataSize) zend_hash_str_add((ht), (key), (uint)(len - 1), (pData))
+#define PHP5to7_ZEND_HASH_DEL(ht, key, len) zend_hash_str_del_ind((ht), (key), (unsigned)(len - 1))
+#define PHP5to7_ZEND_HASH_ADD(ht, key, len, pData, nDataSize) zend_hash_str_add((ht), (key), (unsigned)(len - 1), (pData))
 #define PHP5to7_ZEND_HASH_STR_UPD_MEM(ht, key, len, pData, nDataSize) zend_hash_str_update_mem((ht), (key), (size_t)(len), &(pData), (nDataSize))
 #define PHP5to7_ZEND_HASH_STR_FIND_PTR(ht, key, len, res) ((res = zend_hash_str_find_ptr((ht), (key), (size_t)(len))) != NULL)
-#define PHP5to7_ZEND_HASH_STR_DEL(ht, key, len) zend_hash_str_del_ind((ht), (key), (uint)(len))
+#define PHP5to7_ZEND_HASH_STR_DEL(ht, key, len) zend_hash_str_del_ind((ht), (key), (unsigned)(len))
 
 #define PHP5to7_SET_FCI_RETVAL_PTR(fci, pzv) (fci).retval = (pzv);
 #define PHP5to7_CHECK_FCI_RETVAL_PTR(fci) ((fci).retval)


### PR DESCRIPTION
As of PHP 7.4.0, portable definitions of `ulong` and `uint` are no
longer available.  Therefore we replace `uint` with `unsigned`, and
`ulong` with `zend_ulong`.