### PR TITLE
Use latests PHP versions for AppVeyor instead of .0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,62 +12,62 @@ cache:
 environment:
   BIN_SDK_VER: 2.2.0
   matrix:
-    - PHP_VER: 7.4.0
+    - PHP_VER: 7.4.4
       ARCH: x64
       TS: 1
       VC: vc15
       DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.4.0
-      ARCH: x64
-      TS: 0
-      VC: vc15
-      DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.4.0
-      ARCH: x86
-      TS: 1
-      VC: vc15
-      DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.4.0
-      ARCH: x86
-      TS: 1
-      VC: vc15
-      DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.3.0
-      ARCH: x64
-      TS: 1
-      VC: vc15
-      DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.3.0
+    - PHP_VER: 7.4.4
       ARCH: x64
       TS: 0
       VC: vc15
       DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.3.0
+    - PHP_VER: 7.4.4
       ARCH: x86
       TS: 1
       VC: vc15
       DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.3.0
+    - PHP_VER: 7.4.4
       ARCH: x86
       TS: 1
       VC: vc15
       DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.2.0
+    - PHP_VER: 7.3.16
       ARCH: x64
       TS: 1
       VC: vc15
       DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.2.0
+    - PHP_VER: 7.3.16
       ARCH: x64
       TS: 0
       VC: vc15
       DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.2.0
+    - PHP_VER: 7.3.16
       ARCH: x86
       TS: 1
       VC: vc15
       DEP: librabbitmq-0.9.0
-    - PHP_VER: 7.2.0
+    - PHP_VER: 7.3.16
+      ARCH: x86
+      TS: 1
+      VC: vc15
+      DEP: librabbitmq-0.9.0
+    - PHP_VER: 7.2.29
+      ARCH: x64
+      TS: 1
+      VC: vc15
+      DEP: librabbitmq-0.9.0
+    - PHP_VER: 7.2.29
+      ARCH: x64
+      TS: 0
+      VC: vc15
+      DEP: librabbitmq-0.9.0
+    - PHP_VER: 7.2.29
+      ARCH: x86
+      TS: 1
+      VC: vc15
+      DEP: librabbitmq-0.9.0
+    - PHP_VER: 7.2.29
       ARCH: x86
       TS: 1
       VC: vc15


### PR DESCRIPTION
This should actually solve the PHP 7.2 build failures (see #372).