### PR TITLE
More consistent return types for AMQPEnvelope

### DIFF
--- a/amqp_envelope.c
+++ b/amqp_envelope.c
@@ -107,7 +107,7 @@ static PHP_METHOD(amqp_envelope_class, getBody) {
 
     if (Z_STRLEN_P(zv) == 0) {
         /* BC */
-        RETURN_FALSE;
+        RETURN_STRING("");
     }
 
     RETURN_ZVAL(zv, 1, 0);
@@ -171,7 +171,7 @@ static PHP_METHOD(amqp_envelope_class, getHeader) {
 
     /* Look for the hash key */
     if ((tmp = zend_hash_str_find(HASH_OF(zv), key, key_len)) == NULL) {
-        RETURN_FALSE;
+        RETURN_NULL();
     }
 
     RETURN_ZVAL(tmp, 1, 0);
@@ -257,13 +257,13 @@ PHP_MINIT_FUNCTION (amqp_envelope) {
     INIT_CLASS_ENTRY(ce, "AMQPEnvelope", amqp_envelope_class_functions);
     this_ce = zend_register_internal_class_ex(&ce, amqp_basic_properties_class_entry TSRMLS_CC);
 
-    zend_declare_property_null(this_ce, ZEND_STRL("body"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_stringl(this_ce, ZEND_STRL("body"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
 
     zend_declare_property_null(this_ce, ZEND_STRL("consumer_tag"), ZEND_ACC_PRIVATE TSRMLS_CC);
     zend_declare_property_null(this_ce, ZEND_STRL("delivery_tag"), ZEND_ACC_PRIVATE TSRMLS_CC);
     zend_declare_property_null(this_ce, ZEND_STRL("is_redelivery"), ZEND_ACC_PRIVATE TSRMLS_CC);
     zend_declare_property_null(this_ce, ZEND_STRL("exchange_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(this_ce, ZEND_STRL("routing_key"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_stringl(this_ce, ZEND_STRL("routing_key"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
 
     return SUCCESS;
 }

--- a/stubs/AMQPEnvelope.php
+++ b/stubs/AMQPEnvelope.php
@@ -30,7 +30,7 @@ class AMQPEnvelope extends AMQPBasicProperties
     /**
      * Get the consumer tag of the message.
      *
-     * @return string The consumer tag of the message.
+     * @return string|null The consumer tag of the message.
      */
     public function getConsumerTag()
     {
@@ -39,7 +39,7 @@ class AMQPEnvelope extends AMQPBasicProperties
     /**
      * Get the delivery tag of the message.
      *
-     * @return integer The delivery tag of the message.
+     * @return integer|null The delivery tag of the message.
      */
     public function getDeliveryTag()
     {
@@ -48,7 +48,7 @@ class AMQPEnvelope extends AMQPBasicProperties
     /**
      * Get the exchange name on which the message was published.
      *
-     * @return string The exchange name on which the message was published.
+     * @return string|null The exchange name on which the message was published.
      */
     public function getExchangeName()
     {
@@ -73,8 +73,7 @@ class AMQPEnvelope extends AMQPBasicProperties
      *
      * @param string $header_key Name of the header to get the value from.
      *
-     * @return string|boolean The contents of the specified header or FALSE
-     *                        if not set.
+     * @return string|null The contents of the specified header or null if not set.
      */
     public function getHeader($header_key)
     {

--- a/tests/amqpenvelope_construct.phpt
+++ b/tests/amqpenvelope_construct.phpt
@@ -41,7 +41,7 @@ object(AMQPEnvelope)#1 (20) {
   ["cluster_id":"AMQPBasicProperties":private]=>
   string(0) ""
   ["body":"AMQPEnvelope":private]=>
-  NULL
+  string(0) ""
   ["consumer_tag":"AMQPEnvelope":private]=>
   NULL
   ["delivery_tag":"AMQPEnvelope":private]=>
@@ -51,5 +51,5 @@ object(AMQPEnvelope)#1 (20) {
   ["exchange_name":"AMQPEnvelope":private]=>
   NULL
   ["routing_key":"AMQPEnvelope":private]=>
-  NULL
+  string(0) ""
 }

--- a/tests/amqpqueue_get_headers.phpt
+++ b/tests/amqpqueue_get_headers.phpt
@@ -59,4 +59,4 @@ bool(true)
 one
 2
 Has nonexistent header: false
-Get nonexistent header: false
+Get nonexistent header: NULL

--- a/tests/bug_351.phpt
+++ b/tests/bug_351.phpt
@@ -1,0 +1,51 @@
+--TEST--
+AMQPEnvelope::getBody returns false instead of empty string
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+// Declare a new exchange
+$ex = new AMQPExchange($ch);
+$ex->setName('exchange' . microtime(true));
+$ex->setType(AMQP_EX_TYPE_FANOUT);
+$ex->declareExchange();
+
+// Create a new queue
+$q = new AMQPQueue($ch);
+$q->setName('queue1' . microtime(true));
+$q->declareQueue();
+
+// Bind it on the exchange to routing.key
+$q->bind($ex->getName(), '*');
+
+// Publish a message to the exchange with a routing key
+$ex->publish('');
+
+$msg = $q->get(AMQP_AUTOACK);
+echo "MSG1\n";
+var_dump($msg->getBody(), $msg->getRoutingKey(), $msg->getConsumerTag(), $msg->getDeliveryTag(), $msg->getExchangeName());
+
+$msg2 = new AMQPEnvelope();
+echo "MSG2\n";
+var_dump($msg2->getBody(), $msg2->getRoutingKey(), $msg2->getConsumerTag(), $msg2->getDeliveryTag(), $msg2->getExchangeName());
+?>
+==DONE==
+--EXPECTF--
+MSG1
+string(0) ""
+string(0) ""
+string(0) ""
+int(%d)
+string(%d) "exchange%s"
+MSG2
+string(0) ""
+string(0) ""
+NULL
+NULL
+NULL
+==DONE==

--- a/tests/bug_351.phpt
+++ b/tests/bug_351.phpt
@@ -9,21 +9,17 @@ $cnn->connect();
 
 $ch = new AMQPChannel($cnn);
 
-// Declare a new exchange
 $ex = new AMQPExchange($ch);
 $ex->setName('exchange' . microtime(true));
 $ex->setType(AMQP_EX_TYPE_FANOUT);
 $ex->declareExchange();
 
-// Create a new queue
 $q = new AMQPQueue($ch);
 $q->setName('queue1' . microtime(true));
 $q->declareQueue();
 
-// Bind it on the exchange to routing.key
 $q->bind($ex->getName(), '*');
 
-// Publish a message to the exchange with a routing key
 $ex->publish('');
 
 $msg = $q->get(AMQP_AUTOACK);


### PR DESCRIPTION
 * `AMQPEnvelope::getBody()` always returns a string now while previously it returned false for an empty body
 * `AMQPEnvelope::getHeader()` returns null for an unknown header instead of false
 * `AMQPEnvelope::getRoutingKey()` always returns a string now