### PR TITLE
Support connection_name parameter for custom connection names in RabbitMQ

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -559,6 +559,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
 	/* Pull the connection_name out of the $params array */
 	zdata = NULL;
 	if (ini_arr && PHP5to7_ZEND_HASH_FIND(HASH_OF(ini_arr), "connection_name", sizeof("connection_name"), zdata)) {
+		SEPARATE_ZVAL(zdata);
 		convert_to_string(PHP5to7_MAYBE_DEREF(zdata));
 	}
 	if (zdata && Z_STRLEN_P(PHP5to7_MAYBE_DEREF(zdata)) > 0) {

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -1375,16 +1375,20 @@ static PHP_METHOD(amqp_connection_class, getConnectionName)
 }
 /* }}} */
 
-/* {{{ proto amqp::setConnectionName(string cert) */
+/* {{{ proto amqp::setConnectionName(string connectionName) */
 static PHP_METHOD(amqp_connection_class, setConnectionName)
 {
 	char *str = NULL;	PHP5to7_param_str_len_type_t str_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s!", &str, &str_len) == FAILURE) {
 		return;
 	}
+	if (str == NULL) {
+		zend_update_property_null(this_ce, getThis(), ZEND_STRL("connection_name") TSRMLS_CC);
+	} else {
+		zend_update_property_stringl(this_ce, getThis(), ZEND_STRL("connection_name"), str, str_len TSRMLS_CC);
+	}
 
-	zend_update_property_stringl(this_ce, getThis(), ZEND_STRL("connection_name"), str, str_len TSRMLS_CC);
 
 	RETURN_TRUE;
 }

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -414,7 +414,13 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
 	amqp_table_entry_t client_properties_entries[5];
 	amqp_table_t       client_properties_table;
 
-	amqp_table_entry_t custom_properties_entries[1];
+	int custom_properties_entries_len;
+	if (params->connection_name) {
+		custom_properties_entries_len = 2;
+	} else {
+		custom_properties_entries_len = 1;
+	}
+	amqp_table_entry_t custom_properties_entries[custom_properties_entries_len];
 	amqp_table_t       custom_properties_table;
 
 	amqp_connection_resource *resource;
@@ -525,6 +531,13 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
 	custom_properties_entries[0].key               = amqp_cstring_bytes("client");
 	custom_properties_entries[0].value.kind        = AMQP_FIELD_KIND_TABLE;
 	custom_properties_entries[0].value.value.table = client_properties_table;
+
+
+	if (params->connection_name) {
+		custom_properties_entries[1].key               = amqp_cstring_bytes("connection_name");
+		custom_properties_entries[1].value.kind        = AMQP_FIELD_KIND_UTF8;
+		custom_properties_entries[1].value.value.bytes = amqp_cstring_bytes(params->connection_name);
+	}
 
 	custom_properties_table.entries     = custom_properties_entries;
 	custom_properties_table.num_entries = sizeof(custom_properties_entries) / sizeof(amqp_table_entry_t);

--- a/amqp_connection_resource.h
+++ b/amqp_connection_resource.h
@@ -55,6 +55,7 @@ typedef struct _amqp_connection_params {
   char *key;
   int verify;
   int sasl_method;
+  char *connection_name;
 } amqp_connection_params;
 
 /* Figure out what's going on connection and handle protocol exceptions, if any */

--- a/package.xml
+++ b/package.xml
@@ -93,6 +93,7 @@ https://github.com/pdezwart/php-amqp/compare/v1.9.4...v1.9.5
             <file name="tests/amqpconnection_construct_ini_timeout.phpt" role="test"/>
             <file name="tests/amqpconnection_construct_ini_timeout_and_read_timeout.phpt" role="test"/>
             <file name="tests/amqpconnection_construct_ini_timeout_default.phpt" role="test"/>
