### PR TITLE
Fixed build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: php
 
-sudo: false
-
-services:
-  - rabbitmq
-
 env:
   global:
     - NO_INTERACTION=1
@@ -75,6 +70,7 @@ addons:
     packages:
       - cmake
       - valgrind
+      - rabbitmq-server 
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ matrix:
     - php: 7.4
       env: LIBRABBITMQ_VERSION=master
     - php: 7.4
-      env: LIBRABBITMQ_VERSION=master TEST_PHP_ARGS=-m
+      env: LIBRABBITMQ_VERSION=v0.8.0
     - php: 7.4
-      env: LIBRABBITMQ_VERSION=v0.8.0 TEST_PHP_ARGS=-m
-    - php: 7.4
-      env: LIBRABBITMQ_VERSION=v0.7.1 TEST_PHP_ARGS=-m
+      env: LIBRABBITMQ_VERSION=v0.7.1
 
     - php: 7.3
       env: LIBRABBITMQ_VERSION=master

--- a/tests/bug_gh147.phpt
+++ b/tests/bug_gh147.phpt
@@ -4,6 +4,16 @@
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
 <?php
+
+// Register error handler to be able to catch the error
+// as it's not catchable with try/catch before PHP 7.4
+// see https://github.com/php/php-src/pull/3887
+function exception_error_handler($severity, $message, $file, $line) {
+    echo $message;
+    exit;
+}
+set_error_handler("exception_error_handler");
+
 $time = microtime(true);
 
 $connection = new AMQPConnection();
@@ -26,13 +36,19 @@ $queue->bind($exchange->getName(), 'test');
 
 $exchange->publish('test message', 'test');
 
-echo 'start', PHP_EOL;
-$queue->consume(function(AMQPEnvelope $e) use (&$consume) {
-    echo 'consuming';
-    $e . 'should fail';
+echo 'start'.PHP_EOL;
+try {
+    $queue->consume(function(AMQPEnvelope $e) use (&$consume) {
+        echo 'consuming'.PHP_EOL;
+        $e . 'should fail';
 
-    return false;
-});
+        return false;
+    });
+} catch (Throwable $ex) {
+    // Exception is only thrown as of PHP 7.4
+    echo $ex->getMessage();
+    exit;
+}
 
 echo 'done', PHP_EOL;
 
@@ -41,4 +57,4 @@ echo 'done', PHP_EOL;
 --EXPECTF--
 start
 consuming
-%s fatal error: Object of class %s could not be converted to string in %s on line %d
+Object of class %s could not be converted to string


### PR DESCRIPTION
1. Fixed RabbitMQ installation. Since Xenial it's not available as a service with Travis and has to be installed with `apt`.
2. Fixed test `bug_gh147.phpt` on PHP 7.4. As of PHP 7.4 converting object to string throws an exception if it cannot be converted. Since error in PHP 7.3 and exception in PHP 7.4 is formatted differently, I catch both the error (with error handler function) and exception and only print the message.
This PR fixes issue https://github.com/pdezwart/php-amqp/issues/354 with a better solution than https://github.com/pdezwart/php-amqp/pull/358 (which simply skips the problematic test)
3. Disabled memleak check on PHP 7.4 as it reports false positives same as in PHP 7.3. I'll provide a PR with PoC of memleak tests re-enabled and explanation later.

We should finally have a green build here with these fixes :)