### PR TITLE
Fix #372: AppVeyor: Builds are failing but still show up as successful

### DIFF
--- a/appveyor/build.ps1
+++ b/appveyor/build.ps1
@@ -14,3 +14,6 @@ $here = (Get-Item -Path "." -Verbose).FullName
 $runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
 $task = $here + '\task.bat'
 & $runner -t $task
+if (-not $?) {
+    throw "build failed with errorlevel $LastExitCode"
+}


### PR DESCRIPTION
We have to explicitly catch eventual batch errors, and rethrow.