+            <file name="tests/amqpconnection_construct_with_connection_name.phpt" role="test"/>
             <file name="tests/amqpconnection_construct_with_connect_timeout.phpt" role="test"/>
             <file name="tests/amqpconnection_construct_with_limits.phpt" role="test"/>
             <file name="tests/amqpconnection_construct_with_timeout.phpt" role="test"/>
@@ -106,6 +107,7 @@ https://github.com/pdezwart/php-amqp/compare/v1.9.4...v1.9.5
             <file name="tests/amqpconnection_persistent_construct_basic.phpt" role="test"/>
             <file name="tests/amqpconnection_persistent_in_use.phpt" role="test"/>
             <file name="tests/amqpconnection_persistent_reusable.phpt" role="test"/>
+            <file name="tests/amqpconnection_setConnectionName.phpt" role="test"/>
             <file name="tests/amqpconnection_setHost.phpt" role="test"/>
             <file name="tests/amqpconnection_setLogin.phpt" role="test"/>
             <file name="tests/amqpconnection_setPassword.phpt" role="test"/>

--- a/tests/amqpchannel_var_dump.phpt
+++ b/tests/amqpchannel_var_dump.phpt
@@ -20,7 +20,7 @@ var_dump($ch);
 --EXPECT--
 object(AMQPChannel)#2 (4) {
   ["connection":"AMQPChannel":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -55,6 +55,8 @@ object(AMQPChannel)#2 (4) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["prefetch_count":"AMQPChannel":private]=>
   int(3)
@@ -66,7 +68,7 @@ object(AMQPChannel)#2 (4) {
 }
 object(AMQPChannel)#2 (4) {
   ["connection":"AMQPChannel":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -101,6 +103,8 @@ object(AMQPChannel)#2 (4) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["prefetch_count":"AMQPChannel":private]=>
   int(3)

--- a/tests/amqpconnection_construct_params_by_value.phpt
+++ b/tests/amqpconnection_construct_params_by_value.phpt
@@ -16,6 +16,7 @@ $params = [
     'write_timeout'   => 10,
     'connect_timeout' => 10,
     'rpc_timeout'     => 10,
+    'connection_name' => 'custom_connection_name'
 ];
 
 $conn = new \AMQPConnection($params);
@@ -29,6 +30,7 @@ echo gettype($params['read_timeout']) . PHP_EOL;
 echo gettype($params['write_timeout']) . PHP_EOL;
 echo gettype($params['connect_timeout']) . PHP_EOL;
 echo gettype($params['rpc_timeout']) . PHP_EOL;
+echo gettype($params['connection_name']) . PHP_EOL;
 
 --EXPECT--
 string
@@ -39,3 +41,4 @@ integer
 integer
 integer
 integer
+string

--- a/tests/amqpconnection_construct_with_connection_name.phpt
+++ b/tests/amqpconnection_construct_with_connection_name.phpt
@@ -1,0 +1,12 @@
+--TEST--
+AMQPConnection constructor with connection_name parameter in creadentials
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$credentials = array('connection_name' => "custom connection name");
+$cnn = new AMQPConnection($credentials);
+var_dump($cnn->getConnectionName());
+?>
+--EXPECT--
+string(22) "custom connection name"

--- a/tests/amqpconnection_construct_with_connection_name.phpt
+++ b/tests/amqpconnection_construct_with_connection_name.phpt
@@ -4,9 +4,15 @@ AMQPConnection constructor with connection_name parameter in creadentials
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
 <?php
+// Test connection name as a string
 $credentials = array('connection_name' => "custom connection name");
+$cnn = new AMQPConnection($credentials);
+var_dump($cnn->getConnectionName());
+// Test explicitly setting connection name as null
+$credentials = array('connection_name' => null);
 $cnn = new AMQPConnection($credentials);
 var_dump($cnn->getConnectionName());
 ?>
 --EXPECT--
 string(22) "custom connection name"
+NULL

--- a/tests/amqpconnection_construct_with_limits.phpt
+++ b/tests/amqpconnection_construct_with_limits.phpt
@@ -15,7 +15,7 @@ $cnn->connect();
 var_dump($cnn);
 ?>
 --EXPECT--
-object(AMQPConnection)#1 (17) {
+object(AMQPConnection)#1 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>

--- a/tests/amqpconnection_construct_with_limits.phpt
+++ b/tests/amqpconnection_construct_with_limits.phpt
@@ -50,4 +50,6 @@ object(AMQPConnection)#1 (17) {
   bool(true)
   ["sasl_method":"AMQPConnection":private]=>
   int(0)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }

