### PR TITLE
Avoid variable lengths arrays

### DIFF
--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -534,7 +534,7 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
 	}
 
 	custom_properties_table.entries     = custom_properties_entries;
-	custom_properties_table.num_entries = sizeof(custom_properties_entries) / sizeof(amqp_table_entry_t);
+	custom_properties_table.num_entries = params->connection_name ? 2 : 1;
 
 	/* We can assume that connection established here but it is not true, real handshake goes during login */
 

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -414,13 +414,7 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
 	amqp_table_entry_t client_properties_entries[5];
 	amqp_table_t       client_properties_table;
 
-	int custom_properties_entries_len;
-	if (params->connection_name) {
-		custom_properties_entries_len = 2;
-	} else {
-		custom_properties_entries_len = 1;
-	}
-	amqp_table_entry_t custom_properties_entries[custom_properties_entries_len];
+	amqp_table_entry_t custom_properties_entries[2];
 	amqp_table_t       custom_properties_table;
 
 	amqp_connection_resource *resource;


### PR DESCRIPTION
Despite conforming to C99, variable length arrays are not supported by
MSVC, and maybe some other relevant compilers.  Therefore we hard-code
the maximum required space.

---

This would solve the Windows PECL [build failures](https://windows.php.net/downloads/pecl/releases/amqp/1.10.0/). An alternative would be to use do_alloca() and friends (similar to https://github.com/php/php-src/commit/9d31a42a30e944688c29aefc4bd0396ce395efe1), but this appears to be overkill in this case.