### PR TITLE
Build against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,15 @@ matrix:
     - php: nightly
       env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
 
+    - php: 7.4
+      env: LIBRABBITMQ_VERSION=master
+    - php: 7.4
+      env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
+    - php: 7.4
+      env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
+    - php: 7.4
+      env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
+
     - php: 7.3
       env: LIBRABBITMQ_VERSION=master
     - php: 7.3


### PR DESCRIPTION
As now PHP 7.4 is the latest stable version, the library should be tested against this new version. This test is going to fail until https://github.com/pdezwart/php-amqp/pull/359 is merged.