--- a/tests/amqpconnection_heartbeat_with_consumer.phpt
+++ b/tests/amqpconnection_heartbeat_with_consumer.phpt
@@ -60,7 +60,7 @@ echo 'Done', PHP_EOL
 
 ?>
 --EXPECTF--
-object(AMQPConnection)#1 (17) {
+object(AMQPConnection)#1 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>

--- a/tests/amqpconnection_heartbeat_with_consumer.phpt
+++ b/tests/amqpconnection_heartbeat_with_consumer.phpt
@@ -95,6 +95,8 @@ object(AMQPConnection)#1 (17) {
   bool(true)
   ["sasl_method":"AMQPConnection":private]=>
   int(0)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }
 Consumed: test message 1 (should be dead lettered)
 Consuming took: %fsec

--- a/tests/amqpconnection_setConnectionName.phpt
+++ b/tests/amqpconnection_setConnectionName.phpt
@@ -1,0 +1,13 @@
+--TEST--
+AMQPConnection setConnectionName
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+var_dump($cnn->getConnectionName());
+$cnn->setConnectionName('custom connection name');
+var_dump($cnn->getConnectionName());
+--EXPECTF--
+NULL
+string(22) "custom connection name"

--- a/tests/amqpconnection_setConnectionName.phpt
+++ b/tests/amqpconnection_setConnectionName.phpt
@@ -8,6 +8,9 @@ $cnn = new AMQPConnection();
 var_dump($cnn->getConnectionName());
 $cnn->setConnectionName('custom connection name');
 var_dump($cnn->getConnectionName());
+$cnn->setConnectionName(null);
+var_dump($cnn->getConnectionName());
 --EXPECTF--
 NULL
 string(22) "custom connection name"
+NULL

--- a/tests/amqpconnection_ssl.phpt
+++ b/tests/amqpconnection_ssl.phpt
@@ -60,7 +60,7 @@ echo ($cnn->isConnected() ? 'connected' : 'disconnected'), PHP_EOL;
 
 ?>
 --EXPECTF--
-object(AMQPConnection)#1 (17) {
+object(AMQPConnection)#1 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>
@@ -100,7 +100,7 @@ object(AMQPConnection)#1 (17) {
 }
 connected
 
-object(AMQPConnection)#2 (17) {
+object(AMQPConnection)#2 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>

--- a/tests/amqpconnection_ssl.phpt
+++ b/tests/amqpconnection_ssl.phpt
@@ -95,6 +95,8 @@ object(AMQPConnection)#1 (17) {
   bool(false)
   ["sasl_method":"AMQPConnection":private]=>
   int(0)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }
 connected
 
@@ -133,5 +135,7 @@ object(AMQPConnection)#2 (17) {
   bool(false)
   ["sasl_method":"AMQPConnection":private]=>
   int(0)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }
 connected

--- a/tests/amqpconnection_ssl_by_cert.phpt
+++ b/tests/amqpconnection_ssl_by_cert.phpt
@@ -117,6 +117,8 @@ object(AMQPConnection)#1 (17) {
   bool(true)
   ["sasl_method":"AMQPConnection":private]=>
   int(1)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }
 connected
 
@@ -155,6 +157,8 @@ object(AMQPConnection)#2 (17) {
   bool(true)
   ["sasl_method":"AMQPConnection":private]=>
   int(1)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }
 AMQPConnectionException(0): Socket error: could not connect to host.
 disconnected

--- a/tests/amqpconnection_ssl_by_cert.phpt
+++ b/tests/amqpconnection_ssl_by_cert.phpt
@@ -82,7 +82,7 @@ echo ($cnn->isConnected() ? 'connected' : 'disconnected'), PHP_EOL;
 
 ?>
 --EXPECTF--
-object(AMQPConnection)#1 (17) {
+object(AMQPConnection)#1 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>
@@ -122,7 +122,7 @@ object(AMQPConnection)#1 (17) {
 }
 connected
 
-object(AMQPConnection)#2 (17) {
+object(AMQPConnection)#2 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>

--- a/tests/amqpconnection_var_dump.phpt
+++ b/tests/amqpconnection_var_dump.phpt
@@ -58,6 +58,8 @@ object(AMQPConnection)#1 (17) {
   bool(true)
   ["sasl_method":"AMQPConnection":private]=>
   int(0)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }
 bool(true)
 bool(true)
@@ -96,6 +98,8 @@ object(AMQPConnection)#1 (17) {
   bool(true)
   ["sasl_method":"AMQPConnection":private]=>
   int(0)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }
 bool(false)
 object(AMQPConnection)#1 (17) {
@@ -133,4 +137,6 @@ object(AMQPConnection)#1 (17) {
   bool(true)
   ["sasl_method":"AMQPConnection":private]=>
   int(0)
+  ["connection_name":"AMQPConnection":private]=>
+  NULL
 }

--- a/tests/amqpconnection_var_dump.phpt
+++ b/tests/amqpconnection_var_dump.phpt
@@ -23,7 +23,7 @@ var_dump($cnn);
 ?>
 --EXPECT--
 bool(false)
-object(AMQPConnection)#1 (17) {
+object(AMQPConnection)#1 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>
@@ -63,7 +63,7 @@ object(AMQPConnection)#1 (17) {
 }
 bool(true)
 bool(true)
-object(AMQPConnection)#1 (17) {
+object(AMQPConnection)#1 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>
@@ -102,7 +102,7 @@ object(AMQPConnection)#1 (17) {
   NULL
 }
 bool(false)
-object(AMQPConnection)#1 (17) {
+object(AMQPConnection)#1 (18) {
   ["login":"AMQPConnection":private]=>
   string(5) "guest"
   ["password":"AMQPConnection":private]=>

--- a/tests/amqpexchange_setArgument.phpt
+++ b/tests/amqpexchange_setArgument.phpt
@@ -44,7 +44,7 @@ var_dump($ex);
 --EXPECTF--
 object(AMQPExchange)#3 (9) {
   ["connection":"AMQPExchange":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -79,11 +79,13 @@ object(AMQPExchange)#3 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPExchange":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -118,6 +120,8 @@ object(AMQPExchange)#3 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)
@@ -145,7 +149,7 @@ object(AMQPExchange)#3 (9) {
 }
 object(AMQPExchange)#4 (9) {
   ["connection":"AMQPExchange":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -180,11 +184,13 @@ object(AMQPExchange)#4 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPExchange":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -219,6 +225,8 @@ object(AMQPExchange)#4 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)
@@ -256,7 +264,7 @@ object(AMQPExchange)#4 (9) {
 }
 object(AMQPExchange)#4 (9) {
   ["connection":"AMQPExchange":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -291,11 +299,13 @@ object(AMQPExchange)#4 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPExchange":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -330,6 +340,8 @@ object(AMQPExchange)#4 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)

--- a/tests/amqpexchange_set_flags.phpt
+++ b/tests/amqpexchange_set_flags.phpt
@@ -22,7 +22,7 @@ var_dump($ex);
 --EXPECTF--
 object(AMQPExchange)#3 (9) {
   ["connection":"AMQPExchange":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -57,11 +57,13 @@ object(AMQPExchange)#3 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPExchange":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -96,6 +98,8 @@ object(AMQPExchange)#3 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)

--- a/tests/amqpexchange_var_dump.phpt
+++ b/tests/amqpexchange_var_dump.phpt
@@ -21,7 +21,7 @@ var_dump($ex);
 --EXPECTF--
 object(AMQPExchange)#3 (9) {
   ["connection":"AMQPExchange":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -56,11 +56,13 @@ object(AMQPExchange)#3 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPExchange":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -95,6 +97,8 @@ object(AMQPExchange)#3 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)
@@ -122,7 +126,7 @@ object(AMQPExchange)#3 (9) {
 }
 object(AMQPExchange)#3 (9) {
   ["connection":"AMQPExchange":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -157,11 +161,13 @@ object(AMQPExchange)#3 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPExchange":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -196,6 +202,8 @@ object(AMQPExchange)#3 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)

--- a/tests/amqpqueue_setArgument.phpt
+++ b/tests/amqpqueue_setArgument.phpt
@@ -38,7 +38,7 @@ var_dump($q_dead);
 --EXPECTF--
 object(AMQPQueue)#3 (9) {
   ["connection":"AMQPQueue":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -73,11 +73,13 @@ object(AMQPQueue)#3 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPQueue":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -112,6 +114,8 @@ object(AMQPQueue)#3 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)
@@ -139,7 +143,7 @@ object(AMQPQueue)#3 (9) {
 }
 object(AMQPQueue)#4 (9) {
   ["connection":"AMQPQueue":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -174,11 +178,13 @@ object(AMQPQueue)#4 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPQueue":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -213,6 +219,8 @@ object(AMQPQueue)#4 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)
@@ -246,7 +254,7 @@ object(AMQPQueue)#4 (9) {
 }
 object(AMQPQueue)#4 (9) {
   ["connection":"AMQPQueue":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -281,11 +289,13 @@ object(AMQPQueue)#4 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPQueue":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -320,6 +330,8 @@ object(AMQPQueue)#4 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)

--- a/tests/amqpqueue_var_dump.phpt
+++ b/tests/amqpqueue_var_dump.phpt
@@ -24,7 +24,7 @@ var_dump($q);
 --EXPECT--
 object(AMQPQueue)#4 (9) {
   ["connection":"AMQPQueue":private]=>
-  object(AMQPConnection)#1 (17) {
+  object(AMQPConnection)#1 (18) {
     ["login":"AMQPConnection":private]=>
     string(5) "guest"
     ["password":"AMQPConnection":private]=>
@@ -59,11 +59,13 @@ object(AMQPQueue)#4 (9) {
     bool(true)
     ["sasl_method":"AMQPConnection":private]=>
     int(0)
+    ["connection_name":"AMQPConnection":private]=>
+    NULL
   }
   ["channel":"AMQPQueue":private]=>
   object(AMQPChannel)#2 (4) {
     ["connection":"AMQPChannel":private]=>
-    object(AMQPConnection)#1 (17) {
+    object(AMQPConnection)#1 (18) {
       ["login":"AMQPConnection":private]=>
       string(5) "guest"
       ["password":"AMQPConnection":private]=>
@@ -98,6 +100,8 @@ object(AMQPQueue)#4 (9) {
       bool(true)
       ["sasl_method":"AMQPConnection":private]=>
       int(0)
+      ["connection_name":"AMQPConnection":private]=>
+      NULL
     }
     ["prefetch_count":"AMQPChannel":private]=>
     int(3)


### PR DESCRIPTION
This PR adds support for connection_name parameter. 
It can be used to pass custom connection name to RabbitMQ, which is shown in the management console like this:
![Screenshot from 2020-01-28 16-07-34](https://user-images.githubusercontent.com/25199815/73271213-dc274280-41e8-11ea-97af-96a4aaa69300.png)


