### PR TITLE
Auto-format the codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,85 @@
+# Generated from CLion C/C++ Code Style settings
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: None
+AlignOperands: Align
+
+AllowAllArgumentsOnNextLine: false
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: BlockIndent
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Custom
+MacroBlockBegin: "(ZEND_BEGIN_ARG_INFO(_EX)?|PHP_INI_BEGIN)"
+MacroBlockEnd: "(ZEND_END_ARG_INFO|PHP_INI_END)"
+Macros:
+  - "PHP_ME(a, b, c, d)={a, b, c, d},"
+  - "PHP_MALIAS(a, b, c, d, e)={a, b, c, d, e},"
+  - "ZEND_HASH_FOREACH_KEY_VAL(a, b, c, d)=do {"
+  - "ZEND_HASH_FOREACH_STR_KEY(a, b)=do {"
+  - "ZEND_HASH_FOREACH_STR_KEY_VAL(a, b, c)=do {"
+  - "ZEND_HASH_FOREACH_END=} while(true)"
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 120
+CompactNamespaces: false
+IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Right
+ReferenceAlignment: Right
+ReflowComments: false
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 4
+UseTab: Never
+AlignArrayOfStructures: Left
+SortIncludes: Never
+IndentWrappedFunctionNames: true
+InsertNewlineAtEOF: true
+PenaltyReturnTypeOnItsOwnLine: 9999
+PenaltyExcessCharacter: 100

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,20 @@ env:
     TEST_TIMEOUT: 120
 
 jobs:
+    checkstyle:
+        name: Check coding style
+        runs-on: ubuntu-22.04
+        steps:
+          - name: install clang-format
+            uses: myci-actions/add-deb-repo@11
+            with:
+                repo: "http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
+                repo-name: llvm
+                keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+                install: clang-format-17
+          - name: Check style
+            run: clang-format-17 --dry-run --Werror  *.c *.h
+
     test:
         name: php-${{ matrix.php-version }} librabbitmq-${{ matrix.librabbitmq-version }} ${{ matrix.test-php-args == '-m' && 'memory leaks' || '' }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,10 @@ jobs:
                 repo: "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
                 repo-name: llvm
                 keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
-                install: clang-format
+          - name: Install
+            run: sudo apt-get install clang-format-17
           - name: Check style
-            run: clang-format --dry-run --Werror  *.c *.h
+            run: clang-format-17 --dry-run --Werror  *.c *.h
 
     test:
         name: php-${{ matrix.php-version }} librabbitmq-${{ matrix.librabbitmq-version }} ${{ matrix.test-php-args == '-m' && 'memory leaks' || '' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           - name: install clang-format
             uses: myci-actions/add-deb-repo@11
             with:
-                repo: "http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
+                repo: "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
                 repo-name: llvm
                 keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
                 install: clang-format-17

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           - name: install clang-format
             uses: myci-actions/add-deb-repo@11
             with:
-                repo: "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
+                repo: "deb https://apt.llvm.org/kinetic/ llvm-toolchain-kinetic main"
                 repo-name: llvm
                 keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
           - name: Install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           - name: install clang-format
             uses: myci-actions/add-deb-repo@11
             with:
-                repo: "deb https://apt.llvm.org/kinetic/ llvm-toolchain-kinetic main"
+                repo: "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
                 repo-name: llvm
                 keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
           - name: Install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,9 @@ jobs:
                 repo: "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
                 repo-name: llvm
                 keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
-          - name: Install
-            run: sudo apt-get install clang-format-17
+                install: clang-format-17
+          - name: Checkout
+            uses: actions/checkout@v3.5.3
           - name: Check style
             run: clang-format-17 --dry-run --Werror  *.c *.h
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,10 @@ jobs:
                 repo-name: llvm
                 keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
                 install: clang-format-17
+
           - name: Checkout
             uses: actions/checkout@v3.5.3
+
           - name: Check style
             run: clang-format-17 --dry-run --Werror  *.c *.h
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,9 @@ jobs:
                 repo: "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
                 repo-name: llvm
                 keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
-                install: clang-format-17
+                install: clang-format
           - name: Check style
-            run: clang-format-17 --dry-run --Werror  *.c *.h
+            run: clang-format --dry-run --Werror  *.c *.h
 
     test:
         name: php-${{ matrix.php-version }} librabbitmq-${{ matrix.librabbitmq-version }} ${{ matrix.test-php-args == '-m' && 'memory leaks' || '' }}

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ using `-Y amqp` attribute, just give a try - `tshark -i lo -Y amqp`.
    
 > NOTE: -w provides raw packet data, not text. If you want text output you need to redirect stdout (e.g. using '>'), don't use the -w option for this.
 
+#### Formatting
+
+Run `./tools/dev-format.sh` to automatically format all `.c` and `.h` files. Note: this requires `clang-format` >=17.
 
 #### Configuring a RabbitMQ server
 

--- a/amqp.c
+++ b/amqp.c
@@ -21,7 +21,7 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -31,23 +31,23 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# if PHP_VERSION_ID >= 80000
-#  include "main/php_stdint.h"
-# else
-#  include "win32/php_stdint.h"
-# endif
-# include "win32/signal.h"
+    #if PHP_VERSION_ID >= 80000
+        #include "main/php_stdint.h"
+    #else
+        #include "win32/php_stdint.h"
+    #endif
+    #include "win32/signal.h"
 #else
-# include <stdint.h>
-# include <signal.h>
+    #include <stdint.h>
+    #include <signal.h>
 #endif
 
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/framing.h>
+    #include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/framing.h>
 #else
-#include <amqp.h>
-#include <amqp_framing.h>
+    #include <amqp.h>
+    #include <amqp_framing.h>
 #endif
 
 #include "php_amqp.h"
@@ -62,101 +62,85 @@
 #include "amqp_decimal.h"
 
 #ifdef PHP_WIN32
-# include "win32/unistd.h"
+    #include "win32/unistd.h"
 #else
-# include <unistd.h>
+    #include <unistd.h>
 #endif
 
 /* True global resources - no need for thread safety here */
 
-zend_class_entry *amqp_exception_class_entry,
-				 *amqp_connection_exception_class_entry,
-				 *amqp_channel_exception_class_entry,
-				 *amqp_queue_exception_class_entry,
-				 *amqp_exchange_exception_class_entry,
-				 *amqp_envelope_exception_class_entry,
-				 *amqp_value_exception_class_entry;
+zend_class_entry *amqp_exception_class_entry, *amqp_connection_exception_class_entry,
+    *amqp_channel_exception_class_entry, *amqp_queue_exception_class_entry, *amqp_exchange_exception_class_entry,
+    *amqp_envelope_exception_class_entry, *amqp_value_exception_class_entry;
 
 /* {{{ amqp_functions[]
 *
 *Every user visible function must have an entry in amqp_functions[].
 */
 zend_function_entry amqp_functions[] = {
-	{NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 /* }}} */
 
-zend_bool php_amqp_is_valid_identifier(zend_string *val) {
+zend_bool php_amqp_is_valid_identifier(zend_string *val)
+{
     return ZSTR_LEN(val) > 0 && ZSTR_LEN(val) <= PHP_AMQP_MAX_IDENTIFIER_LENGTH;
 }
 
-zend_bool php_amqp_is_valid_credential(zend_string *val) {
+zend_bool php_amqp_is_valid_credential(zend_string *val)
+{
     return ZSTR_LEN(val) > 0 && ZSTR_LEN(val) <= PHP_AMQP_MAX_CREDENTIALS_LENGTH;
 }
 
-zend_bool php_amqp_is_valid_port(zend_long val) {
-    return val >= PHP_AMQP_MIN_PORT && val <= PHP_AMQP_MAX_PORT;
-}
+zend_bool php_amqp_is_valid_port(zend_long val) { return val >= PHP_AMQP_MIN_PORT && val <= PHP_AMQP_MAX_PORT; }
 
-zend_bool php_amqp_is_valid_timeout(double timeout) {
-    return timeout >= 0;
-}
+zend_bool php_amqp_is_valid_timeout(double timeout) { return timeout >= 0; }
 
-zend_bool php_amqp_is_valid_channel_max(zend_long val) {
-    return val > 0 && val <= PHP_AMQP_DEFAULT_CHANNEL_MAX;
-}
+zend_bool php_amqp_is_valid_channel_max(zend_long val) { return val > 0 && val <= PHP_AMQP_DEFAULT_CHANNEL_MAX; }
 
-zend_bool php_amqp_is_valid_frame_size_max(zend_long val) {
-    return val > 0 && val <= PHP_AMQP_MAX_FRAME_SIZE;
-}
+zend_bool php_amqp_is_valid_frame_size_max(zend_long val) { return val > 0 && val <= PHP_AMQP_MAX_FRAME_SIZE; }
 
-zend_bool php_amqp_is_valid_heartbeat(zend_long val) {
-    return val > 0 && val <= PHP_AMQP_MAX_HEARTBEAT;
-}
+zend_bool php_amqp_is_valid_heartbeat(zend_long val) { return val > 0 && val <= PHP_AMQP_MAX_HEARTBEAT; }
 
-zend_bool php_amqp_is_valid_prefetch_size(zend_long val) {
-  return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_SIZE;
-}
+zend_bool php_amqp_is_valid_prefetch_size(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_SIZE; }
 
-zend_bool php_amqp_is_valid_prefetch_count(zend_long val) {
-  return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_COUNT;
-}
+zend_bool php_amqp_is_valid_prefetch_count(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_COUNT; }
 
 static ZEND_INI_MH(onUpdateIdentifier)
 {
-	if (new_value != NULL && !php_amqp_is_valid_identifier(new_value)) {
-		return FAILURE;
-	}
+    if (new_value != NULL && !php_amqp_is_valid_identifier(new_value)) {
+        return FAILURE;
+    }
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 static ZEND_INI_MH(onUpdateCredentials)
 {
-	if (new_value != NULL && !php_amqp_is_valid_credential(new_value)) {
-		return FAILURE;
-	}
+    if (new_value != NULL && !php_amqp_is_valid_credential(new_value)) {
+        return FAILURE;
+    }
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 static ZEND_INI_MH(onUpdatePort)
 {
-	zend_long val = zend_ini_parse_quantity_warn(new_value, entry->name);
-	if (!php_amqp_is_valid_port(val)) {
-		return FAILURE;
-	}
+    zend_long val = zend_ini_parse_quantity_warn(new_value, entry->name);
+    if (!php_amqp_is_valid_port(val)) {
+        return FAILURE;
+    }
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 static ZEND_INI_MH(onUpdateTimeout)
 {
-	if (!php_amqp_is_valid_timeout(zend_strtod(ZSTR_VAL(new_value), NULL))) {
-		return FAILURE;
-	}
+    if (!php_amqp_is_valid_timeout(zend_strtod(ZSTR_VAL(new_value), NULL))) {
+        return FAILURE;
+    }
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 static ZEND_INI_MH(onUpdateChannelMax)
@@ -191,12 +175,12 @@ static ZEND_INI_MH(onUpdateHeartbeat)
 
 static ZEND_INI_MH(onUpdatePrefetchCount)
 {
-  zend_long val = zend_ini_parse_quantity_warn(new_value, entry->name);
-  if (!php_amqp_is_valid_prefetch_count(val)) {
-    return FAILURE;
-  }
+    zend_long val = zend_ini_parse_quantity_warn(new_value, entry->name);
+    if (!php_amqp_is_valid_prefetch_count(val)) {
+        return FAILURE;
+    }
 
-  return SUCCESS;
+    return SUCCESS;
 }
 
 static ZEND_INI_MH(onUpdatePrefetchSize)
@@ -210,276 +194,302 @@ static ZEND_INI_MH(onUpdatePrefetchSize)
 }
 
 PHP_INI_BEGIN()
-	PHP_INI_ENTRY("amqp.host",					DEFAULT_HOST,					PHP_INI_ALL, onUpdateIdentifier)
-	PHP_INI_ENTRY("amqp.vhost",					DEFAULT_VHOST,					PHP_INI_ALL, onUpdateIdentifier)
-	PHP_INI_ENTRY("amqp.port",					DEFAULT_PORT,					PHP_INI_ALL, onUpdatePort)
-	PHP_INI_ENTRY("amqp.timeout",				DEFAULT_TIMEOUT,				PHP_INI_ALL, onUpdateTimeout)
-	PHP_INI_ENTRY("amqp.read_timeout",			DEFAULT_READ_TIMEOUT,			PHP_INI_ALL, onUpdateTimeout)
-	PHP_INI_ENTRY("amqp.write_timeout",			DEFAULT_WRITE_TIMEOUT,			PHP_INI_ALL, onUpdateTimeout)
-	PHP_INI_ENTRY("amqp.connect_timeout",		DEFAULT_CONNECT_TIMEOUT,		PHP_INI_ALL, onUpdateTimeout)
-	PHP_INI_ENTRY("amqp.rpc_timeout",			DEFAULT_RPC_TIMEOUT,			PHP_INI_ALL, onUpdateTimeout)
-	PHP_INI_ENTRY("amqp.login",					DEFAULT_LOGIN,					PHP_INI_ALL, onUpdateCredentials)
-	PHP_INI_ENTRY("amqp.password",				DEFAULT_PASSWORD,				PHP_INI_ALL, onUpdateCredentials)
-	PHP_INI_ENTRY("amqp.auto_ack",				DEFAULT_AUTOACK,				PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("amqp.prefetch_count",		DEFAULT_PREFETCH_COUNT,			PHP_INI_ALL, onUpdatePrefetchCount)
-	PHP_INI_ENTRY("amqp.prefetch_size",			DEFAULT_PREFETCH_SIZE,			PHP_INI_ALL, onUpdatePrefetchSize)
-	PHP_INI_ENTRY("amqp.global_prefetch_count",	DEFAULT_GLOBAL_PREFETCH_COUNT,	PHP_INI_ALL, onUpdatePrefetchCount)
-	PHP_INI_ENTRY("amqp.global_prefetch_size",	DEFAULT_GLOBAL_PREFETCH_SIZE,	PHP_INI_ALL, onUpdatePrefetchSize)
-	PHP_INI_ENTRY("amqp.channel_max",			DEFAULT_CHANNEL_MAX,			PHP_INI_ALL, onUpdateChannelMax)
-	PHP_INI_ENTRY("amqp.frame_max",				DEFAULT_FRAME_MAX,				PHP_INI_ALL, onUpdateFrameSizeMax)
-	PHP_INI_ENTRY("amqp.heartbeat",				DEFAULT_HEARTBEAT,				PHP_INI_ALL, onUpdateHeartbeat)
-	PHP_INI_ENTRY("amqp.cacert",				DEFAULT_CACERT,					PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("amqp.cert",					DEFAULT_CERT,					PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("amqp.key",					DEFAULT_KEY,					PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("amqp.verify",				DEFAULT_VERIFY,					PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("amqp.sasl_method",			DEFAULT_SASL_METHOD,			PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("amqp.host", DEFAULT_HOST, PHP_INI_ALL, onUpdateIdentifier)
+    PHP_INI_ENTRY("amqp.vhost", DEFAULT_VHOST, PHP_INI_ALL, onUpdateIdentifier)
+    PHP_INI_ENTRY("amqp.port", DEFAULT_PORT, PHP_INI_ALL, onUpdatePort)
+    PHP_INI_ENTRY("amqp.timeout", DEFAULT_TIMEOUT, PHP_INI_ALL, onUpdateTimeout)
+    PHP_INI_ENTRY("amqp.read_timeout", DEFAULT_READ_TIMEOUT, PHP_INI_ALL, onUpdateTimeout)
+    PHP_INI_ENTRY("amqp.write_timeout", DEFAULT_WRITE_TIMEOUT, PHP_INI_ALL, onUpdateTimeout)
+    PHP_INI_ENTRY("amqp.connect_timeout", DEFAULT_CONNECT_TIMEOUT, PHP_INI_ALL, onUpdateTimeout)
+    PHP_INI_ENTRY("amqp.rpc_timeout", DEFAULT_RPC_TIMEOUT, PHP_INI_ALL, onUpdateTimeout)
+    PHP_INI_ENTRY("amqp.login", DEFAULT_LOGIN, PHP_INI_ALL, onUpdateCredentials)
+    PHP_INI_ENTRY("amqp.password", DEFAULT_PASSWORD, PHP_INI_ALL, onUpdateCredentials)
+    PHP_INI_ENTRY("amqp.auto_ack", DEFAULT_AUTOACK, PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("amqp.prefetch_count", DEFAULT_PREFETCH_COUNT, PHP_INI_ALL, onUpdatePrefetchCount)
+    PHP_INI_ENTRY("amqp.prefetch_size", DEFAULT_PREFETCH_SIZE, PHP_INI_ALL, onUpdatePrefetchSize)
+    PHP_INI_ENTRY("amqp.global_prefetch_count", DEFAULT_GLOBAL_PREFETCH_COUNT, PHP_INI_ALL, onUpdatePrefetchCount)
+    PHP_INI_ENTRY("amqp.global_prefetch_size", DEFAULT_GLOBAL_PREFETCH_SIZE, PHP_INI_ALL, onUpdatePrefetchSize)
+    PHP_INI_ENTRY("amqp.channel_max", DEFAULT_CHANNEL_MAX, PHP_INI_ALL, onUpdateChannelMax)
+    PHP_INI_ENTRY("amqp.frame_max", DEFAULT_FRAME_MAX, PHP_INI_ALL, onUpdateFrameSizeMax)
+    PHP_INI_ENTRY("amqp.heartbeat", DEFAULT_HEARTBEAT, PHP_INI_ALL, onUpdateHeartbeat)
+    PHP_INI_ENTRY("amqp.cacert", DEFAULT_CACERT, PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("amqp.cert", DEFAULT_CERT, PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("amqp.key", DEFAULT_KEY, PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("amqp.verify", DEFAULT_VERIFY, PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("amqp.sasl_method", DEFAULT_SASL_METHOD, PHP_INI_ALL, NULL)
 PHP_INI_END()
 
 ZEND_DECLARE_MODULE_GLOBALS(amqp)
 
 static PHP_GINIT_FUNCTION(amqp) /* {{{ */
 {
-	amqp_globals->error_message = NULL;
-	amqp_globals->error_code = 0;
+    amqp_globals->error_message = NULL;
+    amqp_globals->error_code = 0;
 } /* }}} */
 
 static PHP_MINIT_FUNCTION(amqp) /* {{{ */
 {
-	zend_class_entry ce;
+    zend_class_entry ce;
 
-	/* Set up the connection resource */
-	le_amqp_connection_resource = zend_register_list_destructors_ex(amqp_connection_resource_dtor, NULL, PHP_AMQP_CONNECTION_RES_NAME, module_number);
-	le_amqp_connection_resource_persistent = zend_register_list_destructors_ex(NULL, amqp_connection_resource_dtor_persistent, PHP_AMQP_CONNECTION_RES_NAME, module_number);
+    /* Set up the connection resource */
+    le_amqp_connection_resource = zend_register_list_destructors_ex(
+        amqp_connection_resource_dtor,
+        NULL,
+        PHP_AMQP_CONNECTION_RES_NAME,
+        module_number
+    );
+    le_amqp_connection_resource_persistent = zend_register_list_destructors_ex(
+        NULL,
+        amqp_connection_resource_dtor_persistent,
+        PHP_AMQP_CONNECTION_RES_NAME,
+        module_number
+    );
 
-	PHP_MINIT(amqp_connection)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(amqp_channel)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(amqp_queue)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(amqp_exchange)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(amqp_basic_properties)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(amqp_envelope)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(amqp_timestamp)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(amqp_decimal)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_connection)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_channel)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_queue)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_exchange)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_basic_properties)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_envelope)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_timestamp)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_decimal)(INIT_FUNC_ARGS_PASSTHRU);
 
-	/* Class Exceptions */
-	INIT_CLASS_ENTRY(ce, "AMQPException", NULL);
-	amqp_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C));
+    /* Class Exceptions */
+    INIT_CLASS_ENTRY(ce, "AMQPException", NULL);
+    amqp_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C));
 
-	INIT_CLASS_ENTRY(ce, "AMQPConnectionException", NULL);
-	amqp_connection_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
+    INIT_CLASS_ENTRY(ce, "AMQPConnectionException", NULL);
+    amqp_connection_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
 
-	INIT_CLASS_ENTRY(ce, "AMQPChannelException", NULL);
-	amqp_channel_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
+    INIT_CLASS_ENTRY(ce, "AMQPChannelException", NULL);
+    amqp_channel_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
 
-	INIT_CLASS_ENTRY(ce, "AMQPQueueException", NULL);
-	amqp_queue_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
+    INIT_CLASS_ENTRY(ce, "AMQPQueueException", NULL);
+    amqp_queue_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
 
-	INIT_CLASS_ENTRY(ce, "AMQPEnvelopeException", NULL);
-	amqp_envelope_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
-	zend_declare_property_null(amqp_envelope_exception_class_entry, ZEND_STRL("envelope"), ZEND_ACC_PUBLIC TSRMLS_CC);
+    INIT_CLASS_ENTRY(ce, "AMQPEnvelopeException", NULL);
+    amqp_envelope_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
+    zend_declare_property_null(amqp_envelope_exception_class_entry, ZEND_STRL("envelope"), ZEND_ACC_PUBLIC TSRMLS_CC);
 
-	INIT_CLASS_ENTRY(ce, "AMQPExchangeException", NULL);
-	amqp_exchange_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
+    INIT_CLASS_ENTRY(ce, "AMQPExchangeException", NULL);
+    amqp_exchange_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
 
-	INIT_CLASS_ENTRY(ce, "AMQPValueException", NULL);
-	amqp_value_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
+    INIT_CLASS_ENTRY(ce, "AMQPValueException", NULL);
+    amqp_value_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
 
-	REGISTER_INI_ENTRIES();
+    REGISTER_INI_ENTRIES();
 
-	REGISTER_LONG_CONSTANT("AMQP_NOPARAM",			AMQP_NOPARAM,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_JUST_CONSUME",		AMQP_JUST_CONSUME,	CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_DURABLE",			AMQP_DURABLE,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_PASSIVE",			AMQP_PASSIVE,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_EXCLUSIVE",		AMQP_EXCLUSIVE,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_AUTODELETE",		AMQP_AUTODELETE,	CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_INTERNAL",			AMQP_INTERNAL,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_NOLOCAL",			AMQP_NOLOCAL,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_AUTOACK",			AMQP_AUTOACK,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_IFEMPTY",			AMQP_IFEMPTY,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_IFUNUSED",			AMQP_IFUNUSED,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_MANDATORY",		AMQP_MANDATORY,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_IMMEDIATE",		AMQP_IMMEDIATE,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_MULTIPLE",			AMQP_MULTIPLE,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_NOWAIT",			AMQP_NOWAIT,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_REQUEUE",			AMQP_REQUEUE,		CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_NOPARAM", AMQP_NOPARAM, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_JUST_CONSUME", AMQP_JUST_CONSUME, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_DURABLE", AMQP_DURABLE, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_PASSIVE", AMQP_PASSIVE, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_EXCLUSIVE", AMQP_EXCLUSIVE, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_AUTODELETE", AMQP_AUTODELETE, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_INTERNAL", AMQP_INTERNAL, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_NOLOCAL", AMQP_NOLOCAL, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_AUTOACK", AMQP_AUTOACK, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_IFEMPTY", AMQP_IFEMPTY, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_IFUNUSED", AMQP_IFUNUSED, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_MANDATORY", AMQP_MANDATORY, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_IMMEDIATE", AMQP_IMMEDIATE, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_MULTIPLE", AMQP_MULTIPLE, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_NOWAIT", AMQP_NOWAIT, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_REQUEUE", AMQP_REQUEUE, CONST_CS | CONST_PERSISTENT);
 
-	REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_DIRECT",	AMQP_EX_TYPE_DIRECT,	CONST_CS | CONST_PERSISTENT);
-	REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_FANOUT",	AMQP_EX_TYPE_FANOUT,	CONST_CS | CONST_PERSISTENT);
-	REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_TOPIC",	AMQP_EX_TYPE_TOPIC,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_HEADERS",AMQP_EX_TYPE_HEADERS,	CONST_CS | CONST_PERSISTENT);
+    REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_DIRECT", AMQP_EX_TYPE_DIRECT, CONST_CS | CONST_PERSISTENT);
+    REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_FANOUT", AMQP_EX_TYPE_FANOUT, CONST_CS | CONST_PERSISTENT);
+    REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_TOPIC", AMQP_EX_TYPE_TOPIC, CONST_CS | CONST_PERSISTENT);
+    REGISTER_STRING_CONSTANT("AMQP_EX_TYPE_HEADERS", AMQP_EX_TYPE_HEADERS, CONST_CS | CONST_PERSISTENT);
 
-	REGISTER_LONG_CONSTANT("AMQP_OS_SOCKET_TIMEOUT_ERRNO",	AMQP_OS_SOCKET_TIMEOUT_ERRNO,	CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("PHP_AMQP_MAX_CHANNELS",			PHP_AMQP_MAX_CHANNELS,			CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_OS_SOCKET_TIMEOUT_ERRNO", AMQP_OS_SOCKET_TIMEOUT_ERRNO, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("PHP_AMQP_MAX_CHANNELS", PHP_AMQP_MAX_CHANNELS, CONST_CS | CONST_PERSISTENT);
 
-	REGISTER_LONG_CONSTANT("AMQP_SASL_METHOD_PLAIN",		AMQP_SASL_METHOD_PLAIN,		CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_SASL_METHOD_EXTERNAL",		AMQP_SASL_METHOD_EXTERNAL,	CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_SASL_METHOD_PLAIN", AMQP_SASL_METHOD_PLAIN, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_SASL_METHOD_EXTERNAL", AMQP_SASL_METHOD_EXTERNAL, CONST_CS | CONST_PERSISTENT);
 
-	REGISTER_LONG_CONSTANT("AMQP_DELIVERY_MODE_TRANSIENT",		AMQP_DELIVERY_NONPERSISTENT,	CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("AMQP_DELIVERY_MODE_PERSISTENT",		AMQP_DELIVERY_PERSISTENT,	CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_DELIVERY_MODE_TRANSIENT", AMQP_DELIVERY_NONPERSISTENT, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("AMQP_DELIVERY_MODE_PERSISTENT", AMQP_DELIVERY_PERSISTENT, CONST_CS | CONST_PERSISTENT);
 
-	return SUCCESS;
+    return SUCCESS;
 } /* }}} */
 
 static PHP_MSHUTDOWN_FUNCTION(amqp) /* {{{ */
 {
-	UNREGISTER_INI_ENTRIES();
+    UNREGISTER_INI_ENTRIES();
 
-	return SUCCESS;
+    return SUCCESS;
 } /* }}} */
 
 static PHP_RSHUTDOWN_FUNCTION(amqp) /* {{{ */
 {
-	if (NULL != PHP_AMQP_G(error_message)) {
-		efree(PHP_AMQP_G(error_message));
-		PHP_AMQP_G(error_message) = NULL;
-	}
+    if (NULL != PHP_AMQP_G(error_message)) {
+        efree(PHP_AMQP_G(error_message));
+        PHP_AMQP_G(error_message) = NULL;
+    }
 
-	PHP_AMQP_G(error_code) = 0;
+    PHP_AMQP_G(error_code) = 0;
 
-	return SUCCESS;
+    return SUCCESS;
 } /* }}} */
 
 static PHP_MINFO_FUNCTION(amqp) /* {{{ */
 {
-	php_info_print_table_start();
-	php_info_print_table_header(2, "Version",					PHP_AMQP_VERSION);
-	php_info_print_table_header(2, "Revision",					PHP_AMQP_REVISION);
-	php_info_print_table_header(2, "Compiled",					__DATE__ " @ "  __TIME__);
-	php_info_print_table_header(2, "AMQP protocol version", 	"0-9-1");
-	php_info_print_table_header(2, "librabbitmq version", amqp_version());
-	php_info_print_table_header(2, "Default max channels per connection",	DEFAULT_CHANNEL_MAX);
-	php_info_print_table_header(2, "Default max frame size",	DEFAULT_FRAME_MAX);
-	php_info_print_table_header(2, "Default heartbeats interval",	DEFAULT_HEARTBEAT);
-	DISPLAY_INI_ENTRIES();
+    php_info_print_table_start();
+    php_info_print_table_header(2, "Version", PHP_AMQP_VERSION);
+    php_info_print_table_header(2, "Revision", PHP_AMQP_REVISION);
+    php_info_print_table_header(2, "Compiled", __DATE__ " @ " __TIME__);
+    php_info_print_table_header(2, "AMQP protocol version", "0-9-1");
+    php_info_print_table_header(2, "librabbitmq version", amqp_version());
+    php_info_print_table_header(2, "Default max channels per connection", DEFAULT_CHANNEL_MAX);
+    php_info_print_table_header(2, "Default max frame size", DEFAULT_FRAME_MAX);
+    php_info_print_table_header(2, "Default heartbeats interval", DEFAULT_HEARTBEAT);
+    DISPLAY_INI_ENTRIES();
 } /* }}} */
 
 /* {{{ amqp_module_entry
 */
 zend_module_entry amqp_module_entry = {
-	STANDARD_MODULE_HEADER,
-	"amqp",
-	amqp_functions,
-	PHP_MINIT(amqp),
-	PHP_MSHUTDOWN(amqp),
-	NULL,
-	PHP_RSHUTDOWN(amqp),
-	PHP_MINFO(amqp),
-	PHP_AMQP_VERSION,
-	PHP_MODULE_GLOBALS(amqp),
-	PHP_GINIT(amqp),
-	NULL,
-	NULL,
-	STANDARD_MODULE_PROPERTIES_EX
+    STANDARD_MODULE_HEADER,
+    "amqp",
+    amqp_functions,
+    PHP_MINIT(amqp),
+    PHP_MSHUTDOWN(amqp),
+    NULL,
+    PHP_RSHUTDOWN(amqp),
+    PHP_MINFO(amqp),
+    PHP_AMQP_VERSION,
+    PHP_MODULE_GLOBALS(amqp),
+    PHP_GINIT(amqp),
+    NULL,
+    NULL,
+    STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */
 
 #ifdef COMPILE_DL_AMQP
-	ZEND_GET_MODULE(amqp)
+ZEND_GET_MODULE(amqp)
 #endif
 
-int php_amqp_error(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *connection_resource, amqp_channel_resource *channel_resource TSRMLS_DC)
+int php_amqp_error(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *connection_resource,
+    amqp_channel_resource *channel_resource TSRMLS_DC
+)
 {
-	return php_amqp_error_advanced(reply, message, connection_resource, channel_resource, 1 TSRMLS_CC);
+    return php_amqp_error_advanced(reply, message, connection_resource, channel_resource, 1 TSRMLS_CC);
 }
 
-int php_amqp_error_advanced(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *connection_resource, amqp_channel_resource *channel_resource, int fail_on_errors TSRMLS_DC)
+int php_amqp_error_advanced(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *connection_resource,
+    amqp_channel_resource *channel_resource,
+    int fail_on_errors TSRMLS_DC
+)
 {
-	assert(connection_resource != NULL);
+    assert(connection_resource != NULL);
 
-	PHP_AMQP_G(error_code) = 0;
-	if (*message != NULL) {
-		efree(*message);
-	}
+    PHP_AMQP_G(error_code) = 0;
+    if (*message != NULL) {
+        efree(*message);
+    }
 
-	int res = php_amqp_connection_resource_error(reply, message, connection_resource, (amqp_channel_t)(channel_resource ? channel_resource->channel_id : 0) TSRMLS_CC);
+    int res = php_amqp_connection_resource_error(
+        reply,
+        message,
+        connection_resource,
+        (amqp_channel_t) (channel_resource ? channel_resource->channel_id : 0) TSRMLS_CC
+    );
 
-	switch (res) {
-		case PHP_AMQP_RESOURCE_RESPONSE_OK:
-			break;
-		case PHP_AMQP_RESOURCE_RESPONSE_ERROR:
-			if (!fail_on_errors) {
-				break;
-			}
-			/* Library or other non-protocol or even protocol related errors may be here. */
-			/* In most cases it designate some underlying hard errors. Fail fast. */
-		case PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED:
-			/* Mark connection resource as closed to prevent sending any further requests */
-			connection_resource->is_connected = '\0';
+    switch (res) {
+        case PHP_AMQP_RESOURCE_RESPONSE_OK:
+            break;
+        case PHP_AMQP_RESOURCE_RESPONSE_ERROR:
+            if (!fail_on_errors) {
+                break;
+            }
+            /* Library or other non-protocol or even protocol related errors may be here. */
+            /* In most cases it designate some underlying hard errors. Fail fast. */
+        case PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED:
+            /* Mark connection resource as closed to prevent sending any further requests */
+            connection_resource->is_connected = '\0';
 
-			/* Close connection with all its channels */
-			php_amqp_disconnect_force(connection_resource TSRMLS_CC);
+            /* Close connection with all its channels */
+            php_amqp_disconnect_force(connection_resource TSRMLS_CC);
 
-			break;
-		case PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED:
-			/* Mark channel as closed to prevent sending channel.close request */
-			assert(channel_resource != NULL);
-			if (channel_resource) {
-				channel_resource->is_connected = '\0';
+            break;
+        case PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED:
+            /* Mark channel as closed to prevent sending channel.close request */
+            assert(channel_resource != NULL);
+            if (channel_resource) {
+                channel_resource->is_connected = '\0';
 
-				/* Close channel */
-				php_amqp_close_channel(channel_resource, 1 TSRMLS_CC);
-			}
-			/* No more error handling necessary, returning. */
-			break;
-		default:
-			spprintf(message, 0, "Unknown server error, method id 0x%08X (not handled by extension)", reply.reply.id);
-			break;
-	}
+                /* Close channel */
+                php_amqp_close_channel(channel_resource, 1 TSRMLS_CC);
+            }
+            /* No more error handling necessary, returning. */
+            break;
+        default:
+            spprintf(message, 0, "Unknown server error, method id 0x%08X (not handled by extension)", reply.reply.id);
+            break;
+    }
 
-	return res;
+    return res;
 }
 
-void php_amqp_zend_throw_exception_short(amqp_rpc_reply_t reply, zend_class_entry *exception_ce TSRMLS_DC) {
-	php_amqp_zend_throw_exception(reply, exception_ce, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-}
-
-void php_amqp_zend_throw_exception(amqp_rpc_reply_t reply, zend_class_entry *exception_ce, const char *message, zend_long code TSRMLS_DC)
+void php_amqp_zend_throw_exception_short(amqp_rpc_reply_t reply, zend_class_entry *exception_ce TSRMLS_DC)
 {
-	switch (reply.reply_type) {
-		case AMQP_RESPONSE_NORMAL:
-			break;
-		case AMQP_RESPONSE_NONE:
-			exception_ce = amqp_exception_class_entry;
-			break;
-		case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-			exception_ce = amqp_exception_class_entry;
-			break;
-		case AMQP_RESPONSE_SERVER_EXCEPTION:
-			switch (reply.reply.id) {
-				case AMQP_CONNECTION_CLOSE_METHOD:
-					/* Fatal errors - pass them to connection level */
-					exception_ce = amqp_connection_exception_class_entry;
-					break;
-				case AMQP_CHANNEL_CLOSE_METHOD:
-					/* Most channel-level errors occurs due to previously known action and thus their kind can be predicted. */
-					/* exception_ce = amqp_channel_exception_class_entry; */
-					break;
-			}
-			break;
-		/* Default for the above switch should be handled by the below default. */
-		default:
-			exception_ce = amqp_exception_class_entry;
-			break;
-	}
-
-	zend_throw_exception(exception_ce, message, code TSRMLS_CC);
+    php_amqp_zend_throw_exception(reply, exception_ce, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
 }
 
-
-void php_amqp_maybe_release_buffers_on_channel(amqp_connection_resource *connection_resource, amqp_channel_resource *channel_resource)
+void php_amqp_zend_throw_exception(
+    amqp_rpc_reply_t reply,
+    zend_class_entry *exception_ce,
+    const char *message,
+    zend_long code TSRMLS_DC
+)
 {
-	assert(channel_resource != NULL);
-	assert(channel_resource->channel_id > 0);
+    switch (reply.reply_type) {
+        case AMQP_RESPONSE_NORMAL:
+            break;
+        case AMQP_RESPONSE_NONE:
+            exception_ce = amqp_exception_class_entry;
+            break;
+        case AMQP_RESPONSE_LIBRARY_EXCEPTION:
+            exception_ce = amqp_exception_class_entry;
+            break;
+        case AMQP_RESPONSE_SERVER_EXCEPTION:
+            switch (reply.reply.id) {
+                case AMQP_CONNECTION_CLOSE_METHOD:
+                    /* Fatal errors - pass them to connection level */
+                    exception_ce = amqp_connection_exception_class_entry;
+                    break;
+                case AMQP_CHANNEL_CLOSE_METHOD:
+                    /* Most channel-level errors occurs due to previously known action and thus their kind can be predicted. */
+                    /* exception_ce = amqp_channel_exception_class_entry; */
+                    break;
+            }
+            break;
+        /* Default for the above switch should be handled by the below default. */
+        default:
+            exception_ce = amqp_exception_class_entry;
+            break;
+    }
 
-	if (connection_resource) {
-		amqp_maybe_release_buffers_on_channel(connection_resource->connection_state, channel_resource->channel_id);
-	}
+    zend_throw_exception(exception_ce, message, code TSRMLS_CC);
 }
 
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/
+
+void php_amqp_maybe_release_buffers_on_channel(
+    amqp_connection_resource *connection_resource,
+    amqp_channel_resource *channel_resource
+)
+{
+    assert(channel_resource != NULL);
+    assert(channel_resource->channel_id > 0);
+
+    if (connection_resource) {
+        amqp_maybe_release_buffers_on_channel(connection_resource->connection_state, channel_resource->channel_id);
+    }
+}

--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -22,7 +22,7 @@
 */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -32,29 +32,29 @@
 #include "Zend/zend_interfaces.h"
 
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/framing.h>
+    #include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/framing.h>
 #else
-#include <amqp.h>
-#include <amqp_framing.h>
+    #include <amqp.h>
+    #include <amqp_framing.h>
 #endif
 
 #ifdef PHP_WIN32
-# include "win32/unistd.h"
-# if PHP_VERSION_ID >= 80000
-#  include "main/php_stdint.h"
-# else
-#  include "win32/php_stdint.h"
-# endif
-# include "win32/signal.h"
+    #include "win32/unistd.h"
+    #if PHP_VERSION_ID >= 80000
+        #include "main/php_stdint.h"
+    #else
+        #include "win32/php_stdint.h"
+    #endif
+    #include "win32/signal.h"
 #else
-# include <signal.h>
-# include <stdint.h>
-# include <unistd.h>
+    #include <signal.h>
+    #include <stdint.h>
+    #include <unistd.h>
 #endif
 
 #if HAVE_INTTYPES_H
-# include <inttypes.h>
+    #include <inttypes.h>
 #endif
 
 #include "amqp_basic_properties.h"
@@ -73,7 +73,8 @@ void php_amqp_basic_properties_convert_to_zval(amqp_basic_properties_t *props, z
     php_amqp_basic_properties_extract(props, obj TSRMLS_CC);
 }
 
-void php_amqp_basic_properties_set_empty_headers(zval *obj TSRMLS_DC) {
+void php_amqp_basic_properties_set_empty_headers(zval *obj TSRMLS_DC)
+{
     zval headers;
 
     ZVAL_UNDEF(&headers);
@@ -81,54 +82,89 @@ void php_amqp_basic_properties_set_empty_headers(zval *obj TSRMLS_DC) {
 
     zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("headers"), &headers TSRMLS_CC);
 
-	zval_ptr_dtor(&headers);
+    zval_ptr_dtor(&headers);
 }
 
 
 /* {{{ proto AMQPBasicProperties::__construct() */
-static PHP_METHOD(AMQPBasicProperties, __construct) {
+static PHP_METHOD(AMQPBasicProperties, __construct)
+{
 
-    char *content_type = NULL;      size_t content_type_len = 0;
-    char *content_encoding = NULL;  size_t content_encoding_len = 0;
+    char *content_type = NULL;
+    size_t content_type_len = 0;
+    char *content_encoding = NULL;
+    size_t content_encoding_len = 0;
 
     zval *headers = NULL;
 
     zend_long delivery_mode = AMQP_DELIVERY_NONPERSISTENT;
     zend_long priority = 0;
 
-    char *correlation_id = NULL;    size_t correlation_id_len = 0;
-    char *reply_to = NULL;          size_t reply_to_len = 0;
-    char *expiration = NULL;        size_t expiration_len = 0;
-    char *message_id = NULL;        size_t message_id_len = 0;
+    char *correlation_id = NULL;
+    size_t correlation_id_len = 0;
+    char *reply_to = NULL;
+    size_t reply_to_len = 0;
+    char *expiration = NULL;
+    size_t expiration_len = 0;
+    char *message_id = NULL;
+    size_t message_id_len = 0;
 
     zend_long timestamp = 0;
 
-    char *type = NULL;          size_t type_len = 0;
-    char *user_id = NULL;       size_t user_id_len = 0;
-    char *app_id = NULL;        size_t app_id_len = 0;
-    char *cluster_id = NULL;    size_t cluster_id_len = 0;
+    char *type = NULL;
+    size_t type_len = 0;
+    char *user_id = NULL;
+    size_t user_id_len = 0;
+    char *app_id = NULL;
+    size_t app_id_len = 0;
+    char *cluster_id = NULL;
+    size_t cluster_id_len = 0;
 
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|ssallsssslssss",
-                              /* s */ &content_type, &content_type_len,
-                              /* s */ &content_encoding, &content_encoding_len,
-                              /* a */ &headers,
-                              /* l */ &delivery_mode,
-                              /* l */ &priority,
-                              /* s */ &correlation_id, &correlation_id_len,
-                              /* s */ &reply_to, &reply_to_len,
-                              /* s */ &expiration, &expiration_len,
-                              /* s */ &message_id, &message_id_len,
-                              /* l */ &timestamp,
-                              /* s */ &type, &type_len,
-                              /* s */ &user_id, &user_id_len,
-                              /* s */ &app_id, &app_id_len,
-                              /* s */ &cluster_id, &cluster_id_len
-                             ) == FAILURE) {
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS() TSRMLS_CC,
+            "|ssallsssslssss",
+            /* s */ &content_type,
+            &content_type_len,
+            /* s */ &content_encoding,
+            &content_encoding_len,
+            /* a */ &headers,
+            /* l */ &delivery_mode,
+            /* l */ &priority,
+            /* s */ &correlation_id,
+            &correlation_id_len,
+            /* s */ &reply_to,
+            &reply_to_len,
+            /* s */ &expiration,
+            &expiration_len,
+            /* s */ &message_id,
+            &message_id_len,
+            /* l */ &timestamp,
+            /* s */ &type,
+            &type_len,
+            /* s */ &user_id,
+            &user_id_len,
+            /* s */ &app_id,
+            &app_id_len,
+            /* s */ &cluster_id,
+            &cluster_id_len
+        ) == FAILURE) {
         return;
     }
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("content_type"), content_type, content_type_len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("content_encoding"), content_encoding, content_encoding_len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("content_type"),
+        content_type,
+        content_type_len TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("content_encoding"),
+        content_encoding,
+        content_encoding_len TSRMLS_CC
+    );
 
     if (headers != NULL) {
         zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("headers"), headers TSRMLS_CC);
@@ -136,25 +172,73 @@ static PHP_METHOD(AMQPBasicProperties, __construct) {
         php_amqp_basic_properties_set_empty_headers(getThis() TSRMLS_CC);
     }
 
-    zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("delivery_mode"), delivery_mode TSRMLS_CC);
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("delivery_mode"),
+        delivery_mode TSRMLS_CC
+    );
     zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("priority"), priority TSRMLS_CC);
 
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("correlation_id"), correlation_id, correlation_id_len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("reply_to"), reply_to, reply_to_len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("expiration"), expiration, expiration_len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("message_id"), message_id, message_id_len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("correlation_id"),
+        correlation_id,
+        correlation_id_len TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("reply_to"),
+        reply_to,
+        reply_to_len TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("expiration"),
+        expiration,
+        expiration_len TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("message_id"),
+        message_id,
+        message_id_len TSRMLS_CC
+    );
 
     zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("timestamp"), timestamp TSRMLS_CC);
 
     zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("type"), type, type_len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("user_id"), user_id, user_id_len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("app_id"), app_id, app_id_len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("cluster_id"), cluster_id, cluster_id_len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("user_id"),
+        user_id,
+        user_id_len TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("app_id"),
+        app_id,
+        app_id_len TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("cluster_id"),
+        cluster_id,
+        cluster_id_len TSRMLS_CC
+    );
 }
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getContentType() */
-static PHP_METHOD(AMQPBasicProperties, getContentType) {
+static PHP_METHOD(AMQPBasicProperties, getContentType)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("content_type");
@@ -162,7 +246,8 @@ static PHP_METHOD(AMQPBasicProperties, getContentType) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getContentEncoding() */
-static PHP_METHOD(AMQPBasicProperties, getContentEncoding) {
+static PHP_METHOD(AMQPBasicProperties, getContentEncoding)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("content_encoding");
@@ -170,7 +255,8 @@ static PHP_METHOD(AMQPBasicProperties, getContentEncoding) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getCorrelationId() */
-static PHP_METHOD(AMQPBasicProperties, getHeaders) {
+static PHP_METHOD(AMQPBasicProperties, getHeaders)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("headers");
@@ -178,7 +264,8 @@ static PHP_METHOD(AMQPBasicProperties, getHeaders) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getDeliveryMode() */
-static PHP_METHOD(AMQPBasicProperties, getDeliveryMode) {
+static PHP_METHOD(AMQPBasicProperties, getDeliveryMode)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("delivery_mode");
@@ -186,7 +273,8 @@ static PHP_METHOD(AMQPBasicProperties, getDeliveryMode) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getPriority() */
-static PHP_METHOD(AMQPBasicProperties, getPriority) {
+static PHP_METHOD(AMQPBasicProperties, getPriority)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("priority");
@@ -194,7 +282,8 @@ static PHP_METHOD(AMQPBasicProperties, getPriority) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getCorrelationId() */
-static PHP_METHOD(AMQPBasicProperties, getCorrelationId) {
+static PHP_METHOD(AMQPBasicProperties, getCorrelationId)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("correlation_id");
@@ -202,7 +291,8 @@ static PHP_METHOD(AMQPBasicProperties, getCorrelationId) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getReplyTo() */
-static PHP_METHOD(AMQPBasicProperties, getReplyTo) {
+static PHP_METHOD(AMQPBasicProperties, getReplyTo)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("reply_to");
@@ -211,7 +301,8 @@ static PHP_METHOD(AMQPBasicProperties, getReplyTo) {
 
 /* {{{ proto AMQPBasicProperties::getExpiration()
 check amqp envelope */
-static PHP_METHOD(AMQPBasicProperties, getExpiration) {
+static PHP_METHOD(AMQPBasicProperties, getExpiration)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("expiration");
@@ -219,7 +310,8 @@ static PHP_METHOD(AMQPBasicProperties, getExpiration) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getMessageId() */
-static PHP_METHOD(AMQPBasicProperties, getMessageId) {
+static PHP_METHOD(AMQPBasicProperties, getMessageId)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("message_id");
@@ -227,7 +319,8 @@ static PHP_METHOD(AMQPBasicProperties, getMessageId) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getTimestamp() */
-static PHP_METHOD(AMQPBasicProperties, getTimestamp) {
+static PHP_METHOD(AMQPBasicProperties, getTimestamp)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("timestamp");
@@ -235,7 +328,8 @@ static PHP_METHOD(AMQPBasicProperties, getTimestamp) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getType() */
-static PHP_METHOD(AMQPBasicProperties, getType) {
+static PHP_METHOD(AMQPBasicProperties, getType)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("type");
@@ -243,7 +337,8 @@ static PHP_METHOD(AMQPBasicProperties, getType) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getUserId() */
-static PHP_METHOD(AMQPBasicProperties, getUserId) {
+static PHP_METHOD(AMQPBasicProperties, getUserId)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("user_id");
@@ -251,7 +346,8 @@ static PHP_METHOD(AMQPBasicProperties, getUserId) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getAppId() */
-static PHP_METHOD(AMQPBasicProperties, getAppId) {
+static PHP_METHOD(AMQPBasicProperties, getAppId)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("app_id");
@@ -259,7 +355,8 @@ static PHP_METHOD(AMQPBasicProperties, getAppId) {
 /* }}} */
 
 /* {{{ proto AMQPBasicProperties::getClusterId() */
-static PHP_METHOD(AMQPBasicProperties, getClusterId) {
+static PHP_METHOD(AMQPBasicProperties, getClusterId)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("cluster_id");
@@ -335,11 +432,12 @@ zend_function_entry amqp_basic_properties_class_functions[] = {
         PHP_ME(AMQPBasicProperties, getAppId, arginfo_amqp_basic_properties_class_getAppId, ZEND_ACC_PUBLIC)
         PHP_ME(AMQPBasicProperties, getClusterId, arginfo_amqp_basic_properties_class_getClusterId, ZEND_ACC_PUBLIC)
 
-        {NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 
 
-PHP_MINIT_FUNCTION (amqp_basic_properties) {
+PHP_MINIT_FUNCTION(amqp_basic_properties)
+{
     zend_class_entry ce;
 
     INIT_CLASS_ENTRY(ce, "AMQPBasicProperties", amqp_basic_properties_class_functions);
@@ -350,7 +448,12 @@ PHP_MINIT_FUNCTION (amqp_basic_properties) {
 
     zend_declare_property_null(this_ce, ZEND_STRL("headers"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-    zend_declare_property_long(this_ce, ZEND_STRL("delivery_mode"), AMQP_DELIVERY_NONPERSISTENT, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_long(
+        this_ce,
+        ZEND_STRL("delivery_mode"),
+        AMQP_DELIVERY_NONPERSISTENT,
+        ZEND_ACC_PRIVATE TSRMLS_CC
+    );
     zend_declare_property_long(this_ce, ZEND_STRL("priority"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
 
     zend_declare_property_stringl(this_ce, ZEND_STRL("correlation_id"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
@@ -361,15 +464,16 @@ PHP_MINIT_FUNCTION (amqp_basic_properties) {
     zend_declare_property_long(this_ce, ZEND_STRL("timestamp"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
 
     zend_declare_property_stringl(this_ce, ZEND_STRL("type"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_stringl(this_ce, ZEND_STRL("user_id"), "", 0,  ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_stringl(this_ce, ZEND_STRL("app_id"), "", 0,  ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_stringl(this_ce, ZEND_STRL("user_id"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_stringl(this_ce, ZEND_STRL("app_id"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
     zend_declare_property_stringl(this_ce, ZEND_STRL("cluster_id"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
 
     return SUCCESS;
 }
 
 
-void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
+void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC)
+{
     int i;
     zend_bool has_value = 0;
 
@@ -422,7 +526,7 @@ void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
                 break;
             case AMQP_FIELD_KIND_UTF8:
             case AMQP_FIELD_KIND_BYTES:
-				ZVAL_STRINGL(&value, entry->value.value.bytes.bytes, entry->value.value.bytes.len);
+                ZVAL_STRINGL(&value, entry->value.value.bytes.bytes, entry->value.value.bytes.len);
                 break;
             case AMQP_FIELD_KIND_ARRAY: {
                 int j;
@@ -430,10 +534,10 @@ void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
                 for (j = 0; j < entry->value.value.array.num_entries; ++j) {
                     switch (entry->value.value.array.entries[j].kind) {
                         case AMQP_FIELD_KIND_UTF8:
-							add_next_index_stringl(
-                                    &value,
-                                    entry->value.value.array.entries[j].value.bytes.bytes,
-                                    entry->value.value.array.entries[j].value.bytes.len
+                            add_next_index_stringl(
+                                &value,
+                                entry->value.value.array.entries[j].value.bytes.bytes,
+                                entry->value.value.array.entries[j].value.bytes.len
                             );
                             break;
                         case AMQP_FIELD_KIND_TABLE: {
@@ -441,45 +545,40 @@ void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
                             ZVAL_UNDEF(&subtable);
                             array_init(&subtable);
 
-                            parse_amqp_table(
-                                    &(entry->value.value.array.entries[j].value.table),
-                                    &subtable TSRMLS_CC
-                            );
+                            parse_amqp_table(&(entry->value.value.array.entries[j].value.table), &subtable TSRMLS_CC);
                             add_next_index_zval(&value, &subtable);
-                        }
-                            break;
+                        } break;
                         default:
                             break;
                     }
                 }
-            }
-                break;
+            } break;
             case AMQP_FIELD_KIND_TABLE:
                 array_init(&value);
                 parse_amqp_table(&(entry->value.value.table), &value TSRMLS_CC);
                 break;
 
             case AMQP_FIELD_KIND_TIMESTAMP: {
-				char timestamp_str[20];
-				zval timestamp;
-				ZVAL_UNDEF(&timestamp);
+                char timestamp_str[20];
+                zval timestamp;
+                ZVAL_UNDEF(&timestamp);
 
-				int length = snprintf(timestamp_str, sizeof(timestamp_str), ZEND_ULONG_FMT, entry->value.value.u64);
-				ZVAL_STRINGL(&timestamp, (char *)timestamp_str, length);
-				object_init_ex(&value, amqp_timestamp_class_entry);
+                int length = snprintf(timestamp_str, sizeof(timestamp_str), ZEND_ULONG_FMT, entry->value.value.u64);
+                ZVAL_STRINGL(&timestamp, (char *) timestamp_str, length);
+                object_init_ex(&value, amqp_timestamp_class_entry);
 
-				zend_call_method_with_1_params(
-						PHP_AMQP_COMPAT_OBJ_P(&value),
-						amqp_timestamp_class_entry,
-						NULL,
-						"__construct",
-						NULL,
-						&timestamp
-				);
+                zend_call_method_with_1_params(
+                    PHP_AMQP_COMPAT_OBJ_P(&value),
+                    amqp_timestamp_class_entry,
+                    NULL,
+                    "__construct",
+                    NULL,
+                    &timestamp
+                );
 
-				zval_ptr_dtor(&timestamp);
-				break;
-			}
+                zval_ptr_dtor(&timestamp);
+                break;
+            }
 
             case AMQP_FIELD_KIND_VOID:
                 ZVAL_NULL(&value);
@@ -497,17 +596,17 @@ void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
                 object_init_ex(&value, amqp_decimal_class_entry);
 
                 zend_call_method_with_2_params(
-                        PHP_AMQP_COMPAT_OBJ_P(&value),
-                        amqp_decimal_class_entry,
-                        NULL,
-                        "__construct",
-                        NULL,
-                        &e,
-                        &n
+                    PHP_AMQP_COMPAT_OBJ_P(&value),
+                    amqp_decimal_class_entry,
+                    NULL,
+                    "__construct",
+                    NULL,
+                    &e,
+                    &n
                 );
 
-				zval_ptr_dtor(&e);
-				zval_ptr_dtor(&n);
+                zval_ptr_dtor(&e);
+                zval_ptr_dtor(&n);
                 break;
             }
             default:
@@ -520,9 +619,9 @@ void parse_amqp_table(amqp_table_t *table, zval *result TSRMLS_DC) {
             add_assoc_zval(result, key, &value);
             efree(key);
         } else {
-			if (!Z_ISUNDEF(value)) {
-				zval_ptr_dtor(&value);
-			}
+            if (!Z_ISUNDEF(value)) {
+                zval_ptr_dtor(&value);
+            }
         }
     }
     return;
@@ -536,17 +635,35 @@ void php_amqp_basic_properties_extract(amqp_basic_properties_t *p, zval *obj TSR
     array_init(&headers);
 
     if (p->_flags & AMQP_BASIC_CONTENT_TYPE_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("content_type"), (const char *) p->content_type.bytes, (size_t) p->content_type.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("content_type"),
+            (const char *) p->content_type.bytes,
+            (size_t) p->content_type.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("content_type"), "", 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_CONTENT_ENCODING_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("content_encoding"), (const char *) p->content_encoding.bytes, (size_t) p->content_encoding.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("content_encoding"),
+            (const char *) p->content_encoding.bytes,
+            (size_t) p->content_encoding.len TSRMLS_CC
+        );
     } else {
         /* BC */
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("content_encoding"), "", 0 TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("content_encoding"),
+            "",
+            0 TSRMLS_CC
+        );
     }
 
     if (p->_flags & AMQP_BASIC_HEADERS_FLAG) {
@@ -556,84 +673,136 @@ void php_amqp_basic_properties_extract(amqp_basic_properties_t *p, zval *obj TSR
     zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("headers"), &headers TSRMLS_CC);
 
     if (p->_flags & AMQP_BASIC_DELIVERY_MODE_FLAG) {
-        zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("delivery_mode"), (zend_long) p->delivery_mode TSRMLS_CC);
+        zend_update_property_long(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("delivery_mode"),
+            (zend_long) p->delivery_mode TSRMLS_CC
+        );
     } else {
         /* BC */
-        zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("delivery_mode"), AMQP_DELIVERY_NONPERSISTENT TSRMLS_CC);
+        zend_update_property_long(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("delivery_mode"),
+            AMQP_DELIVERY_NONPERSISTENT TSRMLS_CC
+        );
     }
 
     if (p->_flags & AMQP_BASIC_PRIORITY_FLAG) {
-        zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("priority"), (zend_long) p->priority TSRMLS_CC);
+        zend_update_property_long(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("priority"),
+            (zend_long) p->priority TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("priority"), 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_CORRELATION_ID_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("correlation_id"), (const char *) p->correlation_id.bytes, (size_t) p->correlation_id.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("correlation_id"),
+            (const char *) p->correlation_id.bytes,
+            (size_t) p->correlation_id.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("correlation_id"), "", 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_REPLY_TO_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("reply_to"), (const char *) p->reply_to.bytes, (size_t) p->reply_to.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("reply_to"),
+            (const char *) p->reply_to.bytes,
+            (size_t) p->reply_to.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("reply_to"), "", 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_EXPIRATION_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("expiration"), (const char *) p->expiration.bytes, (size_t) p->expiration.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("expiration"),
+            (const char *) p->expiration.bytes,
+            (size_t) p->expiration.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("expiration"), "", 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_MESSAGE_ID_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("message_id"), (const char *) p->message_id.bytes, (size_t) p->message_id.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("message_id"),
+            (const char *) p->message_id.bytes,
+            (size_t) p->message_id.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("message_id"), "", 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_TIMESTAMP_FLAG) {
-        zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("timestamp"), (zend_long) p->timestamp TSRMLS_CC);
+        zend_update_property_long(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("timestamp"),
+            (zend_long) p->timestamp TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("timestamp"), 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_TYPE_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("type"), (const char *) p->type.bytes, (size_t) p->type.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("type"),
+            (const char *) p->type.bytes,
+            (size_t) p->type.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("type"), "", 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_USER_ID_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("user_id"), (const char *) p->user_id.bytes, (size_t) p->user_id.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("user_id"),
+            (const char *) p->user_id.bytes,
+            (size_t) p->user_id.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("user_id"), "", 0 TSRMLS_CC);
     }
 
     if (p->_flags & AMQP_BASIC_APP_ID_FLAG) {
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("app_id"), (const char *) p->app_id.bytes, (size_t) p->app_id.len TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("app_id"),
+            (const char *) p->app_id.bytes,
+            (size_t) p->app_id.len TSRMLS_CC
+        );
     } else {
         /* BC */
         zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("app_id"), "", 0 TSRMLS_CC);
     }
 
-	zval_ptr_dtor(&headers);
+    zval_ptr_dtor(&headers);
 }
-
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_basic_properties.h
+++ b/amqp_basic_properties.h
@@ -35,13 +35,3 @@ void php_amqp_basic_properties_set_empty_headers(zval *obj TSRMLS_DC);
 
 
 PHP_MINIT_FUNCTION(amqp_basic_properties);
-
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_channel.h
+++ b/amqp_channel.h
@@ -25,12 +25,3 @@ extern zend_class_entry *amqp_channel_class_entry;
 void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool check_errors TSRMLS_DC);
 
 PHP_MINIT_FUNCTION(amqp_channel);
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -1968,7 +1968,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getConnectionName, ZEND_SEN
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setConnectionName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-    ZEND_ARG_INFO(0, connection_name)
+ZEND_ARG_INFO(0, connection_name)
 ZEND_END_ARG_INFO()
 
 

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -1968,7 +1968,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getConnectionName, ZEND_SEN
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setConnectionName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-ZEND_ARG_INFO(0, connection_name)
+    ZEND_ARG_INFO(0, connection_name)
 ZEND_END_ARG_INFO()
 
 

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -23,7 +23,7 @@
 
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -31,30 +31,30 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# if PHP_VERSION_ID >= 80000
-#  include "main/php_stdint.h"
-# else
-#  include "win32/php_stdint.h"
-# endif
-# include "win32/signal.h"
+    #if PHP_VERSION_ID >= 80000
+        #include "main/php_stdint.h"
+    #else
+        #include "win32/php_stdint.h"
+    #endif
+    #include "win32/signal.h"
 #else
-# include <signal.h>
-# include <stdint.h>
+    #include <signal.h>
+    #include <stdint.h>
 #endif
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/framing.h>
-#include <rabbitmq-c/tcp_socket.h>
+    #include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/framing.h>
+    #include <rabbitmq-c/tcp_socket.h>
 #else
-#include <amqp.h>
-#include <amqp_framing.h>
-#include <amqp_tcp_socket.h>
+    #include <amqp.h>
+    #include <amqp_framing.h>
+    #include <amqp_tcp_socket.h>
 #endif
 
 #ifdef PHP_WIN32
-# include "win32/unistd.h"
+    #include "win32/unistd.h"
 #else
-# include <unistd.h>
+    #include <unistd.h>
 #endif
 
 #include "php_amqp.h"
@@ -63,7 +63,7 @@
 #include "amqp_connection.h"
 
 #ifndef E_DEPRECATED
-#define E_DEPRECATED E_WARNING
+    #define E_DEPRECATED E_WARNING
 #endif
 
 zend_class_entry *amqp_connection_class_entry;
@@ -71,99 +71,126 @@ zend_class_entry *amqp_connection_class_entry;
 
 zend_object_handlers amqp_connection_object_handlers;
 
-#define PHP_AMQP_EXTRACT_CONNECTION_STR(name) \
-	zdata = NULL; \
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), (name), sizeof(name))) != NULL) { \
-		SEPARATE_ZVAL(zdata); \
-		convert_to_string(zdata); \
-	} \
-	if (zdata && Z_STRLEN_P(zdata) > 0) { \
-		zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), Z_STRVAL_P(zdata) TSRMLS_CC); \
-	} else { \
-		zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), INI_STR("amqp." name) TSRMLS_CC); \
-	}
+#define PHP_AMQP_EXTRACT_CONNECTION_STR(name)                                                                          \
+    zdata = NULL;                                                                                                      \
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), (name), sizeof(name))) != NULL) {                     \
+        SEPARATE_ZVAL(zdata);                                                                                          \
+        convert_to_string(zdata);                                                                                      \
+    }                                                                                                                  \
+    if (zdata && Z_STRLEN_P(zdata) > 0) {                                                                              \
+        zend_update_property_string(                                                                                   \
+            this_ce,                                                                                                   \
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),                                                                          \
+            ZEND_STRL(name),                                                                                           \
+            Z_STRVAL_P(zdata) TSRMLS_CC                                                                                \
+        );                                                                                                             \
+    } else {                                                                                                           \
+        zend_update_property_string(                                                                                   \
+            this_ce,                                                                                                   \
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),                                                                          \
+            ZEND_STRL(name),                                                                                           \
+            INI_STR("amqp." name) TSRMLS_CC                                                                            \
+        );                                                                                                             \
+    }
 
-#define PHP_AMQP_EXTRACT_CONNECTION_BOOL(name) \
-	zdata = NULL; \
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), (name), sizeof(name))) != NULL) { \
-		SEPARATE_ZVAL(zdata); \
-		convert_to_long(zdata); \
-	} \
-	if (zdata) { \
-		zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), Z_LVAL_P(zdata) TSRMLS_CC); \
-	} else { \
-		zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), INI_INT("amqp." name) TSRMLS_CC); \
-	}
+#define PHP_AMQP_EXTRACT_CONNECTION_BOOL(name)                                                                         \
+    zdata = NULL;                                                                                                      \
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), (name), sizeof(name))) != NULL) {                     \
+        SEPARATE_ZVAL(zdata);                                                                                          \
+        convert_to_long(zdata);                                                                                        \
+    }                                                                                                                  \
+    if (zdata) {                                                                                                       \
+        zend_update_property_bool(                                                                                     \
+            this_ce,                                                                                                   \
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),                                                                          \
+            ZEND_STRL(name),                                                                                           \
+            Z_LVAL_P(zdata) TSRMLS_CC                                                                                  \
+        );                                                                                                             \
+    } else {                                                                                                           \
+        zend_update_property_bool(                                                                                     \
+            this_ce,                                                                                                   \
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),                                                                          \
+            ZEND_STRL(name),                                                                                           \
+            INI_INT("amqp." name) TSRMLS_CC                                                                            \
+        );                                                                                                             \
+    }
 
 static int php_amqp_connection_resource_deleter(zval *el, amqp_connection_resource *connection_resource TSRMLS_DC)
 {
-	if (Z_RES_P(el)->ptr == connection_resource) {
-		return ZEND_HASH_APPLY_REMOVE | ZEND_HASH_APPLY_STOP;
-	}
+    if (Z_RES_P(el)->ptr == connection_resource) {
+        return ZEND_HASH_APPLY_REMOVE | ZEND_HASH_APPLY_STOP;
+    }
 
-	return ZEND_HASH_APPLY_KEEP;
+    return ZEND_HASH_APPLY_KEEP;
 }
 
-static size_t php_amqp_get_connection_hash(amqp_connection_params *params, char **hash) {
-	return spprintf(hash,
-					0,
-					"amqp_conn_res_h:%s_p:%d_v:%s_l:%s_p:%s_f:%d_c:%d_h:%d_cacert:%s_cert:%s_key:%s_sasl_method:%d_connection_name:%s",
-					params->host,
-					params->port,
-					params->vhost,
-					params->login,
-					params->password,
-					params->frame_max,
-					params->channel_max,
-					params->heartbeat,
-					params->cacert,
-					params->cert,
-					params->key,
-					params->sasl_method,
-					params->connection_name
-	);
+static size_t php_amqp_get_connection_hash(amqp_connection_params *params, char **hash)
+{
+    return spprintf(
+        hash,
+        0,
+        "amqp_conn_res_h:%s_p:%d_v:%s_l:%s_p:%s_f:%d_c:%d_h:%d_cacert:%s_cert:%s_key:%s_sasl_method:%d_connection_name:"
+        "%s",
+        params->host,
+        params->port,
+        params->vhost,
+        params->login,
+        params->password,
+        params->frame_max,
+        params->channel_max,
+        params->heartbeat,
+        params->cacert,
+        params->cert,
+        params->key,
+        params->sasl_method,
+        params->connection_name
+    );
 }
 
 static void php_amqp_cleanup_connection_resource(amqp_connection_resource *connection_resource TSRMLS_DC)
 {
-	if (!connection_resource) {
-		return;
-	}
+    if (!connection_resource) {
+        return;
+    }
 
-	zend_resource *resource = connection_resource->resource;
+    zend_resource *resource = connection_resource->resource;
 
-	connection_resource->parent->connection_resource = NULL;
-	connection_resource->parent = NULL;
+    connection_resource->parent->connection_resource = NULL;
+    connection_resource->parent = NULL;
 
-	if (connection_resource->is_dirty) {
-		if (connection_resource->is_persistent) {
-			zend_hash_apply_with_argument(&EG(persistent_list), (apply_func_arg_t)php_amqp_connection_resource_deleter, (void*)connection_resource TSRMLS_CC);
-		}
+    if (connection_resource->is_dirty) {
+        if (connection_resource->is_persistent) {
+            zend_hash_apply_with_argument(
+                &EG(persistent_list),
+                (apply_func_arg_t) php_amqp_connection_resource_deleter,
+                (void *) connection_resource TSRMLS_CC
+            );
+        }
 
-		zend_list_delete(resource);
-	} else {
-		if (connection_resource->is_persistent) {
-			connection_resource->resource = NULL;
-		}
+        zend_list_delete(resource);
+    } else {
+        if (connection_resource->is_persistent) {
+            connection_resource->resource = NULL;
+        }
 
-		if (connection_resource->resource != NULL) {
-			zend_list_delete(resource);
-		}
-	}
+        if (connection_resource->resource != NULL) {
+            zend_list_delete(resource);
+        }
+    }
 }
 
 static void php_amqp_disconnect(amqp_connection_resource *resource TSRMLS_DC)
 {
-	php_amqp_prepare_for_disconnect(resource TSRMLS_CC);
-	php_amqp_cleanup_connection_resource(resource TSRMLS_CC);
+    php_amqp_prepare_for_disconnect(resource TSRMLS_CC);
+    php_amqp_cleanup_connection_resource(resource TSRMLS_CC);
 }
 
 
 void php_amqp_disconnect_force(amqp_connection_resource *resource TSRMLS_DC)
 {
-	php_amqp_prepare_for_disconnect(resource TSRMLS_CC);
-	resource->is_dirty = '\1';
-	php_amqp_cleanup_connection_resource(resource TSRMLS_CC);
+    php_amqp_prepare_for_disconnect(resource TSRMLS_CC);
+    resource->is_dirty = '\1';
+    php_amqp_cleanup_connection_resource(resource TSRMLS_CC);
 }
 
 /**
@@ -173,142 +200,163 @@ void php_amqp_disconnect_force(amqp_connection_resource *resource TSRMLS_DC)
  */
 int php_amqp_connect(amqp_connection_object *connection, zend_bool persistent, INTERNAL_FUNCTION_PARAMETERS)
 {
-	zval rv;
+    zval rv;
 
-	char *key = NULL;
-	size_t key_len = 0;
+    char *key = NULL;
+    size_t key_len = 0;
 
-	if (connection->connection_resource) {
-		/* Clean up old memory allocations which are now invalid (new connection) */
-		php_amqp_cleanup_connection_resource(connection->connection_resource TSRMLS_CC);
-	}
+    if (connection->connection_resource) {
+        /* Clean up old memory allocations which are now invalid (new connection) */
+        php_amqp_cleanup_connection_resource(connection->connection_resource TSRMLS_CC);
+    }
 
-	assert(connection->connection_resource == NULL);
+    assert(connection->connection_resource == NULL);
 
-	amqp_connection_params connection_params;
+    amqp_connection_params connection_params;
 
-	connection_params.host = PHP_AMQP_READ_THIS_PROP_STR("host");
-	connection_params.port = (int)PHP_AMQP_READ_THIS_PROP_LONG("port");
-	connection_params.vhost = PHP_AMQP_READ_THIS_PROP_STR("vhost");
-	connection_params.login = PHP_AMQP_READ_THIS_PROP_STR("login");
-	connection_params.password = PHP_AMQP_READ_THIS_PROP_STR("password");
-	connection_params.frame_max = (int) PHP_AMQP_READ_THIS_PROP_LONG("frame_max");
-	connection_params.channel_max = (int) PHP_AMQP_READ_THIS_PROP_LONG("channel_max");
-	connection_params.heartbeat = (int) PHP_AMQP_READ_THIS_PROP_LONG("heartbeat");
-	connection_params.read_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("read_timeout");
-	connection_params.write_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("write_timeout");
-	connection_params.connect_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("connect_timeout");
-	connection_params.rpc_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("rpc_timeout");
-	connection_params.cacert = PHP_AMQP_READ_THIS_PROP_STRLEN("cacert") ? PHP_AMQP_READ_THIS_PROP_STR("cacert") : NULL;
-	connection_params.cert = PHP_AMQP_READ_THIS_PROP_STRLEN("cert") ? PHP_AMQP_READ_THIS_PROP_STR("cert") : NULL;
-	connection_params.key = PHP_AMQP_READ_THIS_PROP_STRLEN("key") ? PHP_AMQP_READ_THIS_PROP_STR("key") : NULL;
-	connection_params.verify = (int) PHP_AMQP_READ_THIS_PROP_BOOL("verify");
-	connection_params.sasl_method = (int) PHP_AMQP_READ_THIS_PROP_LONG("sasl_method");
-	connection_params.connection_name = PHP_AMQP_READ_THIS_PROP_STRLEN("connection_name") ? PHP_AMQP_READ_THIS_PROP_STR("connection_name") : NULL;
+    connection_params.host = PHP_AMQP_READ_THIS_PROP_STR("host");
+    connection_params.port = (int) PHP_AMQP_READ_THIS_PROP_LONG("port");
+    connection_params.vhost = PHP_AMQP_READ_THIS_PROP_STR("vhost");
+    connection_params.login = PHP_AMQP_READ_THIS_PROP_STR("login");
+    connection_params.password = PHP_AMQP_READ_THIS_PROP_STR("password");
+    connection_params.frame_max = (int) PHP_AMQP_READ_THIS_PROP_LONG("frame_max");
+    connection_params.channel_max = (int) PHP_AMQP_READ_THIS_PROP_LONG("channel_max");
+    connection_params.heartbeat = (int) PHP_AMQP_READ_THIS_PROP_LONG("heartbeat");
+    connection_params.read_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("read_timeout");
+    connection_params.write_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("write_timeout");
+    connection_params.connect_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("connect_timeout");
+    connection_params.rpc_timeout = PHP_AMQP_READ_THIS_PROP_DOUBLE("rpc_timeout");
+    connection_params.cacert = PHP_AMQP_READ_THIS_PROP_STRLEN("cacert") ? PHP_AMQP_READ_THIS_PROP_STR("cacert") : NULL;
+    connection_params.cert = PHP_AMQP_READ_THIS_PROP_STRLEN("cert") ? PHP_AMQP_READ_THIS_PROP_STR("cert") : NULL;
+    connection_params.key = PHP_AMQP_READ_THIS_PROP_STRLEN("key") ? PHP_AMQP_READ_THIS_PROP_STR("key") : NULL;
+    connection_params.verify = (int) PHP_AMQP_READ_THIS_PROP_BOOL("verify");
+    connection_params.sasl_method = (int) PHP_AMQP_READ_THIS_PROP_LONG("sasl_method");
+    connection_params.connection_name =
+        PHP_AMQP_READ_THIS_PROP_STRLEN("connection_name") ? PHP_AMQP_READ_THIS_PROP_STR("connection_name") : NULL;
 
-	if (persistent) {
-		zend_resource *le = NULL;
+    if (persistent) {
+        zend_resource *le = NULL;
 
-		/* Look for an established resource */
-		key_len = php_amqp_get_connection_hash(&connection_params, &key);
+        /* Look for an established resource */
+        key_len = php_amqp_get_connection_hash(&connection_params, &key);
 
-		if ((le = zend_hash_str_find_ptr(&EG(persistent_list), key, key_len)) != NULL) {
-			efree(key);
+        if ((le = zend_hash_str_find_ptr(&EG(persistent_list), key, key_len)) != NULL) {
+            efree(key);
 
-			if (le->type != le_amqp_connection_resource_persistent) {
-				/* hash conflict, given name associate with non-amqp persistent connection resource */
-				return 0;
-			}
+            if (le->type != le_amqp_connection_resource_persistent) {
+                /* hash conflict, given name associate with non-amqp persistent connection resource */
+                return 0;
+            }
 
-			/* An entry for this connection resource already exists */
-			/* Stash the connection resource in the connection */
-			connection->connection_resource = le->ptr;
+            /* An entry for this connection resource already exists */
+            /* Stash the connection resource in the connection */
+            connection->connection_resource = le->ptr;
 
-			if (connection->connection_resource->resource != NULL) {
-				/*  resource in use! */
-				connection->connection_resource = NULL;
+            if (connection->connection_resource->resource != NULL) {
+                /*  resource in use! */
+                connection->connection_resource = NULL;
 
-				zend_throw_exception(amqp_connection_exception_class_entry, "There are already established persistent connection to the same resource.", 0 TSRMLS_CC);
-				return 0;
-			}
+                zend_throw_exception(
+                    amqp_connection_exception_class_entry,
+                    "There are already established persistent connection to the same resource.",
+                    0 TSRMLS_CC
+                );
+                return 0;
+            }
 
-			connection->connection_resource->resource = zend_register_resource(connection->connection_resource, persistent ? le_amqp_connection_resource_persistent : le_amqp_connection_resource);
-			connection->connection_resource->parent = connection;
+            connection->connection_resource->resource = zend_register_resource(
+                connection->connection_resource,
+                persistent ? le_amqp_connection_resource_persistent : le_amqp_connection_resource
+            );
+            connection->connection_resource->parent = connection;
 
-			/* Set desired timeouts */
-			if (php_amqp_set_resource_read_timeout(connection->connection_resource, PHP_AMQP_READ_THIS_PROP_DOUBLE("read_timeout") TSRMLS_CC) == 0
-				|| php_amqp_set_resource_write_timeout(connection->connection_resource, PHP_AMQP_READ_THIS_PROP_DOUBLE("write_timeout") TSRMLS_CC) == 0
-				|| php_amqp_set_resource_rpc_timeout(connection->connection_resource, PHP_AMQP_READ_THIS_PROP_DOUBLE("rpc_timeout") TSRMLS_CC) == 0) {
+            /* Set desired timeouts */
+            if (php_amqp_set_resource_read_timeout(
+                    connection->connection_resource,
+                    PHP_AMQP_READ_THIS_PROP_DOUBLE("read_timeout") TSRMLS_CC
+                ) == 0 ||
+                php_amqp_set_resource_write_timeout(
+                    connection->connection_resource,
+                    PHP_AMQP_READ_THIS_PROP_DOUBLE("write_timeout") TSRMLS_CC
+                ) == 0 ||
+                php_amqp_set_resource_rpc_timeout(
+                    connection->connection_resource,
+                    PHP_AMQP_READ_THIS_PROP_DOUBLE("rpc_timeout") TSRMLS_CC
+                ) == 0) {
 
-				php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-				return 0;
-			}
+                php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+                return 0;
+            }
 
-			/* Set connection status to connected */
-			connection->connection_resource->is_connected = '\1';
-			connection->connection_resource->is_persistent = persistent;
+            /* Set connection status to connected */
+            connection->connection_resource->is_connected = '\1';
+            connection->connection_resource->is_persistent = persistent;
 
-			return 1;
-		}
+            return 1;
+        }
 
-		efree(key);
-	}
+        efree(key);
+    }
 
-	connection->connection_resource = connection_resource_constructor(&connection_params, persistent TSRMLS_CC);
+    connection->connection_resource = connection_resource_constructor(&connection_params, persistent TSRMLS_CC);
 
-	if (connection->connection_resource == NULL) {
-		return 0;
-	}
+    if (connection->connection_resource == NULL) {
+        return 0;
+    }
 
-	connection->connection_resource->resource = zend_register_resource(connection->connection_resource, persistent ? le_amqp_connection_resource_persistent : le_amqp_connection_resource);
-	connection->connection_resource->parent = connection;
+    connection->connection_resource->resource = zend_register_resource(
+        connection->connection_resource,
+        persistent ? le_amqp_connection_resource_persistent : le_amqp_connection_resource
+    );
+    connection->connection_resource->parent = connection;
 
-	/* Set connection status to connected */
-	connection->connection_resource->is_connected = '\1';
+    /* Set connection status to connected */
+    connection->connection_resource->is_connected = '\1';
 
-	if (persistent) {
-		connection->connection_resource->is_persistent = persistent;
+    if (persistent) {
+        connection->connection_resource->is_persistent = persistent;
 
-		key_len = php_amqp_get_connection_hash(&connection_params, &key);
+        key_len = php_amqp_get_connection_hash(&connection_params, &key);
 
-		zend_resource new_le;
+        zend_resource new_le;
 
-		/* Store a reference in the persistence list */
-		new_le.ptr  = connection->connection_resource;
-		new_le.type = persistent ? le_amqp_connection_resource_persistent : le_amqp_connection_resource;
+        /* Store a reference in the persistence list */
+        new_le.ptr = connection->connection_resource;
+        new_le.type = persistent ? le_amqp_connection_resource_persistent : le_amqp_connection_resource;
 
-		if (!zend_hash_str_update_mem(&EG(persistent_list), key, key_len, &new_le, sizeof(zend_resource))) {
-			efree(key);
-			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-			return 0;
-		}
-		efree(key);
-	}
+        if (!zend_hash_str_update_mem(&EG(persistent_list), key, key_len, &new_le, sizeof(zend_resource))) {
+            efree(key);
+            php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+            return 0;
+        }
+        efree(key);
+    }
 
-	return 1;
+    return 1;
 }
 
 void amqp_connection_free(zend_object *object TSRMLS_DC)
 {
-	amqp_connection_object *connection = PHP_AMQP_FETCH_CONNECTION(object);
+    amqp_connection_object *connection = PHP_AMQP_FETCH_CONNECTION(object);
 
-	if (connection->connection_resource) {
-		php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
-	}
+    if (connection->connection_resource) {
+        php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
+    }
 
-	zend_object_std_dtor(&connection->zo TSRMLS_CC);
+    zend_object_std_dtor(&connection->zo TSRMLS_CC);
 }
 
 zend_object *amqp_connection_ctor(zend_class_entry *ce TSRMLS_DC)
 {
-	amqp_connection_object* connection = (amqp_connection_object*) ecalloc(1, sizeof(amqp_connection_object) + zend_object_properties_size(ce));
+    amqp_connection_object *connection =
+        (amqp_connection_object *) ecalloc(1, sizeof(amqp_connection_object) + zend_object_properties_size(ce));
 
-	zend_object_std_init(&connection->zo, ce TSRMLS_CC);
-	AMQP_OBJECT_PROPERTIES_INIT(connection->zo, ce);
+    zend_object_std_init(&connection->zo, ce TSRMLS_CC);
+    AMQP_OBJECT_PROPERTIES_INIT(connection->zo, ce);
 
-	connection->zo.handlers = &amqp_connection_object_handlers;
+    connection->zo.handlers = &amqp_connection_object_handlers;
 
-	return &connection->zo;
+    return &connection->zo;
 }
 
 
@@ -317,264 +365,495 @@ zend_object *amqp_connection_ctor(zend_class_entry *ce TSRMLS_DC)
  */
 static PHP_METHOD(amqp_connection_class, __construct)
 {
-	zval* ini_arr = NULL;
+    zval *ini_arr = NULL;
 
-	zval *zdata = NULL;
+    zval *zdata = NULL;
 
-	/* Parse out the method parameters */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|a/", &ini_arr) == FAILURE) {
-		return;
-	}
+    /* Parse out the method parameters */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|a/", &ini_arr) == FAILURE) {
+        return;
+    }
 
-	/* Pull the login out of the $params array */
-	zdata = NULL;
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "login", sizeof("login") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_string(zdata);
-	}
-	/* Validate the given login */
-	if (zdata && Z_STRLEN_P(zdata) > 0) {
+    /* Pull the login out of the $params array */
+    zdata = NULL;
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "login", sizeof("login") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_string(zdata);
+    }
+    /* Validate the given login */
+    if (zdata && Z_STRLEN_P(zdata) > 0) {
         if (!php_amqp_is_valid_credential(Z_STR_P(zdata))) {
-            zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'login' exceeds %d character limit.", PHP_AMQP_MAX_CREDENTIALS_LENGTH);
+            zend_throw_exception_ex(
+                amqp_connection_exception_class_entry,
+                0 TSRMLS_CC,
+                "Parameter 'login' exceeds %d character limit.",
+                PHP_AMQP_MAX_CREDENTIALS_LENGTH
+            );
             return;
         }
 
         zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("login"), zdata TSRMLS_CC);
-	} else {
-		zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("login"), INI_STR("amqp.login") TSRMLS_CC);
-	}
-
-	/* Pull the password out of the $params array */
-	zdata = NULL;
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "password", sizeof("password") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_string(zdata);
-	}
-	/* Validate the given password */
-	if (zdata && Z_STRLEN_P(zdata) > 0) {
-		if (!php_amqp_is_valid_credential(Z_STR_P(zdata))) {
-            zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'password' exceeds %d character limit.", PHP_AMQP_MAX_CREDENTIALS_LENGTH);
-            return;
-        }
-
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("password"), Z_STRVAL_P(zdata), Z_STRLEN_P(zdata) TSRMLS_CC);
     } else {
-        zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("password"), INI_STR("amqp.password") TSRMLS_CC);
-	}
-
-	/* Pull the host out of the $params array */
-	zdata = NULL;
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "host", sizeof("host") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_string(zdata);
-	}
-	/* Validate the given host */
-	if (zdata && Z_STRLEN_P(zdata) > 0) {
-		if (!php_amqp_is_valid_identifier(Z_STR_P(zdata))) {
-            zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'host' exceeds %d character limit.", PHP_AMQP_MAX_IDENTIFIER_LENGTH);
-            return;
-        }
-
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("host"), Z_STRVAL_P(zdata), Z_STRLEN_P(zdata) TSRMLS_CC);
-    } else {
-        zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("host"), INI_STR("amqp.host") TSRMLS_CC);
-	}
-
-	/* Pull the vhost out of the $params array */
-	zdata = NULL;
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "vhost", sizeof("vhost") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_string(zdata);
-	}
-	/* Validate the given vhost */
-	if (zdata && Z_STRLEN_P(zdata) > 0) {
-        if (!php_amqp_is_valid_identifier(Z_STR_P(zdata))) {
-            zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'vhost' exceeds %d character limit.", PHP_AMQP_MAX_IDENTIFIER_LENGTH);
-            return;
-        }
-
-        zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("vhost"), Z_STRVAL_P(zdata), Z_STRLEN_P(zdata) TSRMLS_CC);
-    } else {
-        zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("vhost"), INI_STR("amqp.vhost") TSRMLS_CC);
-
-	}
-
-	zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("port"), INI_INT("amqp.port") TSRMLS_CC);
-
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "port", sizeof("port") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_long(zdata);
-
-        if (!php_amqp_is_valid_port(Z_LVAL_P(zdata))) {
-            zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'port' must be a valid port number  between %d and %d.", PHP_AMQP_MIN_PORT, PHP_AMQP_MAX_PORT);
-            return;
-        }
-
-        zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("port"), Z_LVAL_P(zdata) TSRMLS_CC);
+        zend_update_property_string(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("login"),
+            INI_STR("amqp.login") TSRMLS_CC
+        );
     }
 
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), INI_FLT("amqp.read_timeout") TSRMLS_CC);
-
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "read_timeout", sizeof("read_timeout") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_double(zdata);
-
-        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'read_timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
+    /* Pull the password out of the $params array */
+    zdata = NULL;
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "password", sizeof("password") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_string(zdata);
+    }
+    /* Validate the given password */
+    if (zdata && Z_STRLEN_P(zdata) > 0) {
+        if (!php_amqp_is_valid_credential(Z_STR_P(zdata))) {
+            zend_throw_exception_ex(
+                amqp_connection_exception_class_entry,
+                0 TSRMLS_CC,
+                "Parameter 'password' exceeds %d character limit.",
+                PHP_AMQP_MAX_CREDENTIALS_LENGTH
+            );
             return;
-		}
-
-        zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), Z_DVAL_P(zdata) TSRMLS_CC);
-
-		if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "timeout", sizeof("timeout") - 1)) != NULL) {
-			/* 'read_timeout' takes precedence on 'timeout' but users have to know this */
-			php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Parameter 'timeout' is deprecated, 'read_timeout' used instead");
-		}
-
-	} else if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "timeout", sizeof("timeout") - 1)) != NULL) {
-
-		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "Parameter 'timeout' is deprecated; use 'read_timeout' instead");
-
-		SEPARATE_ZVAL(zdata);
-		convert_to_double(zdata);
-
-        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-            return;
-		}
-
-        zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), Z_DVAL_P(zdata) TSRMLS_CC);
-	} else {
-
-		assert(DEFAULT_TIMEOUT != NULL);
-		if (strcmp(DEFAULT_TIMEOUT, INI_STR("amqp.timeout")) != 0) {
-			php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "INI setting 'amqp.timeout' is deprecated; use 'amqp.read_timeout' instead");
-
-			if (strcmp(DEFAULT_READ_TIMEOUT, INI_STR("amqp.read_timeout")) == 0) {
-				zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), INI_FLT("amqp.timeout") TSRMLS_CC);
-			} else {
-				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "INI setting 'amqp.read_timeout' will be used instead of 'amqp.timeout'");
-				zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), INI_FLT("amqp.read_timeout") TSRMLS_CC);
-			}
-		} else {
-			zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), INI_FLT("amqp.read_timeout") TSRMLS_CC);
-		}
-	}
-
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("write_timeout"), INI_FLT("amqp.write_timeout") TSRMLS_CC);
-
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "write_timeout", sizeof("write_timeout") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_double(zdata);
-
-		if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'write_timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-            return;
-		}
-
-        zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("write_timeout"), Z_DVAL_P(zdata) TSRMLS_CC);
-	}
-
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("rpc_timeout"), INI_FLT("amqp.rpc_timeout") TSRMLS_CC);
-
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "rpc_timeout", sizeof("rpc_timeout") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_double(zdata);
-
-		if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'rpc_timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-            return;
-		}
-
-        zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("rpc_timeout"), Z_DVAL_P(zdata) TSRMLS_CC);
-	}
-
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connect_timeout"), INI_FLT("amqp.connect_timeout") TSRMLS_CC);
-
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "connect_timeout", sizeof("connect_timeout") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_double(zdata);
-
-        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'connect_timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-            return;
-		}
-
-        zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connect_timeout"), Z_DVAL_P(zdata) TSRMLS_CC);
-	}
-
-	zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("channel_max"), INI_INT("amqp.channel_max") TSRMLS_CC);
-
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "channel_max", sizeof("channel_max") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_long(zdata);
-
-		if (!php_amqp_is_valid_channel_max(Z_LVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'channel_max' is out of range.", 0 TSRMLS_CC);
-            return;
-		}
-
-        if(Z_LVAL_P(zdata) == 0) {
-            zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("channel_max"), PHP_AMQP_DEFAULT_CHANNEL_MAX TSRMLS_CC);
-        } else {
-            zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("channel_max"), Z_LVAL_P(zdata) TSRMLS_CC);
         }
-	}
 
-	zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("frame_max"), INI_INT("amqp.frame_max") TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("password"),
+            Z_STRVAL_P(zdata),
+            Z_STRLEN_P(zdata) TSRMLS_CC
+        );
+    } else {
+        zend_update_property_string(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("password"),
+            INI_STR("amqp.password") TSRMLS_CC
+        );
+    }
 
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "frame_max", sizeof("frame_max") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_long(zdata);
-		if (!php_amqp_is_valid_frame_size_max(Z_LVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'frame_max' is out of range.", 0 TSRMLS_CC);
+    /* Pull the host out of the $params array */
+    zdata = NULL;
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "host", sizeof("host") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_string(zdata);
+    }
+    /* Validate the given host */
+    if (zdata && Z_STRLEN_P(zdata) > 0) {
+        if (!php_amqp_is_valid_identifier(Z_STR_P(zdata))) {
+            zend_throw_exception_ex(
+                amqp_connection_exception_class_entry,
+                0 TSRMLS_CC,
+                "Parameter 'host' exceeds %d character limit.",
+                PHP_AMQP_MAX_IDENTIFIER_LENGTH
+            );
             return;
-		}
-
-        if(Z_LVAL_P(zdata) == 0) {
-            zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("frame_max"), PHP_AMQP_DEFAULT_FRAME_MAX TSRMLS_CC);
-        } else {
-            zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("frame_max"), Z_LVAL_P(zdata) TSRMLS_CC);
         }
-	}
 
-	zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("heartbeat"), INI_INT("amqp.heartbeat") TSRMLS_CC);
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("host"),
+            Z_STRVAL_P(zdata),
+            Z_STRLEN_P(zdata) TSRMLS_CC
+        );
+    } else {
+        zend_update_property_string(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("host"),
+            INI_STR("amqp.host") TSRMLS_CC
+        );
+    }
 
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "heartbeat", sizeof("heartbeat") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_long(zdata);
-		if (!php_amqp_is_valid_heartbeat(Z_LVAL_P(zdata))) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'heartbeat' is out of range.", 0 TSRMLS_CC);
+    /* Pull the vhost out of the $params array */
+    zdata = NULL;
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "vhost", sizeof("vhost") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_string(zdata);
+    }
+    /* Validate the given vhost */
+    if (zdata && Z_STRLEN_P(zdata) > 0) {
+        if (!php_amqp_is_valid_identifier(Z_STR_P(zdata))) {
+            zend_throw_exception_ex(
+                amqp_connection_exception_class_entry,
+                0 TSRMLS_CC,
+                "Parameter 'vhost' exceeds %d character limit.",
+                PHP_AMQP_MAX_IDENTIFIER_LENGTH
+            );
             return;
-		}
+        }
 
-        zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("heartbeat"), Z_LVAL_P(zdata) TSRMLS_CC);
-	}
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("vhost"),
+            Z_STRVAL_P(zdata),
+            Z_STRLEN_P(zdata) TSRMLS_CC
+        );
+    } else {
+        zend_update_property_string(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("vhost"),
+            INI_STR("amqp.vhost") TSRMLS_CC
+        );
+    }
 
-	zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("sasl_method"), INI_INT("amqp.sasl_method") TSRMLS_CC);
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("port"),
+        INI_INT("amqp.port") TSRMLS_CC
+    );
 
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "sasl_method", sizeof("sasl_method") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_long(zdata);
-		zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("sasl_method"), Z_LVAL_P(zdata) TSRMLS_CC);
-	}
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "port", sizeof("port") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_long(zdata);
+
+        if (!php_amqp_is_valid_port(Z_LVAL_P(zdata))) {
+            zend_throw_exception_ex(
+                amqp_connection_exception_class_entry,
+                0 TSRMLS_CC,
+                "Parameter 'port' must be a valid port number  between %d and %d.",
+                PHP_AMQP_MIN_PORT,
+                PHP_AMQP_MAX_PORT
+            );
+            return;
+        }
+
+        zend_update_property_long(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("port"),
+            Z_LVAL_P(zdata) TSRMLS_CC
+        );
+    }
+
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("read_timeout"),
+        INI_FLT("amqp.read_timeout") TSRMLS_CC
+    );
+
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "read_timeout", sizeof("read_timeout") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_double(zdata);
+
+        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'read_timeout' must be greater than or equal to zero.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        zend_update_property_double(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("read_timeout"),
+            Z_DVAL_P(zdata) TSRMLS_CC
+        );
+
+        if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "timeout", sizeof("timeout") - 1)) != NULL) {
+            /* 'read_timeout' takes precedence on 'timeout' but users have to know this */
+            php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Parameter 'timeout' is deprecated, 'read_timeout' used instead");
+        }
+
+    } else if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "timeout", sizeof("timeout") - 1)) != NULL) {
+
+        php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "Parameter 'timeout' is deprecated; use 'read_timeout' instead");
+
+        SEPARATE_ZVAL(zdata);
+        convert_to_double(zdata);
+
+        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'timeout' must be greater than or equal to zero.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        zend_update_property_double(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("read_timeout"),
+            Z_DVAL_P(zdata) TSRMLS_CC
+        );
+    } else {
+
+        assert(DEFAULT_TIMEOUT != NULL);
+        if (strcmp(DEFAULT_TIMEOUT, INI_STR("amqp.timeout")) != 0) {
+            php_error_docref(
+                NULL TSRMLS_CC,
+                E_DEPRECATED,
+                "INI setting 'amqp.timeout' is deprecated; use 'amqp.read_timeout' instead"
+            );
+
+            if (strcmp(DEFAULT_READ_TIMEOUT, INI_STR("amqp.read_timeout")) == 0) {
+                zend_update_property_double(
+                    this_ce,
+                    PHP_AMQP_COMPAT_OBJ_P(getThis()),
+                    ZEND_STRL("read_timeout"),
+                    INI_FLT("amqp.timeout") TSRMLS_CC
+                );
+            } else {
+                php_error_docref(
+                    NULL TSRMLS_CC,
+                    E_NOTICE,
+                    "INI setting 'amqp.read_timeout' will be used instead of 'amqp.timeout'"
+                );
+                zend_update_property_double(
+                    this_ce,
+                    PHP_AMQP_COMPAT_OBJ_P(getThis()),
+                    ZEND_STRL("read_timeout"),
+                    INI_FLT("amqp.read_timeout") TSRMLS_CC
+                );
+            }
+        } else {
+            zend_update_property_double(
+                this_ce,
+                PHP_AMQP_COMPAT_OBJ_P(getThis()),
+                ZEND_STRL("read_timeout"),
+                INI_FLT("amqp.read_timeout") TSRMLS_CC
+            );
+        }
+    }
+
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("write_timeout"),
+        INI_FLT("amqp.write_timeout") TSRMLS_CC
+    );
+
+    if (ini_arr &&
+        (zdata = zend_hash_str_find(HASH_OF(ini_arr), "write_timeout", sizeof("write_timeout") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_double(zdata);
+
+        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'write_timeout' must be greater than or equal to zero.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        zend_update_property_double(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("write_timeout"),
+            Z_DVAL_P(zdata) TSRMLS_CC
+        );
+    }
+
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("rpc_timeout"),
+        INI_FLT("amqp.rpc_timeout") TSRMLS_CC
+    );
+
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "rpc_timeout", sizeof("rpc_timeout") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_double(zdata);
+
+        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'rpc_timeout' must be greater than or equal to zero.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        zend_update_property_double(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("rpc_timeout"),
+            Z_DVAL_P(zdata) TSRMLS_CC
+        );
+    }
+
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("connect_timeout"),
+        INI_FLT("amqp.connect_timeout") TSRMLS_CC
+    );
+
+    if (ini_arr &&
+        (zdata = zend_hash_str_find(HASH_OF(ini_arr), "connect_timeout", sizeof("connect_timeout") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_double(zdata);
+
+        if (!php_amqp_is_valid_timeout(Z_DVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'connect_timeout' must be greater than or equal to zero.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        zend_update_property_double(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("connect_timeout"),
+            Z_DVAL_P(zdata) TSRMLS_CC
+        );
+    }
+
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("channel_max"),
+        INI_INT("amqp.channel_max") TSRMLS_CC
+    );
+
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "channel_max", sizeof("channel_max") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_long(zdata);
+
+        if (!php_amqp_is_valid_channel_max(Z_LVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'channel_max' is out of range.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        if (Z_LVAL_P(zdata) == 0) {
+            zend_update_property_long(
+                this_ce,
+                PHP_AMQP_COMPAT_OBJ_P(getThis()),
+                ZEND_STRL("channel_max"),
+                PHP_AMQP_DEFAULT_CHANNEL_MAX TSRMLS_CC
+            );
+        } else {
+            zend_update_property_long(
+                this_ce,
+                PHP_AMQP_COMPAT_OBJ_P(getThis()),
+                ZEND_STRL("channel_max"),
+                Z_LVAL_P(zdata) TSRMLS_CC
+            );
+        }
+    }
+
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("frame_max"),
+        INI_INT("amqp.frame_max") TSRMLS_CC
+    );
+
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "frame_max", sizeof("frame_max") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_long(zdata);
+        if (!php_amqp_is_valid_frame_size_max(Z_LVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'frame_max' is out of range.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        if (Z_LVAL_P(zdata) == 0) {
+            zend_update_property_long(
+                this_ce,
+                PHP_AMQP_COMPAT_OBJ_P(getThis()),
+                ZEND_STRL("frame_max"),
+                PHP_AMQP_DEFAULT_FRAME_MAX TSRMLS_CC
+            );
+        } else {
+            zend_update_property_long(
+                this_ce,
+                PHP_AMQP_COMPAT_OBJ_P(getThis()),
+                ZEND_STRL("frame_max"),
+                Z_LVAL_P(zdata) TSRMLS_CC
+            );
+        }
+    }
+
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("heartbeat"),
+        INI_INT("amqp.heartbeat") TSRMLS_CC
+    );
+
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "heartbeat", sizeof("heartbeat") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_long(zdata);
+        if (!php_amqp_is_valid_heartbeat(Z_LVAL_P(zdata))) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Parameter 'heartbeat' is out of range.",
+                0 TSRMLS_CC
+            );
+            return;
+        }
+
+        zend_update_property_long(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("heartbeat"),
+            Z_LVAL_P(zdata) TSRMLS_CC
+        );
+    }
+
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("sasl_method"),
+        INI_INT("amqp.sasl_method") TSRMLS_CC
+    );
+
+    if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "sasl_method", sizeof("sasl_method") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_long(zdata);
+        zend_update_property_long(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("sasl_method"),
+            Z_LVAL_P(zdata) TSRMLS_CC
+        );
+    }
 
 
-	PHP_AMQP_EXTRACT_CONNECTION_STR("cacert");
-	PHP_AMQP_EXTRACT_CONNECTION_STR("key");
-	PHP_AMQP_EXTRACT_CONNECTION_STR("cert");
+    PHP_AMQP_EXTRACT_CONNECTION_STR("cacert");
+    PHP_AMQP_EXTRACT_CONNECTION_STR("key");
+    PHP_AMQP_EXTRACT_CONNECTION_STR("cert");
 
-	PHP_AMQP_EXTRACT_CONNECTION_BOOL("verify");
+    PHP_AMQP_EXTRACT_CONNECTION_BOOL("verify");
 
-	/* Pull the connection_name out of the $params array */
-	zdata = NULL;
-	if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), "connection_name", sizeof("connection_name") - 1)) != NULL) {
-		SEPARATE_ZVAL(zdata);
-		convert_to_string(zdata);
-	}
-	if (zdata && Z_STRLEN_P(zdata) > 0) {
-		zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connection_name"), Z_STRVAL_P(zdata) TSRMLS_CC);
-	}
+    /* Pull the connection_name out of the $params array */
+    zdata = NULL;
+    if (ini_arr &&
+        (zdata = zend_hash_str_find(HASH_OF(ini_arr), "connection_name", sizeof("connection_name") - 1)) != NULL) {
+        SEPARATE_ZVAL(zdata);
+        convert_to_string(zdata);
+    }
+    if (zdata && Z_STRLEN_P(zdata) > 0) {
+        zend_update_property_string(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("connection_name"),
+            Z_STRVAL_P(zdata) TSRMLS_CC
+        );
+    }
 }
 /* }}} */
 
@@ -583,20 +862,20 @@ static PHP_METHOD(amqp_connection_class, __construct)
 check amqp connection */
 static PHP_METHOD(amqp_connection_class, isConnected)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	/* If the channel_connect is 1, we have a connection */
-	if (connection->connection_resource != NULL && connection->connection_resource->is_connected) {
-		RETURN_TRUE;
-	}
+    /* If the channel_connect is 1, we have a connection */
+    if (connection->connection_resource != NULL && connection->connection_resource->is_connected) {
+        RETURN_TRUE;
+    }
 
-	/* We have no connection */
-	RETURN_FALSE;
+    /* We have no connection */
+    RETURN_FALSE;
 }
 /* }}} */
 
@@ -605,23 +884,27 @@ static PHP_METHOD(amqp_connection_class, isConnected)
 create amqp connection */
 static PHP_METHOD(amqp_connection_class, connect)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
-		if (connection->connection_resource->is_persistent) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Attempt to start transient connection while persistent transient one already established. Continue.");
-		}
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
+        if (connection->connection_resource->is_persistent) {
+            php_error_docref(
+                NULL TSRMLS_CC,
+                E_WARNING,
+                "Attempt to start transient connection while persistent transient one already established. Continue."
+            );
+        }
 
-		RETURN_TRUE;
-	}
+        RETURN_TRUE;
+    }
 
-	/* Actually connect this resource to the broker */
-	RETURN_BOOL(php_amqp_connect(connection, 0, INTERNAL_FUNCTION_PARAM_PASSTHRU));
+    /* Actually connect this resource to the broker */
+    RETURN_BOOL(php_amqp_connect(connection, 0, INTERNAL_FUNCTION_PARAM_PASSTHRU));
 }
 /* }}} */
 
@@ -630,25 +913,29 @@ static PHP_METHOD(amqp_connection_class, connect)
 create amqp connection */
 static PHP_METHOD(amqp_connection_class, pconnect)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
 
-		assert(connection->connection_resource != NULL);
-		if (!connection->connection_resource->is_persistent) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Attempt to start persistent connection while transient one already established. Continue.");
-		}
+        assert(connection->connection_resource != NULL);
+        if (!connection->connection_resource->is_persistent) {
+            php_error_docref(
+                NULL TSRMLS_CC,
+                E_WARNING,
+                "Attempt to start persistent connection while transient one already established. Continue."
+            );
+        }
 
-		RETURN_TRUE;
-	}
+        RETURN_TRUE;
+    }
 
-	/* Actually connect this resource to the broker or use stored connection */
-	RETURN_BOOL(php_amqp_connect(connection, 1, INTERNAL_FUNCTION_PARAM_PASSTHRU));
+    /* Actually connect this resource to the broker or use stored connection */
+    RETURN_BOOL(php_amqp_connect(connection, 1, INTERNAL_FUNCTION_PARAM_PASSTHRU));
 }
 /* }}} */
 
@@ -657,28 +944,32 @@ static PHP_METHOD(amqp_connection_class, pconnect)
 destroy amqp persistent connection */
 static PHP_METHOD(amqp_connection_class, pdisconnect)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (!connection->connection_resource || !connection->connection_resource->is_connected) {
-		RETURN_TRUE;
-	}
+    if (!connection->connection_resource || !connection->connection_resource->is_connected) {
+        RETURN_TRUE;
+    }
 
-	assert(connection->connection_resource != NULL);
+    assert(connection->connection_resource != NULL);
 
-	if (!connection->connection_resource->is_persistent) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Attempt to close persistent connection while transient one already established. Abort.");
+    if (!connection->connection_resource->is_persistent) {
+        php_error_docref(
+            NULL TSRMLS_CC,
+            E_WARNING,
+            "Attempt to close persistent connection while transient one already established. Abort."
+        );
 
-		RETURN_FALSE;
-	}
+        RETURN_FALSE;
+    }
 
-	php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+    php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -687,28 +978,32 @@ static PHP_METHOD(amqp_connection_class, pdisconnect)
 destroy amqp connection */
 static PHP_METHOD(amqp_connection_class, disconnect)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (!connection->connection_resource || !connection->connection_resource->is_connected) {
-		RETURN_TRUE;
-	}
+    if (!connection->connection_resource || !connection->connection_resource->is_connected) {
+        RETURN_TRUE;
+    }
 
-	if (connection->connection_resource->is_persistent) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Attempt to close transient connection while persistent one already established. Abort.");
+    if (connection->connection_resource->is_persistent) {
+        php_error_docref(
+            NULL TSRMLS_CC,
+            E_WARNING,
+            "Attempt to close transient connection while persistent one already established. Abort."
+        );
 
-		RETURN_FALSE;
-	}
+        RETURN_FALSE;
+    }
 
-	assert(connection->connection_resource != NULL);
+    assert(connection->connection_resource != NULL);
 
-	php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
+    php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 
 /* }}} */
@@ -717,27 +1012,31 @@ static PHP_METHOD(amqp_connection_class, disconnect)
 recreate amqp connection */
 static PHP_METHOD(amqp_connection_class, reconnect)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
 
-		assert(connection->connection_resource != NULL);
+        assert(connection->connection_resource != NULL);
 
-		if (connection->connection_resource->is_persistent) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Attempt to reconnect persistent connection while transient one already established. Abort.");
+        if (connection->connection_resource->is_persistent) {
+            php_error_docref(
+                NULL TSRMLS_CC,
+                E_WARNING,
+                "Attempt to reconnect persistent connection while transient one already established. Abort."
+            );
 
-			RETURN_FALSE;
-		}
+            RETURN_FALSE;
+        }
 
-		php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
-	}
+        php_amqp_disconnect(connection->connection_resource TSRMLS_CC);
+    }
 
-	RETURN_BOOL(php_amqp_connect(connection, 0, INTERNAL_FUNCTION_PARAM_PASSTHRU));
+    RETURN_BOOL(php_amqp_connect(connection, 0, INTERNAL_FUNCTION_PARAM_PASSTHRU));
 }
 /* }}} */
 
@@ -745,28 +1044,32 @@ static PHP_METHOD(amqp_connection_class, reconnect)
 recreate amqp connection */
 static PHP_METHOD(amqp_connection_class, preconnect)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
 
-		assert(connection->connection_resource != NULL);
+        assert(connection->connection_resource != NULL);
 
-		if (!connection->connection_resource->is_persistent) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Attempt to reconnect transient connection while persistent one already established. Abort.");
+        if (!connection->connection_resource->is_persistent) {
+            php_error_docref(
+                NULL TSRMLS_CC,
+                E_WARNING,
+                "Attempt to reconnect transient connection while persistent one already established. Abort."
+            );
 
-			RETURN_FALSE;
-		}
+            RETURN_FALSE;
+        }
 
-		php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
-	}
+        php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+    }
 
-	RETURN_BOOL(php_amqp_connect(connection, 1, INTERNAL_FUNCTION_PARAM_PASSTHRU));
+    RETURN_BOOL(php_amqp_connect(connection, 1, INTERNAL_FUNCTION_PARAM_PASSTHRU));
 }
 /* }}} */
 
@@ -775,9 +1078,9 @@ static PHP_METHOD(amqp_connection_class, preconnect)
 get the login */
 static PHP_METHOD(amqp_connection_class, getLogin)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("login");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("login");
 }
 /* }}} */
 
@@ -786,23 +1089,34 @@ static PHP_METHOD(amqp_connection_class, getLogin)
 set the login */
 static PHP_METHOD(amqp_connection_class, setLogin)
 {
-	char *login = NULL;
-	size_t login_len = 0;
+    char *login = NULL;
+    size_t login_len = 0;
 
-	/* Get the login from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &login, &login_len) == FAILURE) {
-		return;
-	}
+    /* Get the login from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &login, &login_len) == FAILURE) {
+        return;
+    }
 
-	/* Validate login length */
-	if (login_len > PHP_AMQP_MAX_CREDENTIALS_LENGTH) {
-        zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'login' exceeds %d character limit.", PHP_AMQP_MAX_CREDENTIALS_LENGTH);
-		return;
-	}
+    /* Validate login length */
+    if (login_len > PHP_AMQP_MAX_CREDENTIALS_LENGTH) {
+        zend_throw_exception_ex(
+            amqp_connection_exception_class_entry,
+            0 TSRMLS_CC,
+            "Parameter 'login' exceeds %d character limit.",
+            PHP_AMQP_MAX_CREDENTIALS_LENGTH
+        );
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("login"), login, login_len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("login"),
+        login,
+        login_len TSRMLS_CC
+    );
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -810,9 +1124,9 @@ static PHP_METHOD(amqp_connection_class, setLogin)
 get the password */
 static PHP_METHOD(amqp_connection_class, getPassword)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("password");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("password");
 }
 /* }}} */
 
@@ -821,23 +1135,34 @@ static PHP_METHOD(amqp_connection_class, getPassword)
 set the password */
 static PHP_METHOD(amqp_connection_class, setPassword)
 {
-	char *password = NULL;
-	size_t password_len = 0;
+    char *password = NULL;
+    size_t password_len = 0;
 
-	/* Get the password from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &password, &password_len) == FAILURE) {
-		return;
-	}
+    /* Get the password from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &password, &password_len) == FAILURE) {
+        return;
+    }
 
-	/* Validate password length */
-	if (password_len > PHP_AMQP_MAX_CREDENTIALS_LENGTH) {
-        zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'password' exceeds %d character limit.", PHP_AMQP_MAX_CREDENTIALS_LENGTH);
-		return;
-	}
+    /* Validate password length */
+    if (password_len > PHP_AMQP_MAX_CREDENTIALS_LENGTH) {
+        zend_throw_exception_ex(
+            amqp_connection_exception_class_entry,
+            0 TSRMLS_CC,
+            "Parameter 'password' exceeds %d character limit.",
+            PHP_AMQP_MAX_CREDENTIALS_LENGTH
+        );
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("password"), password, password_len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("password"),
+        password,
+        password_len TSRMLS_CC
+    );
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -846,9 +1171,9 @@ static PHP_METHOD(amqp_connection_class, setPassword)
 get the host */
 static PHP_METHOD(amqp_connection_class, getHost)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("host");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("host");
 }
 /* }}} */
 
@@ -857,23 +1182,28 @@ static PHP_METHOD(amqp_connection_class, getHost)
 set the host */
 static PHP_METHOD(amqp_connection_class, setHost)
 {
-	char *host = NULL;
-	size_t host_len = 0;
+    char *host = NULL;
+    size_t host_len = 0;
 
-	/* Get the host from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &host, &host_len) == FAILURE) {
-		return;
-	}
+    /* Get the host from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &host, &host_len) == FAILURE) {
+        return;
+    }
 
-	/* Validate host length */
-	if (host_len > PHP_AMQP_MAX_IDENTIFIER_LENGTH) {
-        zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'host' exceeds %d character limit.", PHP_AMQP_MAX_IDENTIFIER_LENGTH);
-		return;
-	}
+    /* Validate host length */
+    if (host_len > PHP_AMQP_MAX_IDENTIFIER_LENGTH) {
+        zend_throw_exception_ex(
+            amqp_connection_exception_class_entry,
+            0 TSRMLS_CC,
+            "Parameter 'host' exceeds %d character limit.",
+            PHP_AMQP_MAX_IDENTIFIER_LENGTH
+        );
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("host"), host, host_len TSRMLS_CC);
+    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("host"), host, host_len TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -882,9 +1212,9 @@ static PHP_METHOD(amqp_connection_class, setHost)
 get the port */
 static PHP_METHOD(amqp_connection_class, getPort)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("port");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("port");
 }
 /* }}} */
 
@@ -893,39 +1223,43 @@ static PHP_METHOD(amqp_connection_class, getPort)
 set the port */
 static PHP_METHOD(amqp_connection_class, setPort)
 {
-	zval *zvalPort;
-	int port;
+    zval *zvalPort;
+    int port;
 
-	/* Get the port from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z/", &zvalPort) == FAILURE) {
-		return;
-	}
+    /* Get the port from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z/", &zvalPort) == FAILURE) {
+        return;
+    }
 
-	/* Parse out the port*/
-	switch (Z_TYPE_P(zvalPort)) {
-		case IS_DOUBLE:
-			port = (int)Z_DVAL_P(zvalPort);
-			break;
-		case IS_LONG:
-			port = (int)Z_LVAL_P(zvalPort);
-			break;
-		case IS_STRING:
-			convert_to_long(zvalPort);
-			port = (int)Z_LVAL_P(zvalPort);
-			break;
-		default:
-			port = 0;
-	}
+    /* Parse out the port*/
+    switch (Z_TYPE_P(zvalPort)) {
+        case IS_DOUBLE:
+            port = (int) Z_DVAL_P(zvalPort);
+            break;
+        case IS_LONG:
+            port = (int) Z_LVAL_P(zvalPort);
+            break;
+        case IS_STRING:
+            convert_to_long(zvalPort);
+            port = (int) Z_LVAL_P(zvalPort);
+            break;
+        default:
+            port = 0;
+    }
 
-	/* Check the port value */
-	if (port <= 0 || port > 65535) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Invalid port given. Value must be between 1 and 65535.", 0 TSRMLS_CC);
-		return;
-	}
+    /* Check the port value */
+    if (port <= 0 || port > 65535) {
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Invalid port given. Value must be between 1 and 65535.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("port"), port TSRMLS_CC);
+    zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("port"), port TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -933,9 +1267,9 @@ static PHP_METHOD(amqp_connection_class, setPort)
 get the vhost */
 static PHP_METHOD(amqp_connection_class, getVhost)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("vhost");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("vhost");
 }
 /* }}} */
 
@@ -944,22 +1278,33 @@ static PHP_METHOD(amqp_connection_class, getVhost)
 set the vhost */
 static PHP_METHOD(amqp_connection_class, setVhost)
 {
-	char *vhost = NULL;
-	size_t vhost_len = 0;
+    char *vhost = NULL;
+    size_t vhost_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &vhost, &vhost_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &vhost, &vhost_len) == FAILURE) {
+        return;
+    }
 
-	/* Validate vhost length */
-	if (vhost_len > PHP_AMQP_MAX_IDENTIFIER_LENGTH) {
-		zend_throw_exception_ex(amqp_connection_exception_class_entry, 0 TSRMLS_CC, "Parameter 'vhost' exceeds %d characters limit.", PHP_AMQP_MAX_IDENTIFIER_LENGTH);
-		return;
-	}
+    /* Validate vhost length */
+    if (vhost_len > PHP_AMQP_MAX_IDENTIFIER_LENGTH) {
+        zend_throw_exception_ex(
+            amqp_connection_exception_class_entry,
+            0 TSRMLS_CC,
+            "Parameter 'vhost' exceeds %d characters limit.",
+            PHP_AMQP_MAX_IDENTIFIER_LENGTH
+        );
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("vhost"), vhost, vhost_len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("vhost"),
+        vhost,
+        vhost_len TSRMLS_CC
+    );
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -968,11 +1313,15 @@ static PHP_METHOD(amqp_connection_class, setVhost)
 get the timeout */
 static PHP_METHOD(amqp_connection_class, getTimeout)
 {
-	php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "AMQPConnection::getTimeout() method is deprecated; use AMQPConnection::getReadTimeout() instead");
+    php_error_docref(
+        NULL TSRMLS_CC,
+        E_DEPRECATED,
+        "AMQPConnection::getTimeout() method is deprecated; use AMQPConnection::getReadTimeout() instead"
+    );
 
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("read_timeout");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("read_timeout");
 }
 /* }}} */
 
@@ -981,37 +1330,51 @@ static PHP_METHOD(amqp_connection_class, getTimeout)
 set the timeout */
 static PHP_METHOD(amqp_connection_class, setTimeout)
 {
-	amqp_connection_object *connection;
-	double read_timeout;
+    amqp_connection_object *connection;
+    double read_timeout;
 
-	php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "AMQPConnection::setTimeout($timeout) method is deprecated; use AMQPConnection::setReadTimeout($timeout) instead");
+    php_error_docref(
+        NULL TSRMLS_CC,
+        E_DEPRECATED,
+        "AMQPConnection::setTimeout($timeout) method is deprecated; use AMQPConnection::setReadTimeout($timeout) "
+        "instead"
+    );
 
-	/* Get the timeout from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &read_timeout) == FAILURE) {
-		return;
-	}
+    /* Get the timeout from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &read_timeout) == FAILURE) {
+        return;
+    }
 
-	/* Validate timeout */
+    /* Validate timeout */
     if (!php_amqp_is_valid_timeout(read_timeout)) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-		return;
-	}
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Parameter 'timeout' must be greater than or equal to zero.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), read_timeout TSRMLS_CC);
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("read_timeout"),
+        read_timeout TSRMLS_CC
+    );
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
-		if (php_amqp_set_resource_read_timeout(connection->connection_resource, read_timeout TSRMLS_CC) == 0) {
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
+        if (php_amqp_set_resource_read_timeout(connection->connection_resource, read_timeout TSRMLS_CC) == 0) {
 
-			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+            php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
 
-			RETURN_FALSE;
-		}
-	}
+            RETURN_FALSE;
+        }
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -1019,9 +1382,9 @@ static PHP_METHOD(amqp_connection_class, setTimeout)
 get the read timeout */
 static PHP_METHOD(amqp_connection_class, getReadTimeout)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("read_timeout");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("read_timeout");
 }
 /* }}} */
 
@@ -1029,35 +1392,44 @@ static PHP_METHOD(amqp_connection_class, getReadTimeout)
 set read timeout */
 static PHP_METHOD(amqp_connection_class, setReadTimeout)
 {
-	amqp_connection_object *connection;
-	double read_timeout;
+    amqp_connection_object *connection;
+    double read_timeout;
 
-	/* Get the timeout from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &read_timeout) == FAILURE) {
-		return;
-	}
+    /* Get the timeout from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &read_timeout) == FAILURE) {
+        return;
+    }
 
-	/* Validate timeout */
+    /* Validate timeout */
     if (!php_amqp_is_valid_timeout(read_timeout)) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'read_timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-		return;
-	}
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Parameter 'read_timeout' must be greater than or equal to zero.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("read_timeout"), read_timeout TSRMLS_CC);
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("read_timeout"),
+        read_timeout TSRMLS_CC
+    );
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
-		if (php_amqp_set_resource_read_timeout(connection->connection_resource, read_timeout TSRMLS_CC) == 0) {
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
+        if (php_amqp_set_resource_read_timeout(connection->connection_resource, read_timeout TSRMLS_CC) == 0) {
 
-			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+            php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
 
-			RETURN_FALSE;
-		}
-	}
+            RETURN_FALSE;
+        }
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -1065,9 +1437,9 @@ static PHP_METHOD(amqp_connection_class, setReadTimeout)
 get write timeout */
 static PHP_METHOD(amqp_connection_class, getWriteTimeout)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("write_timeout");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("write_timeout");
 }
 /* }}} */
 
@@ -1075,35 +1447,44 @@ static PHP_METHOD(amqp_connection_class, getWriteTimeout)
 set write timeout */
 static PHP_METHOD(amqp_connection_class, setWriteTimeout)
 {
-	amqp_connection_object *connection;
-	double write_timeout;
+    amqp_connection_object *connection;
+    double write_timeout;
 
-	/* Get the timeout from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &write_timeout) == FAILURE) {
-		return;
-	}
+    /* Get the timeout from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &write_timeout) == FAILURE) {
+        return;
+    }
 
-	/* Validate timeout */
+    /* Validate timeout */
     if (!php_amqp_is_valid_timeout(write_timeout)) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'write_timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-		return;
-	}
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Parameter 'write_timeout' must be greater than or equal to zero.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("write_timeout"), write_timeout TSRMLS_CC);
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("write_timeout"),
+        write_timeout TSRMLS_CC
+    );
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
-		if (php_amqp_set_resource_write_timeout(connection->connection_resource, write_timeout TSRMLS_CC) == 0) {
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
+        if (php_amqp_set_resource_write_timeout(connection->connection_resource, write_timeout TSRMLS_CC) == 0) {
 
-			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+            php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
 
-			RETURN_FALSE;
-		}
-	}
+            RETURN_FALSE;
+        }
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -1121,9 +1502,9 @@ static PHP_METHOD(amqp_connection_class, getConnectTimeout)
 get rpc timeout */
 static PHP_METHOD(amqp_connection_class, getRpcTimeout)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("rpc_timeout");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("rpc_timeout");
 }
 /* }}} */
 
@@ -1131,35 +1512,44 @@ static PHP_METHOD(amqp_connection_class, getRpcTimeout)
 set rpc timeout */
 static PHP_METHOD(amqp_connection_class, setRpcTimeout)
 {
-	amqp_connection_object *connection;
-	double rpc_timeout;
+    amqp_connection_object *connection;
+    double rpc_timeout;
 
-	/* Get the timeout from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &rpc_timeout) == FAILURE) {
-		return;
-	}
+    /* Get the timeout from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &rpc_timeout) == FAILURE) {
+        return;
+    }
 
-	/* Validate timeout */
+    /* Validate timeout */
     if (!php_amqp_is_valid_timeout(rpc_timeout)) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Parameter 'rpc_timeout' must be greater than or equal to zero.", 0 TSRMLS_CC);
-		return;
-	}
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Parameter 'rpc_timeout' must be greater than or equal to zero.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	zend_update_property_double(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("rpc_timeout"), rpc_timeout TSRMLS_CC);
+    zend_update_property_double(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("rpc_timeout"),
+        rpc_timeout TSRMLS_CC
+    );
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
-		if (php_amqp_set_resource_rpc_timeout(connection->connection_resource, rpc_timeout TSRMLS_CC) == 0) {
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
+        if (php_amqp_set_resource_rpc_timeout(connection->connection_resource, rpc_timeout TSRMLS_CC) == 0) {
 
-			php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
+            php_amqp_disconnect_force(connection->connection_resource TSRMLS_CC);
 
-			RETURN_FALSE;
-		}
-	}
+            RETURN_FALSE;
+        }
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -1167,21 +1557,21 @@ static PHP_METHOD(amqp_connection_class, setRpcTimeout)
 Get max used channels number */
 static PHP_METHOD(amqp_connection_class, getUsedChannels)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	/* Get the timeout from the method params */
-	PHP_AMQP_NOPARAMS();
+    /* Get the timeout from the method params */
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (!connection->connection_resource || !connection->connection_resource->is_connected) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection is not connected.");
+    if (!connection->connection_resource || !connection->connection_resource->is_connected) {
+        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection is not connected.");
 
-		RETURN_LONG(0);
-	}
+        RETURN_LONG(0);
+    }
 
-	RETURN_LONG(connection->connection_resource->used_slots);
+    RETURN_LONG(connection->connection_resource->used_slots);
 }
 /* }}} */
 
@@ -1189,19 +1579,19 @@ static PHP_METHOD(amqp_connection_class, getUsedChannels)
 Get max supported channels number per connection */
 PHP_METHOD(amqp_connection_class, getMaxChannels)
 {
-	zval rv;
-	amqp_connection_object *connection;
+    zval rv;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
-		RETURN_LONG(connection->connection_resource->max_slots);
-	}
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
+        RETURN_LONG(connection->connection_resource->max_slots);
+    }
 
-	PHP_AMQP_RETURN_THIS_PROP("channel_max");
+    PHP_AMQP_RETURN_THIS_PROP("channel_max");
 }
 /* }}} */
 
@@ -1209,19 +1599,19 @@ PHP_METHOD(amqp_connection_class, getMaxChannels)
 Get max supported frame size per connection in bytes */
 static PHP_METHOD(amqp_connection_class, getMaxFrameSize)
 {
-	zval rv;
-	amqp_connection_object *connection;
+    zval rv;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (connection->connection_resource && connection->connection_resource->is_connected) {
-		RETURN_LONG(amqp_get_frame_max(connection->connection_resource->connection_state));
-	}
+    if (connection->connection_resource && connection->connection_resource->is_connected) {
+        RETURN_LONG(amqp_get_frame_max(connection->connection_resource->connection_state));
+    }
 
-	PHP_AMQP_RETURN_THIS_PROP("frame_max");
+    PHP_AMQP_RETURN_THIS_PROP("frame_max");
 }
 /* }}} */
 
@@ -1229,20 +1619,19 @@ static PHP_METHOD(amqp_connection_class, getMaxFrameSize)
 Get number of seconds between heartbeats of the connection in seconds */
 static PHP_METHOD(amqp_connection_class, getHeartbeatInterval)
 {
-	zval rv;
-	amqp_connection_object *connection;
+    zval rv;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	/* Get the connection object out of the store */
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    /* Get the connection object out of the store */
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	if (connection->connection_resource != NULL
-		&& connection->connection_resource->is_connected != '\0') {
-		RETURN_LONG(amqp_get_heartbeat(connection->connection_resource->connection_state));
-	}
+    if (connection->connection_resource != NULL && connection->connection_resource->is_connected != '\0') {
+        RETURN_LONG(amqp_get_heartbeat(connection->connection_resource->connection_state));
+    }
 
-	PHP_AMQP_RETURN_THIS_PROP("heartbeat");
+    PHP_AMQP_RETURN_THIS_PROP("heartbeat");
 }
 /* }}} */
 
@@ -1250,13 +1639,13 @@ static PHP_METHOD(amqp_connection_class, getHeartbeatInterval)
 check whether amqp connection is persistent */
 static PHP_METHOD(amqp_connection_class, isPersistent)
 {
-	amqp_connection_object *connection;
+    amqp_connection_object *connection;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	connection = PHP_AMQP_GET_CONNECTION(getThis());
+    connection = PHP_AMQP_GET_CONNECTION(getThis());
 
-	RETURN_BOOL(connection->connection_resource && connection->connection_resource->is_persistent);
+    RETURN_BOOL(connection->connection_resource && connection->connection_resource->is_persistent);
 }
 /* }}} */
 
@@ -1264,72 +1653,75 @@ static PHP_METHOD(amqp_connection_class, isPersistent)
 /* {{{ proto amqp::getCACert() */
 static PHP_METHOD(amqp_connection_class, getCACert)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("cacert");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("cacert");
 }
 /* }}} */
 
 /* {{{ proto amqp::setCACert(string cacert) */
 static PHP_METHOD(amqp_connection_class, setCACert)
 {
-	char *str = NULL;	size_t str_len = 0;
+    char *str = NULL;
+    size_t str_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("cacert"), str, str_len TSRMLS_CC);
+    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("cacert"), str, str_len TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
 /* {{{ proto amqp::getCert() */
 static PHP_METHOD(amqp_connection_class, getCert)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("cert");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("cert");
 }
 /* }}} */
 
 /* {{{ proto amqp::setCert(string cert) */
 static PHP_METHOD(amqp_connection_class, setCert)
 {
-	char *str = NULL;	size_t str_len = 0;
+    char *str = NULL;
+    size_t str_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("cert"), str, str_len TSRMLS_CC);
+    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("cert"), str, str_len TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
 /* {{{ proto amqp::getKey() */
 static PHP_METHOD(amqp_connection_class, getKey)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("key");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("key");
 }
 /* }}} */
 
 /* {{{ proto amqp::setKey(string key) */
 static PHP_METHOD(amqp_connection_class, setKey)
 {
-	char *str = NULL;	size_t str_len = 0;
+    char *str = NULL;
+    size_t str_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("key"), str, str_len TSRMLS_CC);
+    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("key"), str, str_len TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -1337,24 +1729,24 @@ static PHP_METHOD(amqp_connection_class, setKey)
 /* {{{ proto amqp::getVerify() */
 static PHP_METHOD(amqp_connection_class, getVerify)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("verify");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("verify");
 }
 /* }}} */
 
 /* {{{ proto amqp::setVerify(bool verify) */
 static PHP_METHOD(amqp_connection_class, setVerify)
 {
-	zend_bool verify = 1;
+    zend_bool verify = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &verify) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &verify) == FAILURE) {
+        return;
+    }
 
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("verify"), verify TSRMLS_CC);
+    zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("verify"), verify TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -1362,9 +1754,9 @@ static PHP_METHOD(amqp_connection_class, setVerify)
 get sasl method */
 static PHP_METHOD(amqp_connection_class, getSaslMethod)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("sasl_method");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("sasl_method");
 }
 /* }}} */
 
@@ -1372,56 +1764,67 @@ static PHP_METHOD(amqp_connection_class, getSaslMethod)
 set sasl method */
 static PHP_METHOD(amqp_connection_class, setSaslMethod)
 {
-	long method;
+    long method;
 
-	/* Get the port from the method params */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &method) == FAILURE) {
-		return;
-	}
+    /* Get the port from the method params */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &method) == FAILURE) {
+        return;
+    }
 
-	/* Check the method value */
-	if (method != AMQP_SASL_METHOD_PLAIN && method != AMQP_SASL_METHOD_EXTERNAL) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Invalid SASL method given. Method must be AMQP_SASL_METHOD_PLAIN or AMQP_SASL_METHOD_EXTERNAL.", 0 TSRMLS_CC);
-		return;
-	}
+    /* Check the method value */
+    if (method != AMQP_SASL_METHOD_PLAIN && method != AMQP_SASL_METHOD_EXTERNAL) {
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Invalid SASL method given. Method must be AMQP_SASL_METHOD_PLAIN or AMQP_SASL_METHOD_EXTERNAL.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("sasl_method"), method TSRMLS_CC);
+    zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("sasl_method"), method TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
 /* {{{ proto amqp::getConnectionName() */
 static PHP_METHOD(amqp_connection_class, getConnectionName)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("connection_name");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("connection_name");
 }
 /* }}} */
 
 /* {{{ proto amqp::setConnectionName(string connectionName) */
 static PHP_METHOD(amqp_connection_class, setConnectionName)
 {
-	char *str = NULL;	size_t str_len = 0;
+    char *str = NULL;
+    size_t str_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s!", &str, &str_len) == FAILURE) {
-		return;
-	}
-	if (str == NULL) {
-		zend_update_property_null(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connection_name") TSRMLS_CC);
-	} else {
-		zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connection_name"), str, str_len TSRMLS_CC);
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s!", &str, &str_len) == FAILURE) {
+        return;
+    }
+    if (str == NULL) {
+        zend_update_property_null(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connection_name") TSRMLS_CC);
+    } else {
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("connection_name"),
+            str,
+            str_len TSRMLS_CC
+        );
+    }
 
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
 /* amqp_connection_class ARG_INFO definition */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class__construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
-				ZEND_ARG_ARRAY_INFO(0, credentials, 0)
+    ZEND_ARG_ARRAY_INFO(0, credentials, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_isConnected, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
@@ -1449,56 +1852,56 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getLogin, ZEND_SEND_BY_VAL,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setLogin, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, login)
+    ZEND_ARG_INFO(0, login)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getPassword, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setPassword, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, password)
+    ZEND_ARG_INFO(0, password)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getHost, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setHost, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, host)
+    ZEND_ARG_INFO(0, host)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getPort, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setPort, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, port)
+    ZEND_ARG_INFO(0, port)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getVhost, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setVhost, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, vhost)
+    ZEND_ARG_INFO(0, vhost)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, timeout)
+    ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getReadTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setReadTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, timeout)
+    ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getWriteTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setWriteTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, timeout)
+    ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getConnectTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
@@ -1508,7 +1911,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getRpcTimeout, ZEND_SEND_BY
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setRpcTimeout, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, timeout)
+    ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getUsedChannels, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
@@ -1530,158 +1933,149 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getCACert, ZEND_SEND_BY_VAL
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setCACert, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, cacert)
+    ZEND_ARG_INFO(0, cacert)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getCert, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setCert, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, cert)
+    ZEND_ARG_INFO(0, cert)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getKey, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setKey, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, key)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getVerify, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setVerify, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, verify)
+    ZEND_ARG_INFO(0, verify)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getSaslMethod, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setSaslMethod, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, sasl_method)
+    ZEND_ARG_INFO(0, sasl_method)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_getConnectionName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class_setConnectionName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, connection_name)
+    ZEND_ARG_INFO(0, connection_name)
 ZEND_END_ARG_INFO()
 
 
 zend_function_entry amqp_connection_class_functions[] = {
-		PHP_ME(amqp_connection_class, __construct, 	arginfo_amqp_connection_class__construct,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, isConnected, 	arginfo_amqp_connection_class_isConnected,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, connect, 		arginfo_amqp_connection_class_connect, 		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, pconnect, 	arginfo_amqp_connection_class_pconnect, 	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, pdisconnect, 	arginfo_amqp_connection_class_pdisconnect,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, disconnect, 	arginfo_amqp_connection_class_disconnect,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, reconnect, 	arginfo_amqp_connection_class_reconnect,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, preconnect, 	arginfo_amqp_connection_class_preconnect,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, __construct, 	arginfo_amqp_connection_class__construct,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, isConnected, 	arginfo_amqp_connection_class_isConnected,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, connect, 		arginfo_amqp_connection_class_connect, 		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, pconnect, 	arginfo_amqp_connection_class_pconnect, 	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, pdisconnect, 	arginfo_amqp_connection_class_pdisconnect,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, disconnect, 	arginfo_amqp_connection_class_disconnect,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, reconnect, 	arginfo_amqp_connection_class_reconnect,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, preconnect, 	arginfo_amqp_connection_class_preconnect,	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getLogin, 	arginfo_amqp_connection_class_getLogin,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setLogin, 	arginfo_amqp_connection_class_setLogin,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getLogin, 	arginfo_amqp_connection_class_getLogin,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setLogin, 	arginfo_amqp_connection_class_setLogin,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getPassword, 	arginfo_amqp_connection_class_getPassword,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setPassword, 	arginfo_amqp_connection_class_setPassword,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getPassword, 	arginfo_amqp_connection_class_getPassword,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setPassword, 	arginfo_amqp_connection_class_setPassword,	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getHost, 		arginfo_amqp_connection_class_getHost,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setHost, 		arginfo_amqp_connection_class_setHost,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getHost, 		arginfo_amqp_connection_class_getHost,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setHost, 		arginfo_amqp_connection_class_setHost,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getPort, 		arginfo_amqp_connection_class_getPort,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setPort, 		arginfo_amqp_connection_class_setPort,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getPort, 		arginfo_amqp_connection_class_getPort,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setPort, 		arginfo_amqp_connection_class_setPort,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getVhost, 	arginfo_amqp_connection_class_getVhost,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setVhost, 	arginfo_amqp_connection_class_setVhost,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getVhost, 	arginfo_amqp_connection_class_getVhost,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setVhost, 	arginfo_amqp_connection_class_setVhost,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getTimeout, 	arginfo_amqp_connection_class_getTimeout,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setTimeout, 	arginfo_amqp_connection_class_setTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getTimeout, 	arginfo_amqp_connection_class_getTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setTimeout, 	arginfo_amqp_connection_class_setTimeout,	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getReadTimeout, 	arginfo_amqp_connection_class_getReadTimeout,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setReadTimeout, 	arginfo_amqp_connection_class_setReadTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getReadTimeout, 	arginfo_amqp_connection_class_getReadTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setReadTimeout, 	arginfo_amqp_connection_class_setReadTimeout,	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getWriteTimeout, 	arginfo_amqp_connection_class_getWriteTimeout,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setWriteTimeout, 	arginfo_amqp_connection_class_setWriteTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getWriteTimeout, 	arginfo_amqp_connection_class_getWriteTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setWriteTimeout, 	arginfo_amqp_connection_class_setWriteTimeout,	ZEND_ACC_PUBLIC)
 
-        PHP_ME(amqp_connection_class, getConnectTimeout, 	arginfo_amqp_connection_class_getConnectTimeout,	ZEND_ACC_PUBLIC)
-        /** setConnectTimeout intentionally left out */
+    PHP_ME(amqp_connection_class, getConnectTimeout, 	arginfo_amqp_connection_class_getConnectTimeout,	ZEND_ACC_PUBLIC)
+  /** setConnectTimeout intentionally left out */
 
-		PHP_ME(amqp_connection_class, getRpcTimeout, 	arginfo_amqp_connection_class_getRpcTimeout,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setRpcTimeout, 	arginfo_amqp_connection_class_setRpcTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getRpcTimeout, 	arginfo_amqp_connection_class_getRpcTimeout,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setRpcTimeout, 	arginfo_amqp_connection_class_setRpcTimeout,	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getUsedChannels, arginfo_amqp_connection_class_getUsedChannels,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, getMaxChannels,  arginfo_amqp_connection_class_getMaxChannels,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, isPersistent, 	arginfo_amqp_connection_class_isPersistent,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, getHeartbeatInterval,  arginfo_amqp_connection_class_getHeartbeatInterval,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, getMaxFrameSize,  arginfo_amqp_connection_class_getMaxFrameSize,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getUsedChannels, arginfo_amqp_connection_class_getUsedChannels,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getMaxChannels,  arginfo_amqp_connection_class_getMaxChannels,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, isPersistent, 	arginfo_amqp_connection_class_isPersistent,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getHeartbeatInterval,  arginfo_amqp_connection_class_getHeartbeatInterval,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getMaxFrameSize,  arginfo_amqp_connection_class_getMaxFrameSize,	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getCACert, 	arginfo_amqp_connection_class_getCACert,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setCACert, 	arginfo_amqp_connection_class_setCACert,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getCACert, 	arginfo_amqp_connection_class_getCACert,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setCACert, 	arginfo_amqp_connection_class_setCACert,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getCert, 	arginfo_amqp_connection_class_getCert,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setCert, 	arginfo_amqp_connection_class_setCert,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getCert, 	arginfo_amqp_connection_class_getCert,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setCert, 	arginfo_amqp_connection_class_setCert,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getKey, 	arginfo_amqp_connection_class_getKey,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setKey, 	arginfo_amqp_connection_class_setKey,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getKey, 	arginfo_amqp_connection_class_getKey,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setKey, 	arginfo_amqp_connection_class_setKey,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getVerify, 	arginfo_amqp_connection_class_getVerify,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setVerify, 	arginfo_amqp_connection_class_setVerify,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getVerify, 	arginfo_amqp_connection_class_getVerify,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setVerify, 	arginfo_amqp_connection_class_setVerify,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getSaslMethod, 	arginfo_amqp_connection_class_getSaslMethod,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setSaslMethod, 	arginfo_amqp_connection_class_setSaslMethod,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getSaslMethod, 	arginfo_amqp_connection_class_getSaslMethod,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setSaslMethod, 	arginfo_amqp_connection_class_setSaslMethod,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_connection_class, getConnectionName, 	arginfo_amqp_connection_class_getConnectionName,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_connection_class, setConnectionName, 	arginfo_amqp_connection_class_setConnectionName,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, getConnectionName, 	arginfo_amqp_connection_class_getConnectionName,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_connection_class, setConnectionName, 	arginfo_amqp_connection_class_setConnectionName,		ZEND_ACC_PUBLIC)
 
-		{NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 
 
 PHP_MINIT_FUNCTION(amqp_connection)
 {
-	zend_class_entry ce;
+    zend_class_entry ce;
 
-	INIT_CLASS_ENTRY(ce, "AMQPConnection", amqp_connection_class_functions);
-	ce.create_object = amqp_connection_ctor;
-	this_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    INIT_CLASS_ENTRY(ce, "AMQPConnection", amqp_connection_class_functions);
+    ce.create_object = amqp_connection_ctor;
+    this_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("login"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("password"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("host"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("vhost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("port"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("login"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("password"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("host"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("vhost"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("port"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("read_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("write_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("connect_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("rpc_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("read_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("write_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("connect_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("rpc_timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("channel_max"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("frame_max"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("heartbeat"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("channel_max"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("frame_max"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("heartbeat"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("cacert"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("cert"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("verify"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("cacert"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("cert"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("verify"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("sasl_method"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("sasl_method"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("connection_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("connection_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	memcpy(&amqp_connection_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+    memcpy(&amqp_connection_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-	amqp_connection_object_handlers.offset = XtOffsetOf(amqp_connection_object, zo);
-	amqp_connection_object_handlers.free_obj = amqp_connection_free;
+    amqp_connection_object_handlers.offset = XtOffsetOf(amqp_connection_object, zo);
+    amqp_connection_object_handlers.free_obj = amqp_connection_free;
 
-	return SUCCESS;
+    return SUCCESS;
 }
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<6
-*/

--- a/amqp_connection.h
+++ b/amqp_connection.h
@@ -29,12 +29,3 @@ void php_amqp_disconnect_force(amqp_connection_resource *resource TSRMLS_DC);
 
 
 PHP_MINIT_FUNCTION(amqp_connection);
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -22,7 +22,7 @@
 */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -32,33 +32,33 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# if PHP_VERSION_ID >= 80000
-#  include "main/php_stdint.h"
-# else
-#  include "win32/php_stdint.h"
-# endif
-# include "win32/signal.h"
+    #if PHP_VERSION_ID >= 80000
+        #include "main/php_stdint.h"
+    #else
+        #include "win32/php_stdint.h"
+    #endif
+    #include "win32/signal.h"
 #else
-# include <signal.h>
-# include <stdint.h>
+    #include <signal.h>
+    #include <stdint.h>
 #endif
 
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/framing.h>
-#include <rabbitmq-c/tcp_socket.h>
-#include <rabbitmq-c/ssl_socket.h>
+    #include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/framing.h>
+    #include <rabbitmq-c/tcp_socket.h>
+    #include <rabbitmq-c/ssl_socket.h>
 #else
-#include <amqp.h>
-#include <amqp_framing.h>
-#include <amqp_tcp_socket.h>
-#include <amqp_ssl_socket.h>
+    #include <amqp.h>
+    #include <amqp_framing.h>
+    #include <amqp_tcp_socket.h>
+    #include <amqp_ssl_socket.h>
 #endif
 
 #ifdef PHP_WIN32
-# include "win32/unistd.h"
+    #include "win32/unistd.h"
 #else
-# include <unistd.h>
+    #include <unistd.h>
 #endif
 
 //#include "amqp_basic_properties.h"
@@ -68,119 +68,159 @@
 #include "php_amqp.h"
 
 #ifndef E_DEPRECATED
-#define E_DEPRECATED E_WARNING
+    #define E_DEPRECATED E_WARNING
 #endif
 
 int le_amqp_connection_resource;
 int le_amqp_connection_resource_persistent;
 
 static void connection_resource_destructor(amqp_connection_resource *resource, int persistent TSRMLS_DC);
-static void php_amqp_close_connection_from_server(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource TSRMLS_DC);
-static void php_amqp_close_channel_from_server(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource, amqp_channel_t channel_id TSRMLS_DC);
+static void php_amqp_close_connection_from_server(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource TSRMLS_DC
+);
+static void php_amqp_close_channel_from_server(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id TSRMLS_DC
+);
 
 
 /* Figure out what's going on connection and handle protocol exceptions, if any */
-int php_amqp_connection_resource_error(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource, amqp_channel_t channel_id TSRMLS_DC)
+int php_amqp_connection_resource_error(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id TSRMLS_DC
+)
 {
-	assert (resource != NULL);
+    assert(resource != NULL);
 
-	switch (reply.reply_type) {
-		case AMQP_RESPONSE_NORMAL:
-			return PHP_AMQP_RESOURCE_RESPONSE_OK;
+    switch (reply.reply_type) {
+        case AMQP_RESPONSE_NORMAL:
+            return PHP_AMQP_RESOURCE_RESPONSE_OK;
 
-		case AMQP_RESPONSE_NONE:
-			spprintf(message, 0, "Missing RPC reply type.");
-			return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
+        case AMQP_RESPONSE_NONE:
+            spprintf(message, 0, "Missing RPC reply type.");
+            return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
 
-		case AMQP_RESPONSE_LIBRARY_EXCEPTION:
+        case AMQP_RESPONSE_LIBRARY_EXCEPTION:
+            spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
+            return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
 
-			spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
-			return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
+        case AMQP_RESPONSE_SERVER_EXCEPTION:
+            switch (reply.reply.id) {
+                case AMQP_CONNECTION_CLOSE_METHOD: {
+                    php_amqp_close_connection_from_server(reply, message, resource TSRMLS_CC);
+                    return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED;
+                }
+                case AMQP_CHANNEL_CLOSE_METHOD: {
+                    php_amqp_close_channel_from_server(reply, message, resource, channel_id TSRMLS_CC);
+                    return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED;
+                }
+            }
+        /* Default for the above switch should be handled by the below default. */
+        default:
+            spprintf(message, 0, "Unknown server error, method id 0x%08X", reply.reply.id);
+            return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
+    }
 
-		case AMQP_RESPONSE_SERVER_EXCEPTION:
-			switch (reply.reply.id) {
-				case AMQP_CONNECTION_CLOSE_METHOD: {
-					php_amqp_close_connection_from_server(reply, message, resource TSRMLS_CC);
-					return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED;
-				}
-				case AMQP_CHANNEL_CLOSE_METHOD: {
-					php_amqp_close_channel_from_server(reply, message, resource, channel_id TSRMLS_CC);
-					return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED;
-				}
-			}
-		/* Default for the above switch should be handled by the below default. */
-		default:
-			spprintf(message, 0, "Unknown server error, method id 0x%08X",	reply.reply.id);
-			return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
-	}
-
-	/* Should not never get here*/
+    /* Should not never get here*/
 }
 
-static void php_amqp_close_connection_from_server(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource TSRMLS_DC) {
-	amqp_connection_close_t *m = (amqp_connection_close_t *)reply.reply.decoded;
-	int result;
+static void php_amqp_close_connection_from_server(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource TSRMLS_DC
+)
+{
+    amqp_connection_close_t *m = (amqp_connection_close_t *) reply.reply.decoded;
+    int result;
 
-	if (!reply.reply.id) {
-		PHP_AMQP_G(error_code) = -1;
-		spprintf(message, 0, "Server connection error: %ld, message: %s",
-				 (long)PHP_AMQP_G(error_code),
-				 "unexpected response"
-		);
-	} else {
-		PHP_AMQP_G(error_code) = m->reply_code;
-		spprintf(message, 0, "Server connection error: %d, message: %.*s",
-				 m->reply_code,
-				 (int) m->reply_text.len,
-				 (char *) m->reply_text.bytes
-		);
-	}
-		
-	/*
+    if (!reply.reply.id) {
+        PHP_AMQP_G(error_code) = -1;
+        spprintf(
+            message,
+            0,
+            "Server connection error: %ld, message: %s",
+            (long) PHP_AMQP_G(error_code),
+            "unexpected response"
+        );
+    } else {
+        PHP_AMQP_G(error_code) = m->reply_code;
+        spprintf(
+            message,
+            0,
+            "Server connection error: %d, message: %.*s",
+            m->reply_code,
+            (int) m->reply_text.len,
+            (char *) m->reply_text.bytes
+        );
+    }
+
+    /*
 	 *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
 	 *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
 	 *      details of the exception. The client amqp_send_method() a
 	 *      amqp_connection_close_ok_t and disconnect from the broker.
 	 */
 
-	amqp_connection_close_ok_t *decoded = (amqp_connection_close_ok_t *) NULL;
+    amqp_connection_close_ok_t *decoded = (amqp_connection_close_ok_t *) NULL;
 
-	result = amqp_send_method(
-		resource->connection_state,
-		0, /* NOTE: 0-channel is reserved for things like this */
-		AMQP_CONNECTION_CLOSE_OK_METHOD,
-		&decoded
-	);
+    result = amqp_send_method(
+        resource->connection_state,
+        0, /* NOTE: 0-channel is reserved for things like this */
+        AMQP_CONNECTION_CLOSE_OK_METHOD,
+        &decoded
+    );
 
-	if (result != AMQP_STATUS_OK) {
-		zend_throw_exception(amqp_channel_exception_class_entry, "An error occurred while closing the connection.", 0 TSRMLS_CC);
-	}
+    if (result != AMQP_STATUS_OK) {
+        zend_throw_exception(
+            amqp_channel_exception_class_entry,
+            "An error occurred while closing the connection.",
+            0 TSRMLS_CC
+        );
+    }
 
-	/* Prevent finishing AMQP connection in connection resource destructor */
-	resource->is_connected = '\0';
+    /* Prevent finishing AMQP connection in connection resource destructor */
+    resource->is_connected = '\0';
 }
 
-static void php_amqp_close_channel_from_server(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource, amqp_channel_t channel_id TSRMLS_DC) {
-	assert(channel_id > 0 && channel_id <= resource->max_slots);
+static void php_amqp_close_channel_from_server(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id TSRMLS_DC
+)
+{
+    assert(channel_id > 0 && channel_id <= resource->max_slots);
 
-	amqp_channel_close_t *m = (amqp_channel_close_t *) reply.reply.decoded;
+    amqp_channel_close_t *m = (amqp_channel_close_t *) reply.reply.decoded;
 
-	if (!reply.reply.id) {
-		PHP_AMQP_G(error_code) = -1;
-		spprintf(message, 0, "Server channel error: %ld, message: %s",
-				 (long)PHP_AMQP_G(error_code),
-				 "unexpected response"
-		);
-	} else {
-		PHP_AMQP_G(error_code) = m->reply_code;
-		spprintf(message, 0, "Server channel error: %d, message: %.*s",
-			m->reply_code,
-			(int) m->reply_text.len,
-			(char *)m->reply_text.bytes
-		);
-	}
+    if (!reply.reply.id) {
+        PHP_AMQP_G(error_code) = -1;
+        spprintf(
+            message,
+            0,
+            "Server channel error: %ld, message: %s",
+            (long) PHP_AMQP_G(error_code),
+            "unexpected response"
+        );
+    } else {
+        PHP_AMQP_G(error_code) = m->reply_code;
+        spprintf(
+            message,
+            0,
+            "Server channel error: %d, message: %.*s",
+            m->reply_code,
+            (int) m->reply_text.len,
+            (char *) m->reply_text.bytes
+        );
+    }
 
-	/*
+    /*
 	 *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
 	 *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
 	 *      of the exception. The client should amqp_send_method() a
@@ -189,171 +229,223 @@ static void php_amqp_close_channel_from_server(amqp_rpc_reply_t reply, char **me
 	 *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
 	 *      and must be recreated before attempting to use them again.
 	 */
+    if (resource) {
+        int result;
+        amqp_channel_close_ok_t *decoded = (amqp_channel_close_ok_t *) NULL;
 
-	if (resource) {
-		int result;
-		amqp_channel_close_ok_t *decoded = (amqp_channel_close_ok_t *) NULL;
-
-		result = amqp_send_method(
-				resource->connection_state,
-				channel_id,
-				AMQP_CHANNEL_CLOSE_OK_METHOD,
-				&decoded
-		);
-		if (result != AMQP_STATUS_OK) {
-			zend_throw_exception(amqp_channel_exception_class_entry, "An error occurred while closing channel.", 0 TSRMLS_CC);
-		}
-	}
+        result = amqp_send_method(resource->connection_state, channel_id, AMQP_CHANNEL_CLOSE_OK_METHOD, &decoded);
+        if (result != AMQP_STATUS_OK) {
+            zend_throw_exception(
+                amqp_channel_exception_class_entry,
+                "An error occurred while closing channel.",
+                0 TSRMLS_CC
+            );
+        }
+    }
 }
 
 
-int php_amqp_connection_resource_error_advanced(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel TSRMLS_DC)
+int php_amqp_connection_resource_error_advanced(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel TSRMLS_DC
+)
 {
-	assert(resource != NULL);
+    assert(resource != NULL);
 
-	amqp_frame_t frame;
+    amqp_frame_t frame;
 
-	assert(AMQP_RESPONSE_LIBRARY_EXCEPTION == reply.reply_type);
-	assert(AMQP_STATUS_UNEXPECTED_STATE == reply.library_error);
+    assert(AMQP_RESPONSE_LIBRARY_EXCEPTION == reply.reply_type);
+    assert(AMQP_STATUS_UNEXPECTED_STATE == reply.library_error);
 
-	if (channel_id < 0 || AMQP_STATUS_OK != amqp_simple_wait_frame(resource->connection_state, &frame)) {
-		if (*message != NULL) {
-			efree(*message);
-		}
+    if (channel_id < 0 || AMQP_STATUS_OK != amqp_simple_wait_frame(resource->connection_state, &frame)) {
+        if (*message != NULL) {
+            efree(*message);
+        }
 
-		spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
-		return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
-	}
+        spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
+        return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
+    }
 
-	if (channel_id != frame.channel) {
-		spprintf(message, 0, "Library error: channel mismatch");
-		return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
-	}
+    if (channel_id != frame.channel) {
+        spprintf(message, 0, "Library error: channel mismatch");
+        return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
+    }
 
-	if (AMQP_FRAME_METHOD == frame.frame_type) {
-		switch (frame.payload.method.id) {
-			case AMQP_CONNECTION_CLOSE_METHOD: {
-				php_amqp_close_connection_from_server(reply, message, resource TSRMLS_CC);
-				return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED;
-			}
-			case AMQP_CHANNEL_CLOSE_METHOD: {
-				php_amqp_close_channel_from_server(reply, message, resource, channel_id TSRMLS_CC);
-				return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED;
-			}
+    if (AMQP_FRAME_METHOD == frame.frame_type) {
+        switch (frame.payload.method.id) {
+            case AMQP_CONNECTION_CLOSE_METHOD: {
+                php_amqp_close_connection_from_server(reply, message, resource TSRMLS_CC);
+                return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED;
+            }
+            case AMQP_CHANNEL_CLOSE_METHOD: {
+                php_amqp_close_channel_from_server(reply, message, resource, channel_id TSRMLS_CC);
+                return PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED;
+            }
 
-			case AMQP_BASIC_ACK_METHOD:
-				/* if we've turned publisher confirms on, and we've published a message
+            case AMQP_BASIC_ACK_METHOD:
+                /* if we've turned publisher confirms on, and we've published a message
 				 * here is a message being confirmed
 				 */
 
-				return php_amqp_handle_basic_ack(message, resource, channel_id, channel, &frame.payload.method TSRMLS_CC);
-			case AMQP_BASIC_NACK_METHOD:
-				/* if we've turned publisher confirms on, and we've published a message
+                return php_amqp_handle_basic_ack(
+                    message,
+                    resource,
+                    channel_id,
+                    channel,
+                    &frame.payload.method TSRMLS_CC
+                );
+            case AMQP_BASIC_NACK_METHOD:
+                /* if we've turned publisher confirms on, and we've published a message
 				 * here is a message being confirmed
 				 */
 
-				return php_amqp_handle_basic_nack(message, resource, channel_id, channel, &frame.payload.method TSRMLS_CC);
-			case AMQP_BASIC_RETURN_METHOD:
-				/* if a published message couldn't be routed and the mandatory flag was set
+                return php_amqp_handle_basic_nack(
+                    message,
+                    resource,
+                    channel_id,
+                    channel,
+                    &frame.payload.method TSRMLS_CC
+                );
+            case AMQP_BASIC_RETURN_METHOD:
+                /* if a published message couldn't be routed and the mandatory flag was set
 				 * this is what would be returned. The message then needs to be read.
 				 */
 
-				return php_amqp_handle_basic_return(message, resource, channel_id, channel, &frame.payload.method TSRMLS_CC);
-			default:
-				if (*message != NULL) {
-					efree(*message);
-				}
+                return php_amqp_handle_basic_return(
+                    message,
+                    resource,
+                    channel_id,
+                    channel,
+                    &frame.payload.method TSRMLS_CC
+                );
+            default:
+                if (*message != NULL) {
+                    efree(*message);
+                }
 
-				spprintf(message, 0, "Library error: An unexpected method was received 0x%08X\n", frame.payload.method.id);
-				return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
-		}
-	}
+                spprintf(
+                    message,
+                    0,
+                    "Library error: An unexpected method was received 0x%08X\n",
+                    frame.payload.method.id
+                );
+                return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
+        }
+    }
 
-	if (*message != NULL) {
-		efree(*message);
-	}
+    if (*message != NULL) {
+        efree(*message);
+    }
 
-	spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
-	return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
+    spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
+    return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
 }
 
 /* Socket-related functions */
 int php_amqp_set_resource_read_timeout(amqp_connection_resource *resource, double timeout TSRMLS_DC)
 {
-	assert(timeout >= 0.0);
+    assert(timeout >= 0.0);
 
 #ifdef PHP_WIN32
-	DWORD read_timeout;
-	/*
+    DWORD read_timeout;
+    /*
 	In Windows, setsockopt with SO_RCVTIMEO sets actual timeout
 	to a value that's 500ms greater than specified value.
 	Also, it's not possible to set timeout to any value below 500ms.
 	Zero timeout works like it should, however.
 	*/
-	if (timeout == 0.) {
-		read_timeout = 0;
-	} else {
-		read_timeout = (int) (max(timeout * 1.e+3 - .5e+3, 1.));
-	}
+    if (timeout == 0.) {
+        read_timeout = 0;
+    } else {
+        read_timeout = (int) (max(timeout * 1.e+3 - .5e+3, 1.));
+    }
 #else
-	struct timeval read_timeout;
-	read_timeout.tv_sec = (int) floor(timeout);
-	read_timeout.tv_usec = (int) ((timeout - floor(timeout)) * 1.e+6);
+    struct timeval read_timeout;
+    read_timeout.tv_sec = (int) floor(timeout);
+    read_timeout.tv_usec = (int) ((timeout - floor(timeout)) * 1.e+6);
 #endif
 
-	if (0 != setsockopt(amqp_get_sockfd(resource->connection_state), SOL_SOCKET, SO_RCVTIMEO, (char *)&read_timeout, sizeof(read_timeout))) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: cannot setsockopt SO_RCVTIMEO", 0 TSRMLS_CC);
-		return 0;
-	}
+    if (0 != setsockopt(
+                 amqp_get_sockfd(resource->connection_state),
+                 SOL_SOCKET,
+                 SO_RCVTIMEO,
+                 (char *) &read_timeout,
+                 sizeof(read_timeout)
+             )) {
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Socket error: cannot setsockopt SO_RCVTIMEO",
+            0 TSRMLS_CC
+        );
+        return 0;
+    }
 
-	return 1;
+    return 1;
 }
 
 int php_amqp_set_resource_rpc_timeout(amqp_connection_resource *resource, double timeout TSRMLS_DC)
 {
-	assert(timeout >= 0.0);
+    assert(timeout >= 0.0);
 
 #if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH >= 90
-	struct timeval rpc_timeout;
+    struct timeval rpc_timeout;
 
-	if (timeout == 0.) return 1;
+    if (timeout == 0.)
+        return 1;
 
-	rpc_timeout.tv_sec = (int) floor(timeout);
-	rpc_timeout.tv_usec = (int) ((timeout - floor(timeout)) * 1.e+6);
+    rpc_timeout.tv_sec = (int) floor(timeout);
+    rpc_timeout.tv_usec = (int) ((timeout - floor(timeout)) * 1.e+6);
 
-	if (AMQP_STATUS_OK != amqp_set_rpc_timeout(resource->connection_state, &rpc_timeout)) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Library error: cannot set rpc_timeout", 0 TSRMLS_CC);
-		return 0;
-	}
+    if (AMQP_STATUS_OK != amqp_set_rpc_timeout(resource->connection_state, &rpc_timeout)) {
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Library error: cannot set rpc_timeout",
+            0 TSRMLS_CC
+        );
+        return 0;
+    }
 #endif
 
-	return 1;
+    return 1;
 }
 
 int php_amqp_set_resource_write_timeout(amqp_connection_resource *resource, double timeout TSRMLS_DC)
 {
-	assert(timeout >= 0.0);
+    assert(timeout >= 0.0);
 
 #ifdef PHP_WIN32
-	DWORD write_timeout;
+    DWORD write_timeout;
 
-	if (timeout == 0.) {
-		write_timeout = 0;
-	} else {
-		write_timeout = (int) (max(timeout * 1.e+3 - .5e+3, 1.));
-	}
+    if (timeout == 0.) {
+        write_timeout = 0;
+    } else {
+        write_timeout = (int) (max(timeout * 1.e+3 - .5e+3, 1.));
+    }
 #else
-	struct timeval write_timeout;
-	write_timeout.tv_sec = (int) floor(timeout);
-	write_timeout.tv_usec = (int) ((timeout - floor(timeout)) * 1.e+6);
+    struct timeval write_timeout;
+    write_timeout.tv_sec = (int) floor(timeout);
+    write_timeout.tv_usec = (int) ((timeout - floor(timeout)) * 1.e+6);
 #endif
 
-	if (0 != setsockopt(amqp_get_sockfd(resource->connection_state), SOL_SOCKET, SO_SNDTIMEO, (char *)&write_timeout, sizeof(write_timeout))) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: cannot setsockopt SO_SNDTIMEO", 0 TSRMLS_CC);
-		return 0;
-	}
+    if (0 != setsockopt(
+                 amqp_get_sockfd(resource->connection_state),
+                 SOL_SOCKET,
+                 SO_SNDTIMEO,
+                 (char *) &write_timeout,
+                 sizeof(write_timeout)
+             )) {
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Socket error: cannot setsockopt SO_SNDTIMEO",
+            0 TSRMLS_CC
+        );
+        return 0;
+    }
 
-	return 1;
+    return 1;
 }
 
 
@@ -361,56 +453,60 @@ int php_amqp_set_resource_write_timeout(amqp_connection_resource *resource, doub
 
 amqp_channel_t php_amqp_connection_resource_get_available_channel_id(amqp_connection_resource *resource)
 {
-	assert(resource != NULL);
-	assert(resource->slots != NULL);
+    assert(resource != NULL);
+    assert(resource->slots != NULL);
 
-	/* Check if there are any open slots */
-	if (resource->used_slots >= resource->max_slots) {
-		return 0;
-	}
+    /* Check if there are any open slots */
+    if (resource->used_slots >= resource->max_slots) {
+        return 0;
+    }
 
-	amqp_channel_t slot;
+    amqp_channel_t slot;
 
-	for (slot = 0; slot < resource->max_slots; slot++) {
-		if (resource->slots[slot] == 0) {
-			return (amqp_channel_t) (slot + 1);
-		}
-	}
+    for (slot = 0; slot < resource->max_slots; slot++) {
+        if (resource->slots[slot] == 0) {
+            return (amqp_channel_t) (slot + 1);
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
-int php_amqp_connection_resource_register_channel(amqp_connection_resource *resource, amqp_channel_resource *channel_resource, amqp_channel_t channel_id)
+int php_amqp_connection_resource_register_channel(
+    amqp_connection_resource *resource,
+    amqp_channel_resource *channel_resource,
+    amqp_channel_t channel_id
+)
 {
-	assert(resource != NULL);
-	assert(resource->slots != NULL);
-	assert(channel_id > 0 && channel_id <= resource->max_slots);
+    assert(resource != NULL);
+    assert(resource->slots != NULL);
+    assert(channel_id > 0 && channel_id <= resource->max_slots);
 
-	if (resource->slots[channel_id - 1] != 0) {
-		return FAILURE;
-	}
+    if (resource->slots[channel_id - 1] != 0) {
+        return FAILURE;
+    }
 
-	resource->slots[channel_id - 1] = channel_resource;
-	channel_resource->connection_resource = resource;
-	resource->used_slots++;
+    resource->slots[channel_id - 1] = channel_resource;
+    channel_resource->connection_resource = resource;
+    resource->used_slots++;
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 int php_amqp_connection_resource_unregister_channel(amqp_connection_resource *resource, amqp_channel_t channel_id)
 {
-	assert(resource != NULL);
-	assert(resource->slots != NULL);
-	assert(channel_id > 0 && channel_id <= resource->max_slots);
+    assert(resource != NULL);
+    assert(resource->slots != NULL);
+    assert(channel_id > 0 && channel_id <= resource->max_slots);
 
-	if (resource->slots[channel_id - 1] != 0) {
-		resource->slots[channel_id - 1]->connection_resource = NULL;
+    if (resource->slots[channel_id - 1] != 0) {
+        resource->slots[channel_id - 1]->connection_resource = NULL;
 
-		resource->slots[channel_id - 1] = 0;
-		resource->used_slots--;
-	}
+        resource->slots[channel_id - 1] = 0;
+        resource->used_slots--;
+    }
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 
@@ -418,165 +514,185 @@ int php_amqp_connection_resource_unregister_channel(amqp_connection_resource *re
 
 amqp_connection_resource *connection_resource_constructor(amqp_connection_params *params, zend_bool persistent TSRMLS_DC)
 {
-	struct timeval tv = {0};
-	struct timeval *tv_ptr = &tv;
+    struct timeval tv = {0};
+    struct timeval *tv_ptr = &tv;
 
-	char *std_datetime;
-	amqp_table_entry_t client_properties_entries[5];
-	amqp_table_t       client_properties_table;
+    char *std_datetime;
+    amqp_table_entry_t client_properties_entries[5];
+    amqp_table_t client_properties_table;
 
-	amqp_table_entry_t custom_properties_entries[2];
-	amqp_table_t       custom_properties_table;
+    amqp_table_entry_t custom_properties_entries[2];
+    amqp_table_t custom_properties_table;
 
-	amqp_connection_resource *resource;
+    amqp_connection_resource *resource;
 
-	/* Allocate space for the connection resource */
-	resource = (amqp_connection_resource *)pecalloc(1, sizeof(amqp_connection_resource), persistent);
+    /* Allocate space for the connection resource */
+    resource = (amqp_connection_resource *) pecalloc(1, sizeof(amqp_connection_resource), persistent);
 
-	/* Create the connection */
-	resource->connection_state = amqp_new_connection();
+    /* Create the connection */
+    resource->connection_state = amqp_new_connection();
 
-	/* Create socket object */
-	if (params->cacert) {
-		resource->socket = amqp_ssl_socket_new(resource->connection_state);
+    /* Create socket object */
+    if (params->cacert) {
+        resource->socket = amqp_ssl_socket_new(resource->connection_state);
 
-		if (!resource->socket) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: could not create SSL socket.", 0 TSRMLS_CC);
+        if (!resource->socket) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Socket error: could not create SSL socket.",
+                0 TSRMLS_CC
+            );
 
-			return NULL;
-		}
-	} else {
-		resource->socket = amqp_tcp_socket_new(resource->connection_state);
+            return NULL;
+        }
+    } else {
+        resource->socket = amqp_tcp_socket_new(resource->connection_state);
 
-		if (!resource->socket) {
-			zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: could not create socket.", 0 TSRMLS_CC);
+        if (!resource->socket) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Socket error: could not create socket.",
+                0 TSRMLS_CC
+            );
 
-			return NULL;
-		}
-	}
+            return NULL;
+        }
+    }
 
-	if (params->cacert && amqp_ssl_socket_set_cacert(resource->socket, params->cacert)) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: could not set CA certificate.", 0 TSRMLS_CC);
+    if (params->cacert && amqp_ssl_socket_set_cacert(resource->socket, params->cacert)) {
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Socket error: could not set CA certificate.",
+            0 TSRMLS_CC
+        );
 
-		return NULL;
-	}
+        return NULL;
+    }
 
-	if (params->cacert) {
+    if (params->cacert) {
 #if AMQP_VERSION_MAJOR * 100 + AMQP_VERSION_MINOR * 10 + AMQP_VERSION_PATCH >= 80
-		amqp_ssl_socket_set_verify_peer(resource->socket, params->verify);
-		amqp_ssl_socket_set_verify_hostname(resource->socket, params->verify);
+        amqp_ssl_socket_set_verify_peer(resource->socket, params->verify);
+        amqp_ssl_socket_set_verify_hostname(resource->socket, params->verify);
 #else
-		amqp_ssl_socket_set_verify(resource->socket, params->verify);
+        amqp_ssl_socket_set_verify(resource->socket, params->verify);
 #endif
-	}
+    }
 
-	if (params->cert && params->key && amqp_ssl_socket_set_key(resource->socket, params->cert, params->key)) {
-		zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: could not setting client cert.", 0 TSRMLS_CC);
+    if (params->cert && params->key && amqp_ssl_socket_set_key(resource->socket, params->cert, params->key)) {
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Socket error: could not setting client cert.",
+            0 TSRMLS_CC
+        );
 
-		return NULL;
-	}
+        return NULL;
+    }
 
-	if (params->connect_timeout > 0) {
-		tv.tv_sec = (long int) params->connect_timeout;
-		tv.tv_usec = (long int) ((params->connect_timeout - tv.tv_sec) * 1000000);
-	} else {
-		tv_ptr = NULL;
-	}
+    if (params->connect_timeout > 0) {
+        tv.tv_sec = (long int) params->connect_timeout;
+        tv.tv_usec = (long int) ((params->connect_timeout - tv.tv_sec) * 1000000);
+    } else {
+        tv_ptr = NULL;
+    }
 
-	/* Try to connect and verify that no error occurred */
-	if (amqp_socket_open_noblock(resource->socket, params->host, params->port, tv_ptr)) {
+    /* Try to connect and verify that no error occurred */
+    if (amqp_socket_open_noblock(resource->socket, params->host, params->port, tv_ptr)) {
 
-		zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: could not connect to host.", 0 TSRMLS_CC);
+        zend_throw_exception(
+            amqp_connection_exception_class_entry,
+            "Socket error: could not connect to host.",
+            0 TSRMLS_CC
+        );
 
-		connection_resource_destructor(resource, persistent TSRMLS_CC);
+        connection_resource_destructor(resource, persistent TSRMLS_CC);
 
-		return NULL;
-	}
+        return NULL;
+    }
 
-	if (!php_amqp_set_resource_read_timeout(resource, params->read_timeout TSRMLS_CC)) {
-		connection_resource_destructor(resource, persistent TSRMLS_CC);
-		return NULL;
-	}
+    if (!php_amqp_set_resource_read_timeout(resource, params->read_timeout TSRMLS_CC)) {
+        connection_resource_destructor(resource, persistent TSRMLS_CC);
+        return NULL;
+    }
 
-	if (!php_amqp_set_resource_write_timeout(resource, params->write_timeout TSRMLS_CC)) {
-		connection_resource_destructor(resource, persistent TSRMLS_CC);
-		return NULL;
-	}
+    if (!php_amqp_set_resource_write_timeout(resource, params->write_timeout TSRMLS_CC)) {
+        connection_resource_destructor(resource, persistent TSRMLS_CC);
+        return NULL;
+    }
 
-	if (!php_amqp_set_resource_rpc_timeout(resource, params->rpc_timeout TSRMLS_CC)) {
-		connection_resource_destructor(resource, persistent TSRMLS_CC);
-		return NULL;
-	}
+    if (!php_amqp_set_resource_rpc_timeout(resource, params->rpc_timeout TSRMLS_CC)) {
+        connection_resource_destructor(resource, persistent TSRMLS_CC);
+        return NULL;
+    }
 
-	std_datetime = php_std_date(time(NULL) TSRMLS_CC);
+    std_datetime = php_std_date(time(NULL) TSRMLS_CC);
 
-	client_properties_entries[0].key               = amqp_cstring_bytes("type");
-	client_properties_entries[0].value.kind        = AMQP_FIELD_KIND_UTF8;
-	client_properties_entries[0].value.value.bytes = amqp_cstring_bytes("php-amqp extension");
+    client_properties_entries[0].key = amqp_cstring_bytes("type");
+    client_properties_entries[0].value.kind = AMQP_FIELD_KIND_UTF8;
+    client_properties_entries[0].value.value.bytes = amqp_cstring_bytes("php-amqp extension");
 
-	client_properties_entries[1].key               = amqp_cstring_bytes("version");
-	client_properties_entries[1].value.kind        = AMQP_FIELD_KIND_UTF8;
-	client_properties_entries[1].value.value.bytes = amqp_cstring_bytes(PHP_AMQP_VERSION);
+    client_properties_entries[1].key = amqp_cstring_bytes("version");
+    client_properties_entries[1].value.kind = AMQP_FIELD_KIND_UTF8;
+    client_properties_entries[1].value.value.bytes = amqp_cstring_bytes(PHP_AMQP_VERSION);
 
-	client_properties_entries[2].key               = amqp_cstring_bytes("revision");
-	client_properties_entries[2].value.kind        = AMQP_FIELD_KIND_UTF8;
-	client_properties_entries[2].value.value.bytes = amqp_cstring_bytes(PHP_AMQP_REVISION);
+    client_properties_entries[2].key = amqp_cstring_bytes("revision");
+    client_properties_entries[2].value.kind = AMQP_FIELD_KIND_UTF8;
+    client_properties_entries[2].value.value.bytes = amqp_cstring_bytes(PHP_AMQP_REVISION);
 
-	client_properties_entries[3].key               = amqp_cstring_bytes("connection type");
-	client_properties_entries[3].value.kind        = AMQP_FIELD_KIND_UTF8;
-	client_properties_entries[3].value.value.bytes = amqp_cstring_bytes(persistent ? "persistent" : "transient");
+    client_properties_entries[3].key = amqp_cstring_bytes("connection type");
+    client_properties_entries[3].value.kind = AMQP_FIELD_KIND_UTF8;
+    client_properties_entries[3].value.value.bytes = amqp_cstring_bytes(persistent ? "persistent" : "transient");
 
-	client_properties_entries[4].key               = amqp_cstring_bytes("connection started");
-	client_properties_entries[4].value.kind        = AMQP_FIELD_KIND_UTF8;
-	client_properties_entries[4].value.value.bytes = amqp_cstring_bytes(std_datetime);
+    client_properties_entries[4].key = amqp_cstring_bytes("connection started");
+    client_properties_entries[4].value.kind = AMQP_FIELD_KIND_UTF8;
+    client_properties_entries[4].value.value.bytes = amqp_cstring_bytes(std_datetime);
 
-	client_properties_table.entries = client_properties_entries;
-	client_properties_table.num_entries = sizeof(client_properties_entries) / sizeof(amqp_table_entry_t);
+    client_properties_table.entries = client_properties_entries;
+    client_properties_table.num_entries = sizeof(client_properties_entries) / sizeof(amqp_table_entry_t);
 
-	custom_properties_entries[0].key               = amqp_cstring_bytes("client");
-	custom_properties_entries[0].value.kind        = AMQP_FIELD_KIND_TABLE;
-	custom_properties_entries[0].value.value.table = client_properties_table;
+    custom_properties_entries[0].key = amqp_cstring_bytes("client");
+    custom_properties_entries[0].value.kind = AMQP_FIELD_KIND_TABLE;
+    custom_properties_entries[0].value.value.table = client_properties_table;
 
 
-	if (params->connection_name) {
-		custom_properties_entries[1].key               = amqp_cstring_bytes("connection_name");
-		custom_properties_entries[1].value.kind        = AMQP_FIELD_KIND_UTF8;
-		custom_properties_entries[1].value.value.bytes = amqp_cstring_bytes(params->connection_name);
-	}
+    if (params->connection_name) {
+        custom_properties_entries[1].key = amqp_cstring_bytes("connection_name");
+        custom_properties_entries[1].value.kind = AMQP_FIELD_KIND_UTF8;
+        custom_properties_entries[1].value.value.bytes = amqp_cstring_bytes(params->connection_name);
+    }
 
-	custom_properties_table.entries     = custom_properties_entries;
-	custom_properties_table.num_entries = params->connection_name ? 2 : 1;
+    custom_properties_table.entries = custom_properties_entries;
+    custom_properties_table.num_entries = params->connection_name ? 2 : 1;
 
-	/* We can assume that connection established here but it is not true, real handshake goes during login */
+    /* We can assume that connection established here but it is not true, real handshake goes during login */
 
-	assert(params->frame_max > 0);
+    assert(params->frame_max > 0);
 
-	amqp_rpc_reply_t res = amqp_login_with_properties(
-		resource->connection_state,
-		params->vhost,
-		params->channel_max,
-		params->frame_max,
-		params->heartbeat,
-		&custom_properties_table,
-		params->sasl_method,
-		params->login,
-		params->password
-	);
+    amqp_rpc_reply_t res = amqp_login_with_properties(
+        resource->connection_state,
+        params->vhost,
+        params->channel_max,
+        params->frame_max,
+        params->heartbeat,
+        &custom_properties_table,
+        params->sasl_method,
+        params->login,
+        params->password
+    );
 
-	efree(std_datetime);
+    efree(std_datetime);
 
-	if (AMQP_RESPONSE_NORMAL != res.reply_type) {
-		char *message = NULL, *long_message = NULL;
+    if (AMQP_RESPONSE_NORMAL != res.reply_type) {
+        char *message = NULL, *long_message = NULL;
 
-		php_amqp_connection_resource_error(res, &message, resource, 0 TSRMLS_CC);
+        php_amqp_connection_resource_error(res, &message, resource, 0 TSRMLS_CC);
 
-		spprintf(&long_message, 0, "%s - Potential login failure.", message);
-		zend_throw_exception(amqp_connection_exception_class_entry, long_message, PHP_AMQP_G(error_code) TSRMLS_CC);
+        spprintf(&long_message, 0, "%s - Potential login failure.", message);
+        zend_throw_exception(amqp_connection_exception_class_entry, long_message, PHP_AMQP_G(error_code) TSRMLS_CC);
 
-		efree(message);
-		efree(long_message);
+        efree(message);
+        efree(long_message);
 
-		/* https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf
+        /* https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf
 		 *
 		 * 2.2.4 The Connection Class:
 		 * ... a peer that detects an error MUST close the socket without sending any further data.
@@ -586,105 +702,105 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
 		 * (presumably a thread) for a period of several seconds and then to close the network connection. This
 		 * includes syntax errors, over-sized data, and failed attempts to authenticate.
 		 */
-		connection_resource_destructor(resource, persistent TSRMLS_CC);
-		return NULL;
-	}
+        connection_resource_destructor(resource, persistent TSRMLS_CC);
+        return NULL;
+    }
 
-	/* Allocate space for the channel slots in the ring buffer */
-	resource->max_slots = (amqp_channel_t) amqp_get_channel_max(resource->connection_state);
-	assert(resource->max_slots > 0);
+    /* Allocate space for the channel slots in the ring buffer */
+    resource->max_slots = (amqp_channel_t) amqp_get_channel_max(resource->connection_state);
+    assert(resource->max_slots > 0);
 
-	resource->slots = (amqp_channel_resource **)pecalloc(resource->max_slots + 1, sizeof(amqp_channel_object*), persistent);
+    resource->slots =
+        (amqp_channel_resource **) pecalloc(resource->max_slots + 1, sizeof(amqp_channel_object *), persistent);
 
-	resource->is_connected = '\1';
+    resource->is_connected = '\1';
 
-	return resource;
+    return resource;
 }
 
 ZEND_RSRC_DTOR_FUNC(amqp_connection_resource_dtor_persistent)
 {
-	amqp_connection_resource *resource = (amqp_connection_resource *)res->ptr;
+    amqp_connection_resource *resource = (amqp_connection_resource *) res->ptr;
 
-	connection_resource_destructor(resource, 1 TSRMLS_CC);
+    connection_resource_destructor(resource, 1 TSRMLS_CC);
 }
 
 ZEND_RSRC_DTOR_FUNC(amqp_connection_resource_dtor)
 {
-	amqp_connection_resource *resource = (amqp_connection_resource *)res->ptr;
+    amqp_connection_resource *resource = (amqp_connection_resource *) res->ptr;
 
-	connection_resource_destructor(resource, 0 TSRMLS_CC);
+    connection_resource_destructor(resource, 0 TSRMLS_CC);
 }
 
 static void connection_resource_destructor(amqp_connection_resource *resource, int persistent TSRMLS_DC)
 {
-	assert(resource != NULL);
+    assert(resource != NULL);
 
 #ifndef PHP_WIN32
-	void * old_handler;
+    void *old_handler;
 
-	/*
+    /*
 	If we are trying to close the connection and the connection already closed, it will throw
 	SIGPIPE, which is fine, so ignore all SIGPIPES
 	*/
 
-	/* Start ignoring SIGPIPE */
-	old_handler = signal(SIGPIPE, SIG_IGN);
+    /* Start ignoring SIGPIPE */
+    old_handler = signal(SIGPIPE, SIG_IGN);
 #endif
 
-	if (resource->parent) {
-		resource->parent->connection_resource = NULL;
-	}
+    if (resource->parent) {
+        resource->parent->connection_resource = NULL;
+    }
 
-	if (resource->slots) {
-		php_amqp_prepare_for_disconnect(resource TSRMLS_CC);
+    if (resource->slots) {
+        php_amqp_prepare_for_disconnect(resource TSRMLS_CC);
 
-		pefree(resource->slots, persistent);
-		resource->slots = NULL;
-	}
+        pefree(resource->slots, persistent);
+        resource->slots = NULL;
+    }
 
-	/* connection may be closed in case of previous failure */
-	if (resource->is_connected) {
-		amqp_connection_close(resource->connection_state, AMQP_REPLY_SUCCESS);
-	}
+    /* connection may be closed in case of previous failure */
+    if (resource->is_connected) {
+        amqp_connection_close(resource->connection_state, AMQP_REPLY_SUCCESS);
+    }
 
-	amqp_destroy_connection(resource->connection_state);
+    amqp_destroy_connection(resource->connection_state);
 
 #ifndef PHP_WIN32
-	/* End ignoring of SIGPIPEs */
-	signal(SIGPIPE, old_handler);
+    /* End ignoring of SIGPIPEs */
+    signal(SIGPIPE, old_handler);
 #endif
 
-	pefree(resource, persistent);
+    pefree(resource, persistent);
 }
 
 void php_amqp_prepare_for_disconnect(amqp_connection_resource *resource TSRMLS_DC)
 {
-	if (resource == NULL) {
-		return;
-	}
+    if (resource == NULL) {
+        return;
+    }
 
-	if(resource->slots != NULL) {
-		/* NOTE: when we have persistent connection we do not move channels between php requests
+    if (resource->slots != NULL) {
+        /* NOTE: when we have persistent connection we do not move channels between php requests
 		 *       due to current php-amqp extension limitation in AMQPChannel where __construct == channel.open AMQP method call
 		 *       and __destruct = channel.close AMQP method call
 		 */
 
-		/* Clean up old memory allocations which are now invalid (new connection) */
-		amqp_channel_t slot;
+        /* Clean up old memory allocations which are now invalid (new connection) */
+        amqp_channel_t slot;
 
-		for (slot = 0; slot < resource->max_slots; slot++) {
-			if (resource->slots[slot] != 0) {
-				php_amqp_close_channel(resource->slots[slot], 0 TSRMLS_CC);
-			}
-		}
-	}
+        for (slot = 0; slot < resource->max_slots; slot++) {
+            if (resource->slots[slot] != 0) {
+                php_amqp_close_channel(resource->slots[slot], 0 TSRMLS_CC);
+            }
+        }
+    }
 
-	/* If it's persistent connection do not destroy connection resource (this keep connection alive) */
-	if (resource->is_persistent) {
-		/* Cleanup buffers to reduce memory usage in idle mode */
-		amqp_maybe_release_buffers(resource->connection_state);
-	}
+    /* If it's persistent connection do not destroy connection resource (this keep connection alive) */
+    if (resource->is_persistent) {
+        /* Cleanup buffers to reduce memory usage in idle mode */
+        amqp_maybe_release_buffers(resource->connection_state);
+    }
 
-	return;
+    return;
 }
-

--- a/amqp_connection_resource.h
+++ b/amqp_connection_resource.h
@@ -23,10 +23,10 @@
 #ifndef PHP_AMQP_CONNECTION_RESOURCE_H
 #define PHP_AMQP_CONNECTION_RESOURCE_H
 
-#define PHP_AMQP_RESOURCE_RESPONSE_BREAK                    1
-#define PHP_AMQP_RESOURCE_RESPONSE_OK                       0
-#define PHP_AMQP_RESOURCE_RESPONSE_ERROR                   -1
-#define PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED    -2
+#define PHP_AMQP_RESOURCE_RESPONSE_BREAK 1
+#define PHP_AMQP_RESOURCE_RESPONSE_OK 0
+#define PHP_AMQP_RESOURCE_RESPONSE_ERROR -1
+#define PHP_AMQP_RESOURCE_RESPONSE_ERROR_CHANNEL_CLOSED -2
 #define PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED -3
 
 extern int le_amqp_connection_resource;
@@ -34,37 +34,48 @@ extern int le_amqp_connection_resource_persistent;
 
 #include "php_amqp.h"
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/amqp.h>
 #else
-#include <amqp.h>
+    #include <amqp.h>
 #endif
 
 void php_amqp_prepare_for_disconnect(amqp_connection_resource *resource TSRMLS_DC);
 
 typedef struct _amqp_connection_params {
-  char *login;
-  char *password;
-  char *host;
-  char *vhost;
-  int port;
-  int channel_max;
-  int frame_max;
-  int heartbeat;
-  double read_timeout;
-  double write_timeout;
-  double connect_timeout;
-  double rpc_timeout;
-  char *cacert;
-  char *cert;
-  char *key;
-  int verify;
-  int sasl_method;
-  char *connection_name;
+    char *login;
+    char *password;
+    char *host;
+    char *vhost;
+    int port;
+    int channel_max;
+    int frame_max;
+    int heartbeat;
+    double read_timeout;
+    double write_timeout;
+    double connect_timeout;
+    double rpc_timeout;
+    char *cacert;
+    char *cert;
+    char *key;
+    int verify;
+    int sasl_method;
+    char *connection_name;
 } amqp_connection_params;
 
 /* Figure out what's going on connection and handle protocol exceptions, if any */
-int php_amqp_connection_resource_error(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource, amqp_channel_t channel_id TSRMLS_DC);
-int php_amqp_connection_resource_error_advanced(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel TSRMLS_DC);
+int php_amqp_connection_resource_error(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id TSRMLS_DC
+);
+int php_amqp_connection_resource_error_advanced(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel TSRMLS_DC
+);
 
 /* Socket-related functions */
 int php_amqp_set_resource_read_timeout(amqp_connection_resource *resource, double read_timeout TSRMLS_DC);
@@ -76,19 +87,18 @@ int php_amqp_set_resource_rpc_timeout(amqp_connection_resource *resource, double
 /* Channel-related functions */
 amqp_channel_t php_amqp_connection_resource_get_available_channel_id(amqp_connection_resource *resource);
 int php_amqp_connection_resource_unregister_channel(amqp_connection_resource *resource, amqp_channel_t channel_id);
-int php_amqp_connection_resource_register_channel(amqp_connection_resource *resource, amqp_channel_resource *channel_resource, amqp_channel_t channel_id);
+int php_amqp_connection_resource_register_channel(
+    amqp_connection_resource *resource,
+    amqp_channel_resource *channel_resource,
+    amqp_channel_t channel_id
+);
 
 /* Creating and destroying resource */
-amqp_connection_resource *connection_resource_constructor(amqp_connection_params *params, zend_bool persistent TSRMLS_DC);
+amqp_connection_resource *connection_resource_constructor(
+    amqp_connection_params *params,
+    zend_bool persistent TSRMLS_DC
+);
 ZEND_RSRC_DTOR_FUNC(amqp_connection_resource_dtor_persistent);
 ZEND_RSRC_DTOR_FUNC(amqp_connection_resource_dtor);
 
 #endif
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_decimal.c
+++ b/amqp_decimal.c
@@ -21,7 +21,7 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -43,31 +43,54 @@ static PHP_METHOD(amqp_decimal_class, __construct)
 {
     zend_long exponent, significand;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &exponent, &significand) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &exponent, &significand) == FAILURE) {
+        return;
+    }
 
-	if (exponent < AMQP_DECIMAL_EXPONENT_MIN) {
-		zend_throw_exception_ex(amqp_value_exception_class_entry, 0 TSRMLS_CC, "Decimal exponent value must be unsigned.");
-		return;
-	}
+    if (exponent < AMQP_DECIMAL_EXPONENT_MIN) {
+        zend_throw_exception_ex(
+            amqp_value_exception_class_entry,
+            0 TSRMLS_CC,
+            "Decimal exponent value must be unsigned."
+        );
+        return;
+    }
 
-	if (exponent > AMQP_DECIMAL_EXPONENT_MAX) {
-		zend_throw_exception_ex(amqp_value_exception_class_entry, 0 TSRMLS_CC, "Decimal exponent value must be less than %u.", (unsigned)AMQP_DECIMAL_EXPONENT_MAX);
-		return;
-	}
+    if (exponent > AMQP_DECIMAL_EXPONENT_MAX) {
+        zend_throw_exception_ex(
+            amqp_value_exception_class_entry,
+            0 TSRMLS_CC,
+            "Decimal exponent value must be less than %u.",
+            (unsigned) AMQP_DECIMAL_EXPONENT_MAX
+        );
+        return;
+    }
     if (significand < AMQP_DECIMAL_SIGNIFICAND_MIN) {
-        zend_throw_exception_ex(amqp_value_exception_class_entry, 0 TSRMLS_CC, "Decimal significand value must be unsigned.");
+        zend_throw_exception_ex(
+            amqp_value_exception_class_entry,
+            0 TSRMLS_CC,
+            "Decimal significand value must be unsigned."
+        );
         return;
     }
 
     if (significand > AMQP_DECIMAL_SIGNIFICAND_MAX) {
-        zend_throw_exception_ex(amqp_value_exception_class_entry, 0 TSRMLS_CC, "Decimal significand value must be less than %u.", (unsigned)AMQP_DECIMAL_SIGNIFICAND_MAX);
+        zend_throw_exception_ex(
+            amqp_value_exception_class_entry,
+            0 TSRMLS_CC,
+            "Decimal significand value must be less than %u.",
+            (unsigned) AMQP_DECIMAL_SIGNIFICAND_MAX
+        );
         return;
     }
 
     zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("exponent"), exponent TSRMLS_CC);
-    zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("significand"), significand TSRMLS_CC);
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("significand"),
+        significand TSRMLS_CC
+    );
 }
 /* }}} */
 
@@ -75,10 +98,10 @@ static PHP_METHOD(amqp_decimal_class, __construct)
 Get exponent */
 static PHP_METHOD(amqp_decimal_class, getExponent)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
+    zval rv;
+    PHP_AMQP_NOPARAMS();
 
-	PHP_AMQP_RETURN_THIS_PROP("exponent");
+    PHP_AMQP_RETURN_THIS_PROP("exponent");
 }
 /* }}} */
 
@@ -95,8 +118,8 @@ static PHP_METHOD(amqp_decimal_class, getSignificand)
 
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_decimal_class_construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
-	ZEND_ARG_INFO(0, exponent)
-	ZEND_ARG_INFO(0, significand)
+    ZEND_ARG_INFO(0, exponent)
+    ZEND_ARG_INFO(0, significand)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_decimal_class_getExponent, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
@@ -111,34 +134,25 @@ zend_function_entry amqp_decimal_class_functions[] = {
 	PHP_ME(amqp_decimal_class, getExponent, 	arginfo_amqp_decimal_class_getExponent,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_decimal_class, getSignificand, 	arginfo_amqp_decimal_class_getSignificand,	ZEND_ACC_PUBLIC)
 
-	{NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 
 
 PHP_MINIT_FUNCTION(amqp_decimal)
 {
-	zend_class_entry ce;
+    zend_class_entry ce;
 
-	INIT_CLASS_ENTRY(ce, "AMQPDecimal", amqp_decimal_class_functions);
-	this_ce = zend_register_internal_class(&ce TSRMLS_CC);
-	this_ce->ce_flags = this_ce->ce_flags | ZEND_ACC_FINAL;
+    INIT_CLASS_ENTRY(ce, "AMQPDecimal", amqp_decimal_class_functions);
+    this_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    this_ce->ce_flags = this_ce->ce_flags | ZEND_ACC_FINAL;
 
     zend_declare_class_constant_long(this_ce, ZEND_STRL("EXPONENT_MIN"), AMQP_DECIMAL_EXPONENT_MIN TSRMLS_CC);
     zend_declare_class_constant_long(this_ce, ZEND_STRL("EXPONENT_MAX"), AMQP_DECIMAL_EXPONENT_MAX TSRMLS_CC);
     zend_declare_class_constant_long(this_ce, ZEND_STRL("SIGNIFICAND_MIN"), AMQP_DECIMAL_SIGNIFICAND_MIN TSRMLS_CC);
     zend_declare_class_constant_long(this_ce, ZEND_STRL("SIGNIFICAND_MAX"), AMQP_DECIMAL_SIGNIFICAND_MAX TSRMLS_CC);
 
-	zend_declare_property_long(this_ce, ZEND_STRL("exponent"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_long(this_ce, ZEND_STRL("significand"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_long(this_ce, ZEND_STRL("exponent"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_long(this_ce, ZEND_STRL("significand"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	return SUCCESS;
+    return SUCCESS;
 }
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<6
-*/

--- a/amqp_decimal.h
+++ b/amqp_decimal.h
@@ -25,12 +25,3 @@
 extern zend_class_entry *amqp_decimal_class_entry;
 
 PHP_MINIT_FUNCTION(amqp_decimal);
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_envelope.c
+++ b/amqp_envelope.c
@@ -21,7 +21,7 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -30,33 +30,31 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# if PHP_VERSION_ID >= 80000
-#  include "main/php_stdint.h"
-# else
-#  include "win32/php_stdint.h"
-# endif
-# include "win32/signal.h"
+    #if PHP_VERSION_ID >= 80000
+        #include "main/php_stdint.h"
+    #else
+        #include "win32/php_stdint.h"
+    #endif
+    #include "win32/signal.h"
 #else
 
-# include <signal.h>
-# include <stdint.h>
+    #include <signal.h>
+    #include <stdint.h>
 
 #endif
 
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/framing.h>
+    #include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/framing.h>
 #else
-#include <amqp.h>
-#include <amqp_framing.h>
+    #include <amqp.h>
+    #include <amqp_framing.h>
 #endif
 
 #ifdef PHP_WIN32
-# include "win32/unistd.h"
+    #include "win32/unistd.h"
 #else
-
-# include <unistd.h>
-
+    #include <unistd.h>
 #endif
 
 #include "amqp_envelope.h"
@@ -76,19 +74,54 @@ void convert_amqp_envelope_to_zval(amqp_envelope_t *amqp_envelope, zval *envelop
     amqp_basic_properties_t *p = &amqp_envelope->message.properties;
     amqp_message_t *message = &amqp_envelope->message;
 
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(envelope), ZEND_STRL("body"), (const char *) message->body.bytes, (size_t) message->body.len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(envelope),
+        ZEND_STRL("body"),
+        (const char *) message->body.bytes,
+        (size_t) message->body.len TSRMLS_CC
+    );
 
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(envelope), ZEND_STRL("consumer_tag"), (const char *) amqp_envelope->consumer_tag.bytes, (size_t) amqp_envelope->consumer_tag.len TSRMLS_CC);
-    zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(envelope), ZEND_STRL("delivery_tag"), (zend_long) amqp_envelope->delivery_tag TSRMLS_CC);
-    zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(envelope), ZEND_STRL("is_redelivery"), (zend_long) amqp_envelope->redelivered TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(envelope), ZEND_STRL("exchange_name"), (const char *) amqp_envelope->exchange.bytes, (size_t) amqp_envelope->exchange.len TSRMLS_CC);
-    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(envelope), ZEND_STRL("routing_key"), (const char *) amqp_envelope->routing_key.bytes, (size_t) amqp_envelope->routing_key.len TSRMLS_CC);
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(envelope),
+        ZEND_STRL("consumer_tag"),
+        (const char *) amqp_envelope->consumer_tag.bytes,
+        (size_t) amqp_envelope->consumer_tag.len TSRMLS_CC
+    );
+    zend_update_property_long(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(envelope),
+        ZEND_STRL("delivery_tag"),
+        (zend_long) amqp_envelope->delivery_tag TSRMLS_CC
+    );
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(envelope),
+        ZEND_STRL("is_redelivery"),
+        (zend_long) amqp_envelope->redelivered TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(envelope),
+        ZEND_STRL("exchange_name"),
+        (const char *) amqp_envelope->exchange.bytes,
+        (size_t) amqp_envelope->exchange.len TSRMLS_CC
+    );
+    zend_update_property_stringl(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(envelope),
+        ZEND_STRL("routing_key"),
+        (const char *) amqp_envelope->routing_key.bytes,
+        (size_t) amqp_envelope->routing_key.len TSRMLS_CC
+    );
 
     php_amqp_basic_properties_extract(p, envelope TSRMLS_CC);
 }
 
 /* {{{ proto AMQPEnvelope::__construct() */
-static PHP_METHOD(amqp_envelope_class, __construct) {
+static PHP_METHOD(amqp_envelope_class, __construct)
+{
     PHP_AMQP_NOPARAMS();
 
     /* BC */
@@ -98,12 +131,13 @@ static PHP_METHOD(amqp_envelope_class, __construct) {
 
 
 /* {{{ proto AMQPEnvelope::getBody()*/
-static PHP_METHOD(amqp_envelope_class, getBody) {
+static PHP_METHOD(amqp_envelope_class, getBody)
+{
     zval rv;
 
     PHP_AMQP_NOPARAMS();
 
-    zval* zv = PHP_AMQP_READ_THIS_PROP("body");
+    zval *zv = PHP_AMQP_READ_THIS_PROP("body");
 
     if (Z_STRLEN_P(zv) == 0) {
         /* BC */
@@ -115,7 +149,8 @@ static PHP_METHOD(amqp_envelope_class, getBody) {
 /* }}} */
 
 /* {{{ proto AMQPEnvelope::getRoutingKey() */
-static PHP_METHOD(amqp_envelope_class, getRoutingKey) {
+static PHP_METHOD(amqp_envelope_class, getRoutingKey)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("routing_key");
@@ -123,7 +158,8 @@ static PHP_METHOD(amqp_envelope_class, getRoutingKey) {
 /* }}} */
 
 /* {{{ proto AMQPEnvelope::getDeliveryTag() */
-static PHP_METHOD(amqp_envelope_class, getDeliveryTag) {
+static PHP_METHOD(amqp_envelope_class, getDeliveryTag)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("delivery_tag");
@@ -131,7 +167,8 @@ static PHP_METHOD(amqp_envelope_class, getDeliveryTag) {
 /* }}} */
 
 /* {{{ proto AMQPEnvelope::getConsumerTag() */
-static PHP_METHOD(amqp_envelope_class, getConsumerTag) {
+static PHP_METHOD(amqp_envelope_class, getConsumerTag)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("consumer_tag");
@@ -139,7 +176,8 @@ static PHP_METHOD(amqp_envelope_class, getConsumerTag) {
 /* }}} */
 
 /* {{{ proto AMQPEnvelope::getExchangeName() */
-static PHP_METHOD(amqp_envelope_class, getExchangeName) {
+static PHP_METHOD(amqp_envelope_class, getExchangeName)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("exchange_name");
@@ -147,7 +185,8 @@ static PHP_METHOD(amqp_envelope_class, getExchangeName) {
 /* }}} */
 
 /* {{{ proto AMQPEnvelope::isRedelivery() */
-static PHP_METHOD(amqp_envelope_class, isRedelivery) {
+static PHP_METHOD(amqp_envelope_class, isRedelivery)
+{
     zval rv;
     PHP_AMQP_NOPARAMS();
     PHP_AMQP_RETURN_THIS_PROP("is_redelivery");
@@ -156,18 +195,19 @@ static PHP_METHOD(amqp_envelope_class, isRedelivery) {
 
 
 /* {{{ proto AMQPEnvelope::getHeader(string name) */
-static PHP_METHOD(amqp_envelope_class, getHeader) {
+static PHP_METHOD(amqp_envelope_class, getHeader)
+{
     zval rv;
 
-	char *key;
-	size_t key_len;
+    char *key;
+    size_t key_len;
     zval *tmp = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
         return;
     }
 
-    zval* zv = PHP_AMQP_READ_THIS_PROP_CE("headers", amqp_basic_properties_class_entry);
+    zval *zv = PHP_AMQP_READ_THIS_PROP_CE("headers", amqp_basic_properties_class_entry);
 
     /* Look for the hash key */
     if ((tmp = zend_hash_str_find(HASH_OF(zv), key, key_len)) == NULL) {
@@ -180,20 +220,21 @@ static PHP_METHOD(amqp_envelope_class, getHeader) {
 
 
 /* {{{ proto AMQPEnvelope::hasHeader(string name) */
-static PHP_METHOD(amqp_envelope_class, hasHeader) {
+static PHP_METHOD(amqp_envelope_class, hasHeader)
+{
     zval rv;
 
-	char *key;
-	size_t key_len;
+    char *key;
+    size_t key_len;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
         return;
     }
 
-    zval* zv = PHP_AMQP_READ_THIS_PROP_CE("headers", amqp_basic_properties_class_entry);
+    zval *zv = PHP_AMQP_READ_THIS_PROP_CE("headers", amqp_basic_properties_class_entry);
 
     /* Look for the hash key */
-	if (zend_hash_str_find(HASH_OF(zv), key, key_len) == NULL) {
+    if (zend_hash_str_find(HASH_OF(zv), key, key_len) == NULL) {
         RETURN_FALSE;
     }
 
@@ -225,33 +266,34 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_envelope_class_isRedelivery, ZEND_SEND_BY_VA
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_envelope_class_getHeader, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-                ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, name)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_envelope_class_hasHeader, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-                ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, name)
 ZEND_END_ARG_INFO()
 
 
 zend_function_entry amqp_envelope_class_functions[] = {
-        PHP_ME(amqp_envelope_class, __construct, arginfo_amqp_envelope_class__construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(amqp_envelope_class, __construct, arginfo_amqp_envelope_class__construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
 
-        PHP_ME(amqp_envelope_class, getBody, arginfo_amqp_envelope_class_getBody, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, getBody, arginfo_amqp_envelope_class_getBody, ZEND_ACC_PUBLIC)
 
-        PHP_ME(amqp_envelope_class, getRoutingKey, arginfo_amqp_envelope_class_getRoutingKey, ZEND_ACC_PUBLIC)
-        PHP_ME(amqp_envelope_class, getConsumerTag, arginfo_amqp_envelope_class_getConsumerTag, ZEND_ACC_PUBLIC)
-        PHP_ME(amqp_envelope_class, getDeliveryTag, arginfo_amqp_envelope_class_getDeliveryTag, ZEND_ACC_PUBLIC)
-        PHP_ME(amqp_envelope_class, getExchangeName, arginfo_amqp_envelope_class_getExchangeName, ZEND_ACC_PUBLIC)
-        PHP_ME(amqp_envelope_class, isRedelivery, arginfo_amqp_envelope_class_isRedelivery, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, getRoutingKey, arginfo_amqp_envelope_class_getRoutingKey, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, getConsumerTag, arginfo_amqp_envelope_class_getConsumerTag, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, getDeliveryTag, arginfo_amqp_envelope_class_getDeliveryTag, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, getExchangeName, arginfo_amqp_envelope_class_getExchangeName, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, isRedelivery, arginfo_amqp_envelope_class_isRedelivery, ZEND_ACC_PUBLIC)
 
-        PHP_ME(amqp_envelope_class, getHeader, arginfo_amqp_envelope_class_getHeader, ZEND_ACC_PUBLIC)
-        PHP_ME(amqp_envelope_class, hasHeader, arginfo_amqp_envelope_class_hasHeader, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, getHeader, arginfo_amqp_envelope_class_getHeader, ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_envelope_class, hasHeader, arginfo_amqp_envelope_class_hasHeader, ZEND_ACC_PUBLIC)
 
-        {NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 
 
-PHP_MINIT_FUNCTION (amqp_envelope) {
+PHP_MINIT_FUNCTION(amqp_envelope)
+{
     zend_class_entry ce;
 
     INIT_CLASS_ENTRY(ce, "AMQPEnvelope", amqp_envelope_class_functions);
@@ -267,13 +309,3 @@ PHP_MINIT_FUNCTION (amqp_envelope) {
 
     return SUCCESS;
 }
-
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_envelope.h
+++ b/amqp_envelope.h
@@ -28,13 +28,3 @@ extern zend_class_entry *amqp_envelope_class_entry;
 void convert_amqp_envelope_to_zval(amqp_envelope_t *amqp_envelope, zval *envelope TSRMLS_DC);
 
 PHP_MINIT_FUNCTION(amqp_envelope);
-
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -21,7 +21,7 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -30,28 +30,28 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# if PHP_VERSION_ID >= 80000
-#  include "main/php_stdint.h"
-# else
-#  include "win32/php_stdint.h"
-# endif
-# include "win32/signal.h"
+    #if PHP_VERSION_ID >= 80000
+        #include "main/php_stdint.h"
+    #else
+        #include "win32/php_stdint.h"
+    #endif
+    #include "win32/signal.h"
 #else
-# include <signal.h>
-# include <stdint.h>
+    #include <signal.h>
+    #include <stdint.h>
 #endif
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/framing.h>
+    #include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/framing.h>
 #else
-#include <amqp.h>
-#include <amqp_framing.h>
+    #include <amqp.h>
+    #include <amqp_framing.h>
 #endif
 
 #ifdef PHP_WIN32
-# include "win32/unistd.h"
+    #include "win32/unistd.h"
 #else
-# include <unistd.h>
+    #include <unistd.h>
 #endif
 
 #include "php_amqp.h"
@@ -67,27 +67,32 @@ zend_class_entry *amqp_exchange_class_entry;
 create Exchange   */
 static PHP_METHOD(amqp_exchange_class, __construct)
 {
-	zval rv;
+    zval rv;
 
-	zval arguments;
+    zval arguments;
 
-	zval *channelObj;
-	amqp_channel_resource *channel_resource;
+    zval *channelObj;
+    amqp_channel_resource *channel_resource;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &channelObj, amqp_channel_class_entry) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &channelObj, amqp_channel_class_entry) == FAILURE) {
+        return;
+    }
 
-	ZVAL_UNDEF(&arguments);
-	array_init(&arguments);
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), &arguments TSRMLS_CC);
-	zval_ptr_dtor(&arguments);
+    ZVAL_UNDEF(&arguments);
+    array_init(&arguments);
+    zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), &arguments TSRMLS_CC);
+    zval_ptr_dtor(&arguments);
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channelObj);
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not create exchange.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channelObj);
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not create exchange.");
 
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("channel"), channelObj TSRMLS_CC);
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connection"), PHP_AMQP_READ_OBJ_PROP(amqp_channel_class_entry, channelObj, "connection") TSRMLS_CC);
+    zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("channel"), channelObj TSRMLS_CC);
+    zend_update_property(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("connection"),
+        PHP_AMQP_READ_OBJ_PROP(amqp_channel_class_entry, channelObj, "connection") TSRMLS_CC
+    );
 }
 /* }}} */
 
@@ -96,16 +101,16 @@ static PHP_METHOD(amqp_exchange_class, __construct)
 Get the exchange name */
 static PHP_METHOD(amqp_exchange_class, getName)
 {
-	zval rv;
+    zval rv;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") > 0) {
-		PHP_AMQP_RETURN_THIS_PROP("name");
-	} else {
-		/* BC */
-		RETURN_FALSE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") > 0) {
+        PHP_AMQP_RETURN_THIS_PROP("name");
+    } else {
+        /* BC */
+        RETURN_FALSE;
+    }
 }
 /* }}} */
 
@@ -114,21 +119,25 @@ static PHP_METHOD(amqp_exchange_class, getName)
 Set the exchange name */
 static PHP_METHOD(amqp_exchange_class, setName)
 {
-	char *name = NULL;
-	size_t name_len = 0;
+    char *name = NULL;
+    size_t name_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &name, &name_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &name, &name_len) == FAILURE) {
+        return;
+    }
 
-	/* Verify that the name is not null and not an empty string */
-	if (name_len > 255) {
-		zend_throw_exception(amqp_exchange_exception_class_entry, "Invalid exchange name given, must be less than 255 characters long.", 0 TSRMLS_CC);
-		return;
-	}
+    /* Verify that the name is not null and not an empty string */
+    if (name_len > 255) {
+        zend_throw_exception(
+            amqp_exchange_exception_class_entry,
+            "Invalid exchange name given, must be less than 255 characters long.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	/* Set the exchange name */
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("name"), name, name_len TSRMLS_CC);
+    /* Set the exchange name */
+    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("name"), name, name_len TSRMLS_CC);
 }
 /* }}} */
 
@@ -137,29 +146,29 @@ static PHP_METHOD(amqp_exchange_class, setName)
 Get the exchange parameters */
 static PHP_METHOD(amqp_exchange_class, getFlags)
 {
-	zval rv;
+    zval rv;
 
-	zend_long flags = AMQP_NOPARAM;
+    zend_long flags = AMQP_NOPARAM;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("passive")) {
-		flags |= AMQP_PASSIVE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("passive")) {
+        flags |= AMQP_PASSIVE;
+    }
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("durable")) {
-		flags |= AMQP_DURABLE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("durable")) {
+        flags |= AMQP_DURABLE;
+    }
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete")) {
-		flags |= AMQP_AUTODELETE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete")) {
+        flags |= AMQP_AUTODELETE;
+    }
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("internal")) {
-		flags |= AMQP_INTERNAL;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("internal")) {
+        flags |= AMQP_INTERNAL;
+    }
 
-	RETURN_LONG(flags);
+    RETURN_LONG(flags);
 }
 /* }}} */
 
@@ -168,20 +177,40 @@ static PHP_METHOD(amqp_exchange_class, getFlags)
 Set the exchange parameters */
 static PHP_METHOD(amqp_exchange_class, setFlags)
 {
-	zend_long flags = AMQP_NOPARAM;
-	zend_bool flags_is_null = 1;
+    zend_long flags = AMQP_NOPARAM;
+    zend_bool flags_is_null = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l!", &flags, &flags_is_null) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l!", &flags, &flags_is_null) == FAILURE) {
+        return;
+    }
 
-	/* Set the flags based on the bitmask we were given */
-	flags = flags ? flags & PHP_AMQP_EXCHANGE_FLAGS : flags;
+    /* Set the flags based on the bitmask we were given */
+    flags = flags ? flags & PHP_AMQP_EXCHANGE_FLAGS : flags;
 
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("passive"), IS_PASSIVE(flags) TSRMLS_CC);
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("durable"), IS_DURABLE(flags) TSRMLS_CC);
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("auto_delete"), IS_AUTODELETE(flags) TSRMLS_CC);
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("internal"), IS_INTERNAL(flags) TSRMLS_CC);
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("passive"),
+        IS_PASSIVE(flags) TSRMLS_CC
+    );
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("durable"),
+        IS_DURABLE(flags) TSRMLS_CC
+    );
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("auto_delete"),
+        IS_AUTODELETE(flags) TSRMLS_CC
+    );
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("internal"),
+        IS_INTERNAL(flags) TSRMLS_CC
+    );
 }
 /* }}} */
 
@@ -190,16 +219,16 @@ static PHP_METHOD(amqp_exchange_class, setFlags)
 Get the exchange type */
 static PHP_METHOD(amqp_exchange_class, getType)
 {
-	zval rv;
+    zval rv;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	if (PHP_AMQP_READ_THIS_PROP_STRLEN("type") > 0) {
-		PHP_AMQP_RETURN_THIS_PROP("type");
-	} else {
-		/* BC */
-		RETURN_FALSE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_STRLEN("type") > 0) {
+        PHP_AMQP_RETURN_THIS_PROP("type");
+    } else {
+        /* BC */
+        RETURN_FALSE;
+    }
 }
 /* }}} */
 
@@ -208,13 +237,14 @@ static PHP_METHOD(amqp_exchange_class, getType)
 Set the exchange type */
 static PHP_METHOD(amqp_exchange_class, setType)
 {
-	char *type = NULL;	size_t type_len = 0;
+    char *type = NULL;
+    size_t type_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &type, &type_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &type, &type_len) == FAILURE) {
+        return;
+    }
 
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("type"), type, type_len TSRMLS_CC);
+    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("type"), type, type_len TSRMLS_CC);
 }
 /* }}} */
 
@@ -223,41 +253,42 @@ static PHP_METHOD(amqp_exchange_class, setType)
 Get the exchange argument referenced by key */
 static PHP_METHOD(amqp_exchange_class, getArgument)
 {
-	zval rv;
+    zval rv;
 
-	zval *tmp = NULL;
+    zval *tmp = NULL;
 
-	char *key;	size_t key_len;
+    char *key;
+    size_t key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
+        return;
+    }
 
-	if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
-		RETURN_FALSE;
-	}
+    if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
+        RETURN_FALSE;
+    }
 
-	RETURN_ZVAL(tmp, 1, 0);
+    RETURN_ZVAL(tmp, 1, 0);
 }
 /* }}} */
 
 /* {{{ proto AMQPExchange::hasArgument(string key) */
 static PHP_METHOD(amqp_exchange_class, hasArgument)
 {
-	zval rv;
-	zval *tmp = NULL;
-	char *key;
-	size_t key_len;
+    zval rv;
+    zval *tmp = NULL;
+    char *key;
+    size_t key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
+        return;
+    }
 
-	if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
-		RETURN_FALSE;
-	}
+    if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
+        RETURN_FALSE;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -265,9 +296,9 @@ static PHP_METHOD(amqp_exchange_class, hasArgument)
 Get the exchange arguments */
 static PHP_METHOD(amqp_exchange_class, getArguments)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("arguments");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("arguments");
 }
 /* }}} */
 
@@ -276,15 +307,15 @@ static PHP_METHOD(amqp_exchange_class, getArguments)
 Overwrite all exchange arguments with given args */
 static PHP_METHOD(amqp_exchange_class, setArguments)
 {
-	zval *zvalArguments;
+    zval *zvalArguments;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/", &zvalArguments) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/", &zvalArguments) == FAILURE) {
+        return;
+    }
 
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), zvalArguments TSRMLS_CC);
+    zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), zvalArguments TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -292,35 +323,38 @@ static PHP_METHOD(amqp_exchange_class, setArguments)
 /* {{{ proto AMQPExchange::setArgument(key, value) */
 static PHP_METHOD(amqp_exchange_class, setArgument)
 {
-	zval rv;
+    zval rv;
 
-	char *key= NULL;    size_t key_len = 0;
-	zval *value = NULL;
+    char *key = NULL;
+    size_t key_len = 0;
+    zval *value = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz",
-							  &key, &key_len,
-							  &value) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz", &key, &key_len, &value) == FAILURE) {
+        return;
+    }
 
-	switch (Z_TYPE_P(value)) {
-		case IS_NULL:
-			zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
-			break;
-		case IS_TRUE:
-		case IS_FALSE:
-		case IS_LONG:
-		case IS_DOUBLE:
-		case IS_STRING:
-			zend_hash_str_add(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len, value);
-			Z_TRY_ADDREF_P(value);
-			break;
-		default:
-			zend_throw_exception(amqp_exchange_exception_class_entry, "The value parameter must be of type NULL, int, double or string.", 0 TSRMLS_CC);
-			return;
-	}
+    switch (Z_TYPE_P(value)) {
+        case IS_NULL:
+            zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
+            break;
+        case IS_TRUE:
+        case IS_FALSE:
+        case IS_LONG:
+        case IS_DOUBLE:
+        case IS_STRING:
+            zend_hash_str_add(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len, value);
+            Z_TRY_ADDREF_P(value);
+            break;
+        default:
+            zend_throw_exception(
+                amqp_exchange_exception_class_entry,
+                "The value parameter must be of type NULL, int, double or string.",
+                0 TSRMLS_CC
+            );
+            return;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -330,55 +364,63 @@ declare Exchange
 */
 static PHP_METHOD(amqp_exchange_class, declareExchange)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
-	amqp_table_t *arguments;
+    amqp_channel_resource *channel_resource;
+    amqp_table_t *arguments;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not declare exchange.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not declare exchange.");
 
-	/* Check that the exchange has a name */
-	if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") < 1) {
-		zend_throw_exception(amqp_exchange_exception_class_entry, "Could not declare exchange. Exchanges must have a name.", 0 TSRMLS_CC);
-		return;
-	}
+    /* Check that the exchange has a name */
+    if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") < 1) {
+        zend_throw_exception(
+            amqp_exchange_exception_class_entry,
+            "Could not declare exchange. Exchanges must have a name.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	/* Check that the exchange has a name */
-	if (PHP_AMQP_READ_THIS_PROP_STRLEN("type") < 1) {
-		zend_throw_exception(amqp_exchange_exception_class_entry, "Could not declare exchange. Exchanges must have a type.", 0 TSRMLS_CC);
-		return;
-	}
+    /* Check that the exchange has a name */
+    if (PHP_AMQP_READ_THIS_PROP_STRLEN("type") < 1) {
+        zend_throw_exception(
+            amqp_exchange_exception_class_entry,
+            "Could not declare exchange. Exchanges must have a type.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	arguments = php_amqp_type_convert_zval_to_amqp_table(PHP_AMQP_READ_THIS_PROP("arguments") TSRMLS_CC);
+    arguments = php_amqp_type_convert_zval_to_amqp_table(PHP_AMQP_READ_THIS_PROP("arguments") TSRMLS_CC);
 
-	amqp_exchange_declare(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("type")),
-		PHP_AMQP_READ_THIS_PROP_BOOL("passive"),
-		PHP_AMQP_READ_THIS_PROP_BOOL("durable"),
-		PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete"),
-		PHP_AMQP_READ_THIS_PROP_BOOL("internal"),
-		*arguments
-	);
+    amqp_exchange_declare(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("type")),
+        PHP_AMQP_READ_THIS_PROP_BOOL("passive"),
+        PHP_AMQP_READ_THIS_PROP_BOOL("durable"),
+        PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete"),
+        PHP_AMQP_READ_THIS_PROP_BOOL("internal"),
+        *arguments
+    );
 
-	amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-	php_amqp_type_free_amqp_table(arguments);
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_type_free_amqp_table(arguments);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
+        return;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -388,41 +430,39 @@ delete Exchange
 */
 static PHP_METHOD(amqp_exchange_class, delete)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	char *name = NULL;
-	size_t name_len = 0;
-	zend_long flags = AMQP_NOPARAM;
+    char *name = NULL;
+    size_t name_len = 0;
+    zend_long flags = AMQP_NOPARAM;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|sl",
-							  &name, &name_len,
-							  &flags) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|sl", &name, &name_len, &flags) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not delete exchange.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not delete exchange.");
 
- 	amqp_exchange_delete(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(name_len ? name : PHP_AMQP_READ_THIS_PROP_STR("name")),
-		(AMQP_IFUNUSED & flags) ? 1 : 0
-	);
+    amqp_exchange_delete(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(name_len ? name : PHP_AMQP_READ_THIS_PROP_STR("name")),
+        (AMQP_IFUNUSED & flags) ? 1 : 0
+    );
 
-	amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -432,213 +472,233 @@ publish into Exchange
 */
 static PHP_METHOD(amqp_exchange_class, publish)
 {
-	zval rv;
+    zval rv;
 
-	zval *ini_arr = NULL;
-	zval *tmp = NULL;
+    zval *ini_arr = NULL;
+    zval *tmp = NULL;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	char *key_name = NULL;
-	size_t key_len = 0;
-	char *msg = NULL;
-	size_t msg_len = 0;
-	zend_long flags = AMQP_NOPARAM;
-
-#ifndef PHP_WIN32
-	/* Storage for previous signal handler during SIGPIPE override */
-	void * old_handler;
-#endif
-
-	amqp_basic_properties_t props;
-
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s!la/",
-							  &msg, &msg_len,
-							  &key_name, &key_len,
-							  &flags,
-							  &ini_arr) == FAILURE) {
-		return;
-	}
-
-	/* By default (and for BC) content type is text/plain (may be skipped at all, then set props._flags to 0) */
-	props.content_type = amqp_cstring_bytes("text/plain");
-	props._flags       = AMQP_BASIC_CONTENT_TYPE_FLAG;
-
-	props.headers.entries = 0;
-
-	{
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "content_type", sizeof("content_type") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.content_type = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_CONTENT_TYPE_FLAG;
-		}
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "content_encoding", sizeof("content_encoding") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.content_encoding = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_CONTENT_ENCODING_FLAG;
-		}
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "message_id", sizeof("message_id") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.message_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_MESSAGE_ID_FLAG;
-		}
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "user_id", sizeof("user_id") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.user_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_USER_ID_FLAG;
-		}
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "app_id", sizeof("app_id") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.app_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_APP_ID_FLAG;
-		}
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "delivery_mode", sizeof("delivery_mode") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_long(tmp);
-
-		props.delivery_mode = (uint8_t)Z_LVAL_P(tmp);
-		props._flags |= AMQP_BASIC_DELIVERY_MODE_FLAG;
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "priority", sizeof("priority") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_long(tmp);
-
-		props.priority = (uint8_t)Z_LVAL_P(tmp);
-		props._flags |= AMQP_BASIC_PRIORITY_FLAG;
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "timestamp", sizeof("timestamp") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_long(tmp);
-
-		props.timestamp = (uint64_t)Z_LVAL_P(tmp);
-		props._flags |= AMQP_BASIC_TIMESTAMP_FLAG;
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "expiration", sizeof("expiration") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.expiration = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_EXPIRATION_FLAG;
-		}
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "type", sizeof("type") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.type = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_TYPE_FLAG;
-		}
-	}
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "reply_to", sizeof("reply_to") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.reply_to = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_REPLY_TO_FLAG;
-		}
-	}
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "correlation_id", sizeof("correlation_id") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_string(tmp);
-
-		if (Z_STRLEN_P(tmp) > 0) {
-			props.correlation_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
-			props._flags |= AMQP_BASIC_CORRELATION_ID_FLAG;
-		}
-	}
-
-	}
-
-	amqp_table_t *headers = NULL;
-
-	if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "headers", sizeof("headers") - 1)) != NULL) {
-		SEPARATE_ZVAL(tmp);
-		convert_to_array(tmp);
-
-		headers = php_amqp_type_convert_zval_to_amqp_table(tmp TSRMLS_CC);
-
-		props._flags |= AMQP_BASIC_HEADERS_FLAG;
-		props.headers = *headers;
-	}
-
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not publish to exchange.");
+    char *key_name = NULL;
+    size_t key_len = 0;
+    char *msg = NULL;
+    size_t msg_len = 0;
+    zend_long flags = AMQP_NOPARAM;
 
 #ifndef PHP_WIN32
-	/* Start ignoring SIGPIPE */
-	old_handler = signal(SIGPIPE, SIG_IGN);
+    /* Storage for previous signal handler during SIGPIPE override */
+    void *old_handler;
 #endif
 
-	zval *exchange_name = PHP_AMQP_READ_THIS_PROP("name");
+    amqp_basic_properties_t props;
 
-	/* NOTE: basic.publish is asynchronous and thus will not indicate failure if something goes wrong on the broker */
-	int status = amqp_basic_publish(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		(Z_TYPE_P(exchange_name) == IS_STRING && Z_STRLEN_P(exchange_name) > 0 ? amqp_cstring_bytes(Z_STRVAL_P(exchange_name)) : amqp_empty_bytes),	/* exchange */
-		(key_len > 0 ? amqp_cstring_bytes(key_name) : amqp_empty_bytes), /* routing key */
-		(AMQP_MANDATORY & flags) ? 1 : 0, /* mandatory */
-		(AMQP_IMMEDIATE & flags) ? 1 : 0, /* immediate */
-		&props,
-		php_amqp_type_char_to_amqp_long(msg, msg_len) /* message body */
-	);
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS() TSRMLS_CC,
+            "s|s!la/",
+            &msg,
+            &msg_len,
+            &key_name,
+            &key_len,
+            &flags,
+            &ini_arr
+        ) == FAILURE) {
+        return;
+    }
 
-	if (headers) {
-		php_amqp_type_free_amqp_table(headers);
-	}
+    /* By default (and for BC) content type is text/plain (may be skipped at all, then set props._flags to 0) */
+    props.content_type = amqp_cstring_bytes("text/plain");
+    props._flags = AMQP_BASIC_CONTENT_TYPE_FLAG;
+
+    props.headers.entries = 0;
+
+    {
+        if (ini_arr &&
+            (tmp = zend_hash_str_find(HASH_OF(ini_arr), "content_type", sizeof("content_type") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.content_type = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_CONTENT_TYPE_FLAG;
+            }
+        }
+
+        if (ini_arr &&
+            (tmp = zend_hash_str_find(HASH_OF(ini_arr), "content_encoding", sizeof("content_encoding") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.content_encoding = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_CONTENT_ENCODING_FLAG;
+            }
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "message_id", sizeof("message_id") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.message_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_MESSAGE_ID_FLAG;
+            }
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "user_id", sizeof("user_id") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.user_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_USER_ID_FLAG;
+            }
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "app_id", sizeof("app_id") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.app_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_APP_ID_FLAG;
+            }
+        }
+
+        if (ini_arr &&
+            (tmp = zend_hash_str_find(HASH_OF(ini_arr), "delivery_mode", sizeof("delivery_mode") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_long(tmp);
+
+            props.delivery_mode = (uint8_t) Z_LVAL_P(tmp);
+            props._flags |= AMQP_BASIC_DELIVERY_MODE_FLAG;
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "priority", sizeof("priority") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_long(tmp);
+
+            props.priority = (uint8_t) Z_LVAL_P(tmp);
+            props._flags |= AMQP_BASIC_PRIORITY_FLAG;
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "timestamp", sizeof("timestamp") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_long(tmp);
+
+            props.timestamp = (uint64_t) Z_LVAL_P(tmp);
+            props._flags |= AMQP_BASIC_TIMESTAMP_FLAG;
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "expiration", sizeof("expiration") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.expiration = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_EXPIRATION_FLAG;
+            }
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "type", sizeof("type") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.type = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_TYPE_FLAG;
+            }
+        }
+
+        if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "reply_to", sizeof("reply_to") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.reply_to = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_REPLY_TO_FLAG;
+            }
+        }
+        if (ini_arr &&
+            (tmp = zend_hash_str_find(HASH_OF(ini_arr), "correlation_id", sizeof("correlation_id") - 1)) != NULL) {
+            SEPARATE_ZVAL(tmp);
+            convert_to_string(tmp);
+
+            if (Z_STRLEN_P(tmp) > 0) {
+                props.correlation_id = amqp_cstring_bytes(Z_STRVAL_P(tmp));
+                props._flags |= AMQP_BASIC_CORRELATION_ID_FLAG;
+            }
+        }
+    }
+
+    amqp_table_t *headers = NULL;
+
+    if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), "headers", sizeof("headers") - 1)) != NULL) {
+        SEPARATE_ZVAL(tmp);
+        convert_to_array(tmp);
+
+        headers = php_amqp_type_convert_zval_to_amqp_table(tmp TSRMLS_CC);
+
+        props._flags |= AMQP_BASIC_HEADERS_FLAG;
+        props.headers = *headers;
+    }
+
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not publish to exchange.");
 
 #ifndef PHP_WIN32
-	/* End ignoring of SIGPIPEs */
-	signal(SIGPIPE, old_handler);
+    /* Start ignoring SIGPIPE */
+    old_handler = signal(SIGPIPE, SIG_IGN);
 #endif
 
-	if (status != AMQP_STATUS_OK) {
-		/* Emulate library error */
-		amqp_rpc_reply_t res;
-		res.reply_type 	  = AMQP_RESPONSE_LIBRARY_EXCEPTION;
-		res.library_error = status;
+    zval *exchange_name = PHP_AMQP_READ_THIS_PROP("name");
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+    /* NOTE: basic.publish is asynchronous and thus will not indicate failure if something goes wrong on the broker */
+    int status = amqp_basic_publish(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        (Z_TYPE_P(exchange_name) == IS_STRING && Z_STRLEN_P(exchange_name) > 0
+             ? amqp_cstring_bytes(Z_STRVAL_P(exchange_name))
+             : amqp_empty_bytes),                                        /* exchange */
+        (key_len > 0 ? amqp_cstring_bytes(key_name) : amqp_empty_bytes), /* routing key */
+        (AMQP_MANDATORY & flags) ? 1 : 0,                                /* mandatory */
+        (AMQP_IMMEDIATE & flags) ? 1 : 0,                                /* immediate */
+        &props,
+        php_amqp_type_char_to_amqp_long(msg, msg_len) /* message body */
+    );
 
-		php_amqp_zend_throw_exception(res, amqp_exchange_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+    if (headers) {
+        php_amqp_type_free_amqp_table(headers);
+    }
 
-	RETURN_TRUE;
+#ifndef PHP_WIN32
+    /* End ignoring of SIGPIPEs */
+    signal(SIGPIPE, old_handler);
+#endif
+
+    if (status != AMQP_STATUS_OK) {
+        /* Emulate library error */
+        amqp_rpc_reply_t res;
+        res.reply_type = AMQP_RESPONSE_LIBRARY_EXCEPTION;
+        res.library_error = status;
+
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
+
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_exchange_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
+
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -648,57 +708,62 @@ bind exchange to exchange by routing key
 */
 static PHP_METHOD(amqp_exchange_class, bind)
 {
-	zval rv;
+    zval rv;
 
-	zval *zvalArguments = NULL;
+    zval *zvalArguments = NULL;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	char *src_name;
-	size_t src_name_len = 0;
-	char *keyname = NULL;
-	size_t keyname_len = 0;
+    char *src_name;
+    size_t src_name_len = 0;
+    char *keyname = NULL;
+    size_t keyname_len = 0;
 
-	amqp_table_t *arguments = NULL;
+    amqp_table_t *arguments = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s!a",
-							  &src_name, &src_name_len,
-							  &keyname, &keyname_len,
-							  &zvalArguments) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS() TSRMLS_CC,
+            "s|s!a",
+            &src_name,
+            &src_name_len,
+            &keyname,
+            &keyname_len,
+            &zvalArguments
+        ) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not bind to exchange.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not bind to exchange.");
 
-	if (zvalArguments) {
-		arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
-	}
+    if (zvalArguments) {
+        arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
+    }
 
-	amqp_exchange_bind(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		(src_name_len > 0 ? amqp_cstring_bytes(src_name) : amqp_empty_bytes),
-		(keyname != NULL && keyname_len > 0 ? amqp_cstring_bytes(keyname)  : amqp_empty_bytes),
-		(arguments ? *arguments : amqp_empty_table)
-	);
+    amqp_exchange_bind(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        (src_name_len > 0 ? amqp_cstring_bytes(src_name) : amqp_empty_bytes),
+        (keyname != NULL && keyname_len > 0 ? amqp_cstring_bytes(keyname) : amqp_empty_bytes),
+        (arguments ? *arguments : amqp_empty_table)
+    );
 
-	if (arguments) {
-		php_amqp_type_free_amqp_table(arguments);
-	}
+    if (arguments) {
+        php_amqp_type_free_amqp_table(arguments);
+    }
 
-	amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -707,57 +772,62 @@ remove exchange to exchange binding by routing key
 */
 static PHP_METHOD(amqp_exchange_class, unbind)
 {
-	zval rv;
+    zval rv;
 
-	zval *zvalArguments = NULL;
+    zval *zvalArguments = NULL;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	char *src_name;
-	size_t src_name_len = 0;
-	char *keyname = NULL;
-	size_t keyname_len = 0;
+    char *src_name;
+    size_t src_name_len = 0;
+    char *keyname = NULL;
+    size_t keyname_len = 0;
 
-	amqp_table_t *arguments = NULL;
+    amqp_table_t *arguments = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s!a",
-							  &src_name, &src_name_len,
-							  &keyname, &keyname_len,
-							  &zvalArguments) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS() TSRMLS_CC,
+            "s|s!a",
+            &src_name,
+            &src_name_len,
+            &keyname,
+            &keyname_len,
+            &zvalArguments
+        ) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not unbind from exchange.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not unbind from exchange.");
 
-	if (zvalArguments) {
-		arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
-	}
+    if (zvalArguments) {
+        arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
+    }
 
-	amqp_exchange_unbind(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		(src_name_len > 0 ? amqp_cstring_bytes(src_name) : amqp_empty_bytes),
-		(keyname != NULL && keyname_len > 0 ? amqp_cstring_bytes(keyname)  : amqp_empty_bytes),
-		(arguments ? *arguments : amqp_empty_table)
-	);
+    amqp_exchange_unbind(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        (src_name_len > 0 ? amqp_cstring_bytes(src_name) : amqp_empty_bytes),
+        (keyname != NULL && keyname_len > 0 ? amqp_cstring_bytes(keyname) : amqp_empty_bytes),
+        (arguments ? *arguments : amqp_empty_table)
+    );
 
-	if (arguments) {
-		php_amqp_type_free_amqp_table(arguments);
-	}
+    if (arguments) {
+        php_amqp_type_free_amqp_table(arguments);
+    }
 
-	amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_exchange_exception_class_entry TSRMLS_CC);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -765,9 +835,9 @@ static PHP_METHOD(amqp_exchange_class, unbind)
 Get the AMQPChannel object in use */
 static PHP_METHOD(amqp_exchange_class, getChannel)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("channel");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("channel");
 }
 /* }}} */
 
@@ -775,83 +845,83 @@ static PHP_METHOD(amqp_exchange_class, getChannel)
 Get the AMQPConnection object in use */
 static PHP_METHOD(amqp_exchange_class, getConnection)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("connection");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("connection");
 }
 /* }}} */
 
 /* amqp_exchange ARG_INFO definition */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class__construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_OBJ_INFO(0, amqp_channel, AMQPChannel, 0)
+    ZEND_ARG_OBJ_INFO(0, amqp_channel, AMQPChannel, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_getName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_setName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, exchange_name)
+    ZEND_ARG_INFO(0, exchange_name)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_getFlags, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_setFlags, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_getType, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_setType, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, exchange_type)
+    ZEND_ARG_INFO(0, exchange_type)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_getArgument, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, argument)
+    ZEND_ARG_INFO(0, argument)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_hasArgument, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, argument)
+    ZEND_ARG_INFO(0, argument)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_getArguments, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_setArgument, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
-				ZEND_ARG_INFO(0, key)
-				ZEND_ARG_INFO(0, value)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_setArguments, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_ARRAY_INFO(0, arguments, 0)
+    ZEND_ARG_ARRAY_INFO(0, arguments, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_declareExchange, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_bind, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
-				ZEND_ARG_INFO(0, exchange_name)
-				ZEND_ARG_INFO(0, routing_key)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, exchange_name)
+    ZEND_ARG_INFO(0, routing_key)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_unbind, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
-				ZEND_ARG_INFO(0, exchange_name)
-				ZEND_ARG_INFO(0, routing_key)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, exchange_name)
+    ZEND_ARG_INFO(0, routing_key)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_delete, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
-				ZEND_ARG_INFO(0, exchange_name)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, exchange_name)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_publish, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, message)
-				ZEND_ARG_INFO(0, routing_key)
-				ZEND_ARG_INFO(0, flags)
-				ZEND_ARG_ARRAY_INFO(0, headers, 0)
+    ZEND_ARG_INFO(0, message)
+    ZEND_ARG_INFO(0, routing_key)
+    ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_ARRAY_INFO(0, headers, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_getChannel, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
@@ -861,62 +931,54 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_exchange_class_getConnection, ZEND_SEND_BY_V
 ZEND_END_ARG_INFO()
 
 zend_function_entry amqp_exchange_class_functions[] = {
-		PHP_ME(amqp_exchange_class, __construct,	arginfo_amqp_exchange_class__construct, 	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, __construct,	arginfo_amqp_exchange_class__construct, 	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_exchange_class, getName,		arginfo_amqp_exchange_class_getName,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, setName,		arginfo_amqp_exchange_class_setName,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, getName,		arginfo_amqp_exchange_class_getName,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, setName,		arginfo_amqp_exchange_class_setName,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_exchange_class, getFlags,		arginfo_amqp_exchange_class_getFlags,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, setFlags,		arginfo_amqp_exchange_class_setFlags,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, getFlags,		arginfo_amqp_exchange_class_getFlags,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, setFlags,		arginfo_amqp_exchange_class_setFlags,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_exchange_class, getType,		arginfo_amqp_exchange_class_getType,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, setType,		arginfo_amqp_exchange_class_setType,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, getType,		arginfo_amqp_exchange_class_getType,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, setType,		arginfo_amqp_exchange_class_setType,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_exchange_class, getArgument,	arginfo_amqp_exchange_class_getArgument,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, getArguments,	arginfo_amqp_exchange_class_getArguments,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, setArgument,	arginfo_amqp_exchange_class_setArgument,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, setArguments,	arginfo_amqp_exchange_class_setArguments,	ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, hasArgument,	arginfo_amqp_exchange_class_hasArgument,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, getArgument,	arginfo_amqp_exchange_class_getArgument,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, getArguments,	arginfo_amqp_exchange_class_getArguments,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, setArgument,	arginfo_amqp_exchange_class_setArgument,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, setArguments,	arginfo_amqp_exchange_class_setArguments,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, hasArgument,	arginfo_amqp_exchange_class_hasArgument,	ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_exchange_class, declareExchange,arginfo_amqp_exchange_class_declareExchange,ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, bind,			arginfo_amqp_exchange_class_bind,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, unbind,			arginfo_amqp_exchange_class_unbind,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, delete,			arginfo_amqp_exchange_class_delete,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, publish,		arginfo_amqp_exchange_class_publish,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, declareExchange,arginfo_amqp_exchange_class_declareExchange,ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, bind,			arginfo_amqp_exchange_class_bind,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, unbind,			arginfo_amqp_exchange_class_unbind,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, delete,			arginfo_amqp_exchange_class_delete,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, publish,		arginfo_amqp_exchange_class_publish,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_exchange_class, getChannel,		arginfo_amqp_exchange_class_getChannel,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_exchange_class, getConnection,	arginfo_amqp_exchange_class_getConnection,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, getChannel,		arginfo_amqp_exchange_class_getChannel,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_exchange_class, getConnection,	arginfo_amqp_exchange_class_getConnection,	ZEND_ACC_PUBLIC)
 
-		PHP_MALIAS(amqp_exchange_class, declare, declareExchange, arginfo_amqp_exchange_class_declareExchange, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+    PHP_MALIAS(amqp_exchange_class, declare, declareExchange, arginfo_amqp_exchange_class_declareExchange, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 
-		{NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 
 PHP_MINIT_FUNCTION(amqp_exchange)
 {
-	zend_class_entry ce;
+    zend_class_entry ce;
 
-	INIT_CLASS_ENTRY(ce, "AMQPExchange", amqp_exchange_class_functions);
-	this_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    INIT_CLASS_ENTRY(ce, "AMQPExchange", amqp_exchange_class_functions);
+    this_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("connection"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("channel"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("connection"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("channel"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_stringl(this_ce, ZEND_STRL("name"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_bool(this_ce, ZEND_STRL("passive"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_bool(this_ce, ZEND_STRL("durable"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_bool(this_ce, ZEND_STRL("auto_delete"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_bool(this_ce, ZEND_STRL("internal"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("arguments"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_stringl(this_ce, ZEND_STRL("name"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_bool(this_ce, ZEND_STRL("passive"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_bool(this_ce, ZEND_STRL("durable"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_bool(this_ce, ZEND_STRL("auto_delete"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_bool(this_ce, ZEND_STRL("internal"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("arguments"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	return SUCCESS;
+    return SUCCESS;
 }
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_exchange.h
+++ b/amqp_exchange.h
@@ -24,12 +24,3 @@ extern zend_class_entry *amqp_exchange_class_entry;
 
 
 PHP_MINIT_FUNCTION(amqp_exchange);
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_methods_handling.c
+++ b/amqp_methods_handling.c
@@ -25,217 +25,246 @@
 #include "amqp_methods_handling.h"
 
 /* taken from rabbbitmq-c */
-static int amqp_id_in_reply_list(amqp_method_number_t expected, amqp_method_number_t *list) {
-	while (*list != 0) {
-		if (*list == expected) {
-			return 1;
-		}
-		list++;
-	}
-
-	return 0;
-}
-
-/* taken from rabbbitmq-c */
-int amqp_simple_wait_method_list_noblock(amqp_connection_state_t state,
-										 amqp_channel_t expected_channel,
-										 amqp_method_number_t *expected_methods,
-										 amqp_method_t *output,
-										 struct timeval *timeout) {
-	amqp_frame_t frame;
-	int res = amqp_simple_wait_frame_noblock(state, &frame, timeout);
-
-	if (AMQP_STATUS_OK != res) {
-		return res;
-	}
-
-	if (AMQP_FRAME_METHOD != frame.frame_type ||
-		expected_channel != frame.channel ||
-		!amqp_id_in_reply_list(frame.payload.method.id, expected_methods)) {
-
-		if (AMQP_CHANNEL_CLOSE_METHOD == frame.payload.method.id || AMQP_CONNECTION_CLOSE_METHOD == frame.payload.method.id) {
-
-			*output = frame.payload.method;
-
-			return AMQP_RESPONSE_SERVER_EXCEPTION;
-		}
-
-		return AMQP_STATUS_WRONG_METHOD;
-	}
-
-	*output = frame.payload.method;
-	return AMQP_STATUS_OK;
-}
-
-/* taken from rabbbitmq-c */
-int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
-                            amqp_channel_t expected_channel,
-                            amqp_method_number_t expected_method,
-                            amqp_method_t *output,
-                            struct timeval *timeout)
+static int amqp_id_in_reply_list(amqp_method_number_t expected, amqp_method_number_t *list)
 {
-  amqp_method_number_t expected_methods[] = { 0, 0 };
-  expected_methods[0] = expected_method;
+    while (*list != 0) {
+        if (*list == expected) {
+            return 1;
+        }
+        list++;
+    }
 
-  return amqp_simple_wait_method_list_noblock(state, expected_channel, expected_methods, output, timeout);
+    return 0;
+}
+
+/* taken from rabbbitmq-c */
+int amqp_simple_wait_method_list_noblock(
+    amqp_connection_state_t state,
+    amqp_channel_t expected_channel,
+    amqp_method_number_t *expected_methods,
+    amqp_method_t *output,
+    struct timeval *timeout
+)
+{
+    amqp_frame_t frame;
+    int res = amqp_simple_wait_frame_noblock(state, &frame, timeout);
+
+    if (AMQP_STATUS_OK != res) {
+        return res;
+    }
+
+    if (AMQP_FRAME_METHOD != frame.frame_type || expected_channel != frame.channel ||
+        !amqp_id_in_reply_list(frame.payload.method.id, expected_methods)) {
+
+        if (AMQP_CHANNEL_CLOSE_METHOD == frame.payload.method.id ||
+            AMQP_CONNECTION_CLOSE_METHOD == frame.payload.method.id) {
+
+            *output = frame.payload.method;
+
+            return AMQP_RESPONSE_SERVER_EXCEPTION;
+        }
+
+        return AMQP_STATUS_WRONG_METHOD;
+    }
+
+    *output = frame.payload.method;
+    return AMQP_STATUS_OK;
+}
+
+/* taken from rabbbitmq-c */
+int amqp_simple_wait_method_noblock(
+    amqp_connection_state_t state,
+    amqp_channel_t expected_channel,
+    amqp_method_number_t expected_method,
+    amqp_method_t *output,
+    struct timeval *timeout
+)
+{
+    amqp_method_number_t expected_methods[] = {0, 0};
+    expected_methods[0] = expected_method;
+
+    return amqp_simple_wait_method_list_noblock(state, expected_channel, expected_methods, output, timeout);
 }
 
 
-int php_amqp_handle_basic_return(char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel, amqp_method_t *method TSRMLS_DC) {
-	amqp_rpc_reply_t ret;
-	amqp_message_t msg;
-	int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
+int php_amqp_handle_basic_return(
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel,
+    amqp_method_t *method TSRMLS_DC
+)
+{
+    amqp_rpc_reply_t ret;
+    amqp_message_t msg;
+    int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
 
-	assert(AMQP_BASIC_RETURN_METHOD == method->id);
+    assert(AMQP_BASIC_RETURN_METHOD == method->id);
 
-	amqp_basic_return_t *m = (amqp_basic_return_t *) method->decoded;
+    amqp_basic_return_t *m = (amqp_basic_return_t *) method->decoded;
 
-	ret = amqp_read_message(resource->connection_state, channel_id, &msg, 0);
+    ret = amqp_read_message(resource->connection_state, channel_id, &msg, 0);
 
-	if (AMQP_RESPONSE_NORMAL != ret.reply_type) {
-		return php_amqp_connection_resource_error(ret, message, resource, channel_id TSRMLS_CC);
-	}
+    if (AMQP_RESPONSE_NORMAL != ret.reply_type) {
+        return php_amqp_connection_resource_error(ret, message, resource, channel_id TSRMLS_CC);
+    }
 
-	if (channel->callbacks.basic_return.fci.size > 0) {
-		status = php_amqp_call_basic_return_callback(m, &msg, &channel->callbacks.basic_return TSRMLS_CC);
-	} else {
-		zend_error(E_NOTICE, "Unhandled basic.return method from server received. Use AMQPChannel::setReturnCallback() to process it.");
-		status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
-	}
+    if (channel->callbacks.basic_return.fci.size > 0) {
+        status = php_amqp_call_basic_return_callback(m, &msg, &channel->callbacks.basic_return TSRMLS_CC);
+    } else {
+        zend_error(
+            E_NOTICE,
+            "Unhandled basic.return method from server received. Use AMQPChannel::setReturnCallback() to process it."
+        );
+        status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
+    }
 
-	amqp_destroy_message(&msg);
+    amqp_destroy_message(&msg);
 
-	return status;
+    return status;
 }
 
-int php_amqp_call_basic_return_callback(amqp_basic_return_t *m, amqp_message_t *msg, amqp_callback_bucket *cb TSRMLS_DC) {
-	zval params;
-	zval basic_properties;
+int php_amqp_call_basic_return_callback(amqp_basic_return_t *m, amqp_message_t *msg, amqp_callback_bucket *cb TSRMLS_DC)
+{
+    zval params;
+    zval basic_properties;
 
-	int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
+    int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
 
-	ZVAL_UNDEF(&params);
-	array_init(&params);
+    ZVAL_UNDEF(&params);
+    array_init(&params);
 
-	ZVAL_UNDEF(&basic_properties);
+    ZVAL_UNDEF(&basic_properties);
 
-	/* callback(int $reply_code, string $reply_text, string $exchange, string $routing_key, AMQPBasicProperties $properties, string $body); */
+    /* callback(int $reply_code, string $reply_text, string $exchange, string $routing_key, AMQPBasicProperties $properties, string $body); */
 
-	add_next_index_long(&params, (zend_long) m->reply_code);
-	add_next_index_stringl(&params, m->reply_text.bytes, m->reply_text.len);
-	add_next_index_stringl(&params, m->exchange.bytes, m->exchange.len);
-	add_next_index_stringl(&params, m->routing_key.bytes, m->routing_key.len);
+    add_next_index_long(&params, (zend_long) m->reply_code);
+    add_next_index_stringl(&params, m->reply_text.bytes, m->reply_text.len);
+    add_next_index_stringl(&params, m->exchange.bytes, m->exchange.len);
+    add_next_index_stringl(&params, m->routing_key.bytes, m->routing_key.len);
 
-	php_amqp_basic_properties_convert_to_zval(&msg->properties, &basic_properties TSRMLS_CC);
-	add_next_index_zval(&params, &basic_properties);
-	Z_ADDREF_P(&basic_properties);
+    php_amqp_basic_properties_convert_to_zval(&msg->properties, &basic_properties TSRMLS_CC);
+    add_next_index_zval(&params, &basic_properties);
+    Z_ADDREF_P(&basic_properties);
 
-	add_next_index_stringl(&params, msg->body.bytes, msg->body.len);
+    add_next_index_stringl(&params, msg->body.bytes, msg->body.len);
 
-	status = php_amqp_call_callback_with_params(params, cb TSRMLS_CC);
+    status = php_amqp_call_callback_with_params(params, cb TSRMLS_CC);
 
-	zval_ptr_dtor(&basic_properties);
+    zval_ptr_dtor(&basic_properties);
 
-	return status;
+    return status;
 }
 
-int php_amqp_handle_basic_ack(char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel, amqp_method_t *method TSRMLS_DC) {
-	int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
+int php_amqp_handle_basic_ack(
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel,
+    amqp_method_t *method TSRMLS_DC
+)
+{
+    int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
 
-	assert(AMQP_BASIC_ACK_METHOD == method->id);
+    assert(AMQP_BASIC_ACK_METHOD == method->id);
 
-	amqp_basic_ack_t *m = (amqp_basic_ack_t *) method->decoded;
+    amqp_basic_ack_t *m = (amqp_basic_ack_t *) method->decoded;
 
-	if (channel->callbacks.basic_ack.fci.size > 0) {
-		status = php_amqp_call_basic_ack_callback(m, &channel->callbacks.basic_ack TSRMLS_CC);
-	} else {
-		zend_error(E_NOTICE, "Unhandled basic.ack method from server received. Use AMQPChannel::setConfirmCallback() to process it.");
-		status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
-	}
+    if (channel->callbacks.basic_ack.fci.size > 0) {
+        status = php_amqp_call_basic_ack_callback(m, &channel->callbacks.basic_ack TSRMLS_CC);
+    } else {
+        zend_error(
+            E_NOTICE,
+            "Unhandled basic.ack method from server received. Use AMQPChannel::setConfirmCallback() to process it."
+        );
+        status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
+    }
 
-	return status;
+    return status;
 }
 
-int php_amqp_call_basic_ack_callback(amqp_basic_ack_t *m, amqp_callback_bucket *cb TSRMLS_DC) {
-	zval params;
+int php_amqp_call_basic_ack_callback(amqp_basic_ack_t *m, amqp_callback_bucket *cb TSRMLS_DC)
+{
+    zval params;
 
-	ZVAL_UNDEF(&params);
-	array_init(&params);
+    ZVAL_UNDEF(&params);
+    array_init(&params);
 
-	/* callback(int $delivery_tag, bool $multiple); */
-	add_next_index_long(&params, (zend_long) m->delivery_tag);
-	add_next_index_bool(&params, m->multiple);
+    /* callback(int $delivery_tag, bool $multiple); */
+    add_next_index_long(&params, (zend_long) m->delivery_tag);
+    add_next_index_bool(&params, m->multiple);
 
-	return php_amqp_call_callback_with_params(params, cb TSRMLS_CC);
+    return php_amqp_call_callback_with_params(params, cb TSRMLS_CC);
 }
 
-int php_amqp_handle_basic_nack(char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel, amqp_method_t *method TSRMLS_DC) {
-	int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
+int php_amqp_handle_basic_nack(
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel,
+    amqp_method_t *method TSRMLS_DC
+)
+{
+    int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
 
-	assert(AMQP_BASIC_NACK_METHOD == method->id);
+    assert(AMQP_BASIC_NACK_METHOD == method->id);
 
-	amqp_basic_nack_t *m = (amqp_basic_nack_t *) method->decoded;
+    amqp_basic_nack_t *m = (amqp_basic_nack_t *) method->decoded;
 
-	if (channel->callbacks.basic_nack.fci.size > 0) {
-		status = php_amqp_call_basic_nack_callback(m, &channel->callbacks.basic_nack TSRMLS_CC);
-	} else {
-		zend_error(E_NOTICE, "Unhandled basic.nack method from server received. Use AMQPChannel::setConfirmCallback() to process it.");
-		status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
-	}
+    if (channel->callbacks.basic_nack.fci.size > 0) {
+        status = php_amqp_call_basic_nack_callback(m, &channel->callbacks.basic_nack TSRMLS_CC);
+    } else {
+        zend_error(
+            E_NOTICE,
+            "Unhandled basic.nack method from server received. Use AMQPChannel::setConfirmCallback() to process it."
+        );
+        status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
+    }
 
-	return status;
+    return status;
 }
 
-int php_amqp_call_basic_nack_callback(amqp_basic_nack_t *m, amqp_callback_bucket *cb TSRMLS_DC) {
-	zval params;
+int php_amqp_call_basic_nack_callback(amqp_basic_nack_t *m, amqp_callback_bucket *cb TSRMLS_DC)
+{
+    zval params;
 
-	ZVAL_UNDEF(&params);
-	array_init(&params);
+    ZVAL_UNDEF(&params);
+    array_init(&params);
 
-	/* callback(int $delivery_tag, bool $multiple, bool $requeue); */
-	add_next_index_long(&params, (zend_long) m->delivery_tag);
-	add_next_index_bool(&params, m->multiple);
-	add_next_index_bool(&params, m->requeue);
+    /* callback(int $delivery_tag, bool $multiple, bool $requeue); */
+    add_next_index_long(&params, (zend_long) m->delivery_tag);
+    add_next_index_bool(&params, m->multiple);
+    add_next_index_bool(&params, m->requeue);
 
-	return php_amqp_call_callback_with_params(params, cb TSRMLS_CC);
+    return php_amqp_call_callback_with_params(params, cb TSRMLS_CC);
 }
 
 int php_amqp_call_callback_with_params(zval params, amqp_callback_bucket *cb TSRMLS_DC)
 {
-	zval retval;
-	zval *retval_ptr = &retval;
+    zval retval;
+    zval *retval_ptr = &retval;
 
-	int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
+    int status = PHP_AMQP_RESOURCE_RESPONSE_OK;
 
-	ZVAL_NULL(&retval);
+    ZVAL_NULL(&retval);
 
-	/* Convert everything to be callable */
-	zend_fcall_info_args(&cb->fci, &params TSRMLS_CC);
+    /* Convert everything to be callable */
+    zend_fcall_info_args(&cb->fci, &params TSRMLS_CC);
 
-	/* Initialize the return value pointer */
-	cb->fci.retval = retval_ptr;
+    /* Initialize the return value pointer */
+    cb->fci.retval = retval_ptr;
 
-	zend_call_function(&cb->fci, &cb->fcc TSRMLS_CC);
+    zend_call_function(&cb->fci, &cb->fcc TSRMLS_CC);
 
-	/* Check if user land function wants to bail */
-	if (EG(exception) || Z_TYPE_P(retval_ptr) == IS_FALSE) {
-		status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
-	}
+    /* Check if user land function wants to bail */
+    if (EG(exception) || Z_TYPE_P(retval_ptr) == IS_FALSE) {
+        status = PHP_AMQP_RESOURCE_RESPONSE_BREAK;
+    }
 
-	/* Clean up our mess */
-	zend_fcall_info_args_clear(&cb->fci, 1);
-	zval_ptr_dtor(&params);
-	zval_ptr_dtor(retval_ptr);
+    /* Clean up our mess */
+    zend_fcall_info_args_clear(&cb->fci, 1);
+    zval_ptr_dtor(&params);
+    zval_ptr_dtor(retval_ptr);
 
-	return status;
+    return status;
 }
-
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_methods_handling.h
+++ b/amqp_methods_handling.h
@@ -25,42 +25,55 @@
 
 #include "php_amqp.h"
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/amqp.h>
 #else
-#include <amqp.h>
+    #include <amqp.h>
 #endif
 #include "php.h"
 
-int amqp_simple_wait_method_list_noblock(amqp_connection_state_t state,
-                                         amqp_channel_t expected_channel,
-                                         amqp_method_number_t *expected_methods,
-                                         amqp_method_t *output,
-                                         struct timeval *timeout);
+int amqp_simple_wait_method_list_noblock(
+    amqp_connection_state_t state,
+    amqp_channel_t expected_channel,
+    amqp_method_number_t *expected_methods,
+    amqp_method_t *output,
+    struct timeval *timeout
+);
 
-int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
-                            amqp_channel_t expected_channel,
-                            amqp_method_number_t expected_method,
-                            amqp_method_t *output,
-                            struct timeval *timeout);
+int amqp_simple_wait_method_noblock(
+    amqp_connection_state_t state,
+    amqp_channel_t expected_channel,
+    amqp_method_number_t expected_method,
+    amqp_method_t *output,
+    struct timeval *timeout
+);
 
 int php_amqp_call_callback_with_params(zval params, amqp_callback_bucket *cb TSRMLS_DC);
 
 int php_amqp_call_basic_return_callback(amqp_basic_return_t *m, amqp_message_t *msg, amqp_callback_bucket *cb TSRMLS_DC);
-int php_amqp_handle_basic_return(char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel, amqp_method_t *method TSRMLS_DC);
+int php_amqp_handle_basic_return(
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel,
+    amqp_method_t *method TSRMLS_DC
+);
 
 int php_amqp_call_basic_ack_callback(amqp_basic_ack_t *m, amqp_callback_bucket *cb TSRMLS_DC);
-int php_amqp_handle_basic_ack(char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel, amqp_method_t *method TSRMLS_DC);
+int php_amqp_handle_basic_ack(
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel,
+    amqp_method_t *method TSRMLS_DC
+);
 
 int php_amqp_call_basic_nack_callback(amqp_basic_nack_t *m, amqp_callback_bucket *cb TSRMLS_DC);
-int php_amqp_handle_basic_nack(char **message, amqp_connection_resource *resource, amqp_channel_t channel_id, amqp_channel_object *channel, amqp_method_t *method TSRMLS_DC);
+int php_amqp_handle_basic_nack(
+    char **message,
+    amqp_connection_resource *resource,
+    amqp_channel_t channel_id,
+    amqp_channel_object *channel,
+    amqp_method_t *method TSRMLS_DC
+);
 
 #endif
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -21,7 +21,7 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -30,36 +30,39 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# if PHP_VERSION_ID >= 80000
-#  include "main/php_stdint.h"
-# else
-#  include "win32/php_stdint.h"
-# endif
-# include "win32/signal.h"
+    #if PHP_VERSION_ID >= 80000
+        #include "main/php_stdint.h"
+    #else
+        #include "win32/php_stdint.h"
+    #endif
+    #include "win32/signal.h"
 #else
-# include <signal.h>
-# include <stdint.h>
+    #include <signal.h>
+    #include <stdint.h>
 #endif
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/framing.h>
+    #include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/framing.h>
 #else
-#include <amqp.h>
-#include <amqp_framing.h>
+    #include <amqp.h>
+    #include <amqp_framing.h>
 #endif
 
 #ifdef PHP_WIN32
-# include "win32/unistd.h"
+    #include "win32/unistd.h"
 #else
-# include <unistd.h>
+    #include <unistd.h>
 #endif
 
 #include "php_amqp.h"
 #include "amqp_envelope.h"
 #include "amqp_connection.h"
 #include "amqp_channel.h"
+#include "amqp_connection.h"
+#include "amqp_envelope.h"
 #include "amqp_queue.h"
 #include "amqp_type.h"
+#include "php_amqp.h"
 
 zend_class_entry *amqp_queue_class_entry;
 #define this_ce amqp_queue_class_entry
@@ -70,28 +73,32 @@ AMQPQueue constructor
 */
 static PHP_METHOD(amqp_queue_class, __construct)
 {
-	zval rv;
+    zval rv;
 
-	zval arguments;
+    zval arguments;
 
-	zval *channelObj;
-	amqp_channel_resource *channel_resource;
+    zval *channelObj;
+    amqp_channel_resource *channel_resource;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &channelObj, amqp_channel_class_entry) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &channelObj, amqp_channel_class_entry) == FAILURE) {
+        return;
+    }
 
-	ZVAL_UNDEF(&arguments);
-	array_init(&arguments);
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), &arguments TSRMLS_CC);
-	zval_ptr_dtor(&arguments);
+    ZVAL_UNDEF(&arguments);
+    array_init(&arguments);
+    zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), &arguments TSRMLS_CC);
+    zval_ptr_dtor(&arguments);
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channelObj);
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not create queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channelObj);
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not create queue.");
 
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("channel"), channelObj TSRMLS_CC);
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connection"), PHP_AMQP_READ_OBJ_PROP(amqp_channel_class_entry, channelObj, "connection") TSRMLS_CC);
-
+    zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("channel"), channelObj TSRMLS_CC);
+    zend_update_property(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("connection"),
+        PHP_AMQP_READ_OBJ_PROP(amqp_channel_class_entry, channelObj, "connection") TSRMLS_CC
+    );
 }
 /* }}} */
 
@@ -100,16 +107,16 @@ static PHP_METHOD(amqp_queue_class, __construct)
 Get the queue name */
 static PHP_METHOD(amqp_queue_class, getName)
 {
-	zval rv;
+    zval rv;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") > 0) {
-		PHP_AMQP_RETURN_THIS_PROP("name");
-	} else {
-		/* BC */
-		RETURN_FALSE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") > 0) {
+        PHP_AMQP_RETURN_THIS_PROP("name");
+    } else {
+        /* BC */
+        RETURN_FALSE;
+    }
 }
 /* }}} */
 
@@ -118,55 +125,59 @@ static PHP_METHOD(amqp_queue_class, getName)
 Set the queue name */
 static PHP_METHOD(amqp_queue_class, setName)
 {
-	char *name = NULL;	size_t name_len = 0;
+    char *name = NULL;
+    size_t name_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &name, &name_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &name, &name_len) == FAILURE) {
+        return;
+    }
 
-	if (name_len < 1 || name_len > 255) {
-		/* Verify that the name is not null and not an empty string */
-		zend_throw_exception(amqp_queue_exception_class_entry, "Invalid queue name given, must be between 1 and 255 characters long.", 0 TSRMLS_CC);
-		return;
-	}
+    if (name_len < 1 || name_len > 255) {
+        /* Verify that the name is not null and not an empty string */
+        zend_throw_exception(
+            amqp_queue_exception_class_entry,
+            "Invalid queue name given, must be between 1 and 255 characters long.",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	/* Set the queue name */
-	zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("name"), name, name_len TSRMLS_CC);
+    /* Set the queue name */
+    zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("name"), name, name_len TSRMLS_CC);
 
-	/* BC */
-	RETURN_TRUE;
+    /* BC */
+    RETURN_TRUE;
 }
 /* }}} */
-
 
 
 /* {{{ proto AMQPQueue::getFlags()
 Get the queue parameters */
 static PHP_METHOD(amqp_queue_class, getFlags)
 {
-	zval rv;
+    zval rv;
 
-	zend_long flags = 0;
+    zend_long flags = 0;
 
-	PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS();
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("passive")) {
-		flags |= AMQP_PASSIVE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("passive")) {
+        flags |= AMQP_PASSIVE;
+    }
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("durable")) {
-		flags |= AMQP_DURABLE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("durable")) {
+        flags |= AMQP_DURABLE;
+    }
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("exclusive")) {
-		flags |= AMQP_EXCLUSIVE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("exclusive")) {
+        flags |= AMQP_EXCLUSIVE;
+    }
 
-	if (PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete")) {
-		flags |= AMQP_AUTODELETE;
-	}
+    if (PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete")) {
+        flags |= AMQP_AUTODELETE;
+    }
 
-	RETURN_LONG(flags);
+    RETURN_LONG(flags);
 }
 /* }}} */
 
@@ -175,23 +186,43 @@ static PHP_METHOD(amqp_queue_class, getFlags)
 Set the queue parameters */
 static PHP_METHOD(amqp_queue_class, setFlags)
 {
-	zend_long flags;
-	zend_bool flags_is_null = 1;
+    zend_long flags;
+    zend_bool flags_is_null = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l!", &flags, &flags_is_null) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l!", &flags, &flags_is_null) == FAILURE) {
+        return;
+    }
 
-	/* Set the flags based on the bitmask we were given */
-	flags = flags ? flags & PHP_AMQP_QUEUE_FLAGS : flags;
+    /* Set the flags based on the bitmask we were given */
+    flags = flags ? flags & PHP_AMQP_QUEUE_FLAGS : flags;
 
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("passive"), IS_PASSIVE(flags) TSRMLS_CC);
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("durable"), IS_DURABLE(flags) TSRMLS_CC);
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("exclusive"), IS_EXCLUSIVE(flags) TSRMLS_CC);
-	zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("auto_delete"), IS_AUTODELETE(flags) TSRMLS_CC);
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("passive"),
+        IS_PASSIVE(flags) TSRMLS_CC
+    );
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("durable"),
+        IS_DURABLE(flags) TSRMLS_CC
+    );
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("exclusive"),
+        IS_EXCLUSIVE(flags) TSRMLS_CC
+    );
+    zend_update_property_bool(
+        this_ce,
+        PHP_AMQP_COMPAT_OBJ_P(getThis()),
+        ZEND_STRL("auto_delete"),
+        IS_AUTODELETE(flags) TSRMLS_CC
+    );
 
-	/* BC */
-	RETURN_TRUE;
+    /* BC */
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -200,41 +231,42 @@ static PHP_METHOD(amqp_queue_class, setFlags)
 Get the queue argument referenced by key */
 static PHP_METHOD(amqp_queue_class, getArgument)
 {
-	zval rv;
-	zval *tmp = NULL;
-	char *key;
-	size_t key_len;
+    zval rv;
+    zval *tmp = NULL;
+    char *key;
+    size_t key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
+        return;
+    }
 
-	if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
-		RETURN_FALSE;
-	}
+    if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
+        RETURN_FALSE;
+    }
 
-	RETURN_ZVAL(tmp, 1, 0);
+    RETURN_ZVAL(tmp, 1, 0);
 }
 /* }}} */
 
 /* {{{ proto AMQPQueue::hasArgument(string key) */
 static PHP_METHOD(amqp_queue_class, hasArgument)
 {
-	zval rv;
+    zval rv;
 
-	zval *tmp = NULL;
+    zval *tmp = NULL;
 
-	char *key;	size_t key_len;
+    char *key;
+    size_t key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
+        return;
+    }
 
-	if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
-		RETURN_FALSE;
-	}
+    if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
+        RETURN_FALSE;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -243,9 +275,9 @@ static PHP_METHOD(amqp_queue_class, hasArgument)
 Get the queue arguments */
 static PHP_METHOD(amqp_queue_class, getArguments)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("arguments");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("arguments");
 }
 /* }}} */
 
@@ -253,15 +285,15 @@ static PHP_METHOD(amqp_queue_class, getArguments)
 Overwrite all queue arguments with given args */
 static PHP_METHOD(amqp_queue_class, setArguments)
 {
-	zval *zvalArguments;
+    zval *zvalArguments;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/", &zvalArguments) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/", &zvalArguments) == FAILURE) {
+        return;
+    }
 
-	zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), zvalArguments TSRMLS_CC);
+    zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), zvalArguments TSRMLS_CC);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -270,35 +302,38 @@ static PHP_METHOD(amqp_queue_class, setArguments)
 Get the queue name */
 static PHP_METHOD(amqp_queue_class, setArgument)
 {
-	zval rv;
+    zval rv;
 
-	char *key= NULL;    size_t key_len = 0;
-	zval *value = NULL;
+    char *key = NULL;
+    size_t key_len = 0;
+    zval *value = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz",
-							  &key, &key_len,
-							  &value) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz", &key, &key_len, &value) == FAILURE) {
+        return;
+    }
 
-	switch (Z_TYPE_P(value)) {
-		case IS_NULL:
-			zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
-			break;
-		case IS_TRUE:
-		case IS_FALSE:
-		case IS_LONG:
-		case IS_DOUBLE:
-		case IS_STRING:
-			zend_hash_str_add(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len, value);
-			Z_TRY_ADDREF_P(value);
-			break;
-		default:
-			zend_throw_exception(amqp_exchange_exception_class_entry, "The value parameter must be of type NULL, int, double or string.", 0 TSRMLS_CC);
-			return;
-	}
+    switch (Z_TYPE_P(value)) {
+        case IS_NULL:
+            zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
+            break;
+        case IS_TRUE:
+        case IS_FALSE:
+        case IS_LONG:
+        case IS_DOUBLE:
+        case IS_STRING:
+            zend_hash_str_add(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len, value);
+            Z_TRY_ADDREF_P(value);
+            break;
+        default:
+            zend_throw_exception(
+                amqp_exchange_exception_class_entry,
+                "The value parameter must be of type NULL, int, double or string.",
+                0 TSRMLS_CC
+            );
+            return;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -308,56 +343,66 @@ declare queue
 */
 static PHP_METHOD(amqp_queue_class, declareQueue)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	char *name;
-	amqp_table_t *arguments;
-	zend_long message_count;
+    char *name;
+    amqp_table_t *arguments;
+    zend_long message_count;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not declare queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not declare queue.");
 
-	arguments = php_amqp_type_convert_zval_to_amqp_table(PHP_AMQP_READ_THIS_PROP("arguments") TSRMLS_CC);
+    arguments = php_amqp_type_convert_zval_to_amqp_table(PHP_AMQP_READ_THIS_PROP("arguments") TSRMLS_CC);
 
-	amqp_queue_declare_ok_t *r = amqp_queue_declare(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		PHP_AMQP_READ_THIS_PROP_BOOL("passive"),
-		PHP_AMQP_READ_THIS_PROP_BOOL("durable"),
-		PHP_AMQP_READ_THIS_PROP_BOOL("exclusive"),
-		PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete"),
-		*arguments
-	);
+    amqp_queue_declare_ok_t *r = amqp_queue_declare(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        PHP_AMQP_READ_THIS_PROP_BOOL("passive"),
+        PHP_AMQP_READ_THIS_PROP_BOOL("durable"),
+        PHP_AMQP_READ_THIS_PROP_BOOL("exclusive"),
+        PHP_AMQP_READ_THIS_PROP_BOOL("auto_delete"),
+        *arguments
+    );
 
-	php_amqp_type_free_amqp_table(arguments);
+    php_amqp_type_free_amqp_table(arguments);
 
-	if (!r) {
-		amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    if (!r) {
+        amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_queue_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	message_count = r->message_count;
+    message_count = r->message_count;
 
-	/* Set the queue name, in case it is an autogenerated queue name */
-	name = php_amqp_type_amqp_bytes_to_char(r->queue);
-	zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("name"), name TSRMLS_CC);
-	efree(name);
+    /* Set the queue name, in case it is an autogenerated queue name */
+    name = php_amqp_type_amqp_bytes_to_char(r->queue);
+    zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("name"), name TSRMLS_CC);
+    efree(name);
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_LONG(message_count);
+    RETURN_LONG(message_count);
 }
 /* }}} */
 
@@ -367,55 +412,62 @@ bind queue to exchange by routing key
 */
 static PHP_METHOD(amqp_queue_class, bind)
 {
-	zval rv;
+    zval rv;
 
-	zval *zvalArguments = NULL;
+    zval *zvalArguments = NULL;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	char *exchange_name;		size_t exchange_name_len;
-	char *keyname     = NULL;	size_t keyname_len = 0;
+    char *exchange_name;
+    size_t exchange_name_len;
+    char *keyname = NULL;
+    size_t keyname_len = 0;
 
-	amqp_table_t *arguments = NULL;
+    amqp_table_t *arguments = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s!a",
-							  &exchange_name, &exchange_name_len,
-							  &keyname, &keyname_len,
-							  &zvalArguments) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS() TSRMLS_CC,
+            "s|s!a",
+            &exchange_name,
+            &exchange_name_len,
+            &keyname,
+            &keyname_len,
+            &zvalArguments
+        ) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not bind queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not bind queue.");
 
-	if (zvalArguments) {
-		arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
-	}
+    if (zvalArguments) {
+        arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
+    }
 
-	amqp_queue_bind(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		(exchange_name_len > 0 ? amqp_cstring_bytes(exchange_name) : amqp_empty_bytes),
-		(keyname_len > 0 ? amqp_cstring_bytes(keyname) : amqp_empty_bytes),
-		(arguments ? *arguments : amqp_empty_table)
-	);
+    amqp_queue_bind(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        (exchange_name_len > 0 ? amqp_cstring_bytes(exchange_name) : amqp_empty_bytes),
+        (keyname_len > 0 ? amqp_cstring_bytes(keyname) : amqp_empty_bytes),
+        (arguments ? *arguments : amqp_empty_table)
+    );
 
-	if (arguments) {
-		php_amqp_type_free_amqp_table(arguments);
-	}
+    if (arguments) {
+        php_amqp_type_free_amqp_table(arguments);
+    }
 
-	amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -426,79 +478,79 @@ return array (messages)
 */
 static PHP_METHOD(amqp_queue_class, get)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	zval message;
+    zval message;
 
-	zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
+    zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
 
-	/* Parse out the method parameters */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &flags) == FAILURE) {
-		return;
-	}
+    /* Parse out the method parameters */
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &flags) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not get messages from queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not get messages from queue.");
 
-	amqp_rpc_reply_t res = amqp_basic_get(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		(AMQP_AUTOACK & flags) ? 1 : 0
-	);
+    amqp_rpc_reply_t res = amqp_basic_get(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        (AMQP_AUTOACK & flags) ? 1 : 0
+    );
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	if (AMQP_BASIC_GET_EMPTY_METHOD == res.reply.id) {
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		RETURN_FALSE;
-	}
+    if (AMQP_BASIC_GET_EMPTY_METHOD == res.reply.id) {
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        RETURN_FALSE;
+    }
 
-	assert(AMQP_BASIC_GET_OK_METHOD == res.reply.id);
+    assert(AMQP_BASIC_GET_OK_METHOD == res.reply.id);
 
-	/* Fill the envelope from response */
-	amqp_basic_get_ok_t *get_ok_method = res.reply.decoded;
+    /* Fill the envelope from response */
+    amqp_basic_get_ok_t *get_ok_method = res.reply.decoded;
 
-	amqp_envelope_t envelope;
+    amqp_envelope_t envelope;
 
-	envelope.channel      = channel_resource->channel_id;
-	envelope.consumer_tag = amqp_empty_bytes;
-	envelope.delivery_tag = get_ok_method->delivery_tag;
-	envelope.redelivered  = get_ok_method->redelivered;
-	envelope.exchange     = amqp_bytes_malloc_dup(get_ok_method->exchange);
-	envelope.routing_key  = amqp_bytes_malloc_dup(get_ok_method->routing_key);
+    envelope.channel = channel_resource->channel_id;
+    envelope.consumer_tag = amqp_empty_bytes;
+    envelope.delivery_tag = get_ok_method->delivery_tag;
+    envelope.redelivered = get_ok_method->redelivered;
+    envelope.exchange = amqp_bytes_malloc_dup(get_ok_method->exchange);
+    envelope.routing_key = amqp_bytes_malloc_dup(get_ok_method->routing_key);
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-  	res = amqp_read_message(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		&envelope.message,
-		0
-	);
+    res = amqp_read_message(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        &envelope.message,
+        0
+    );
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		amqp_destroy_envelope(&envelope);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        amqp_destroy_envelope(&envelope);
+        return;
+    }
 
-	ZVAL_UNDEF(&message);
+    ZVAL_UNDEF(&message);
 
-	convert_amqp_envelope_to_zval(&envelope, &message TSRMLS_CC);
+    convert_amqp_envelope_to_zval(&envelope, &message TSRMLS_CC);
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-	amqp_destroy_envelope(&envelope);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    amqp_destroy_envelope(&envelope);
 
-	RETVAL_ZVAL(&message, 1, 0);
-	zval_ptr_dtor(&message);
+    RETVAL_ZVAL(&message, 1, 0);
+    zval_ptr_dtor(&message);
 }
 /* }}} */
 
@@ -508,236 +560,297 @@ consume the message
 */
 static PHP_METHOD(amqp_queue_class, consume)
 {
-	zval rv;
+    zval rv;
 
-	zval current_channel_zv;
+    zval current_channel_zv;
 
-	zval *current_queue_zv = NULL;
+    zval *current_queue_zv = NULL;
 
-	amqp_channel_resource *channel_resource;
-	amqp_channel_resource *current_channel_resource;
+    amqp_channel_resource *channel_resource;
+    amqp_channel_resource *current_channel_resource;
 
-	zend_fcall_info fci = empty_fcall_info;
-	zend_fcall_info_cache fci_cache = empty_fcall_info_cache;
+    zend_fcall_info fci = empty_fcall_info;
+    zend_fcall_info_cache fci_cache = empty_fcall_info_cache;
 
-	amqp_table_t *arguments;
+    amqp_table_t *arguments;
 
-	char *consumer_tag = NULL;  size_t consumer_tag_len = 0;
-	zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
+    char *consumer_tag = NULL;
+    size_t consumer_tag_len = 0;
+    zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|f!ls",
-							  &fci, &fci_cache,
-							  &flags,
-							  &consumer_tag, &consumer_tag_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS() TSRMLS_CC,
+            "|f!ls",
+            &fci,
+            &fci_cache,
+            &flags,
+            &consumer_tag,
+            &consumer_tag_len
+        ) == FAILURE) {
+        return;
+    }
 
-	zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
-	zval *consumers = zend_read_property(amqp_channel_class_entry, PHP_AMQP_COMPAT_OBJ_P(channel_zv), ZEND_STRL("consumers"), 0 , &rv TSRMLS_CC);
+    zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
+    zval *consumers = zend_read_property(
+        amqp_channel_class_entry,
+        PHP_AMQP_COMPAT_OBJ_P(channel_zv),
+        ZEND_STRL("consumers"),
+        0,
+        &rv TSRMLS_CC
+    );
 
-	if (IS_ARRAY != Z_TYPE_P(consumers)) {
-		zend_throw_exception(amqp_queue_exception_class_entry, "Invalid channel consumers, forgot to call channel constructor?", 0 TSRMLS_CC);
-		return;
-	}
+    if (IS_ARRAY != Z_TYPE_P(consumers)) {
+        zend_throw_exception(
+            amqp_queue_exception_class_entry,
+            "Invalid channel consumers, forgot to call channel constructor?",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	amqp_channel_object *channel = PHP_AMQP_GET_CHANNEL(channel_zv);
+    amqp_channel_object *channel = PHP_AMQP_GET_CHANNEL(channel_zv);
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channel_zv);
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not get channel.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channel_zv);
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not get channel.");
 
-	if (!(AMQP_JUST_CONSUME & flags)) {
-		/* Setup the consume */
-		arguments = php_amqp_type_convert_zval_to_amqp_table(PHP_AMQP_READ_THIS_PROP("arguments") TSRMLS_CC);
+    if (!(AMQP_JUST_CONSUME & flags)) {
+        /* Setup the consume */
+        arguments = php_amqp_type_convert_zval_to_amqp_table(PHP_AMQP_READ_THIS_PROP("arguments") TSRMLS_CC);
 
-		amqp_basic_consume_ok_t *r = amqp_basic_consume(
-				channel_resource->connection_resource->connection_state,
-				channel_resource->channel_id,
-				amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-				(consumer_tag_len > 0 ? amqp_cstring_bytes(consumer_tag) : amqp_empty_bytes), /* Consumer tag */
-				(AMQP_NOLOCAL & flags) ? 1 : 0, /* No local */
-				(AMQP_AUTOACK & flags) ? 1 : 0,    /* no_ack, aka AUTOACK */
-				PHP_AMQP_READ_THIS_PROP_BOOL("exclusive"),
-				*arguments
-		);
+        amqp_basic_consume_ok_t *r = amqp_basic_consume(
+            channel_resource->connection_resource->connection_state,
+            channel_resource->channel_id,
+            amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+            (consumer_tag_len > 0 ? amqp_cstring_bytes(consumer_tag) : amqp_empty_bytes), /* Consumer tag */
+            (AMQP_NOLOCAL & flags) ? 1 : 0,                                               /* No local */
+            (AMQP_AUTOACK & flags) ? 1 : 0,                                               /* no_ack, aka AUTOACK */
+            PHP_AMQP_READ_THIS_PROP_BOOL("exclusive"),
+            *arguments
+        );
 
-		php_amqp_type_free_amqp_table(arguments);
+        php_amqp_type_free_amqp_table(arguments);
 
-		if (!r) {
-			amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+        if (!r) {
+            amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-			php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+            php_amqp_error(
+                res,
+                &PHP_AMQP_G(error_message),
+                channel_resource->connection_resource,
+                channel_resource TSRMLS_CC
+            );
 
-			zend_throw_exception(amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-			return;
-		}
+            zend_throw_exception(
+                amqp_queue_exception_class_entry,
+                PHP_AMQP_G(error_message),
+                PHP_AMQP_G(error_code) TSRMLS_CC
+            );
+            php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+            return;
+        }
 
-		char *key;
-		key = estrndup((char *) r->consumer_tag.bytes, (unsigned) r->consumer_tag.len);
+        char *key;
+        key = estrndup((char *) r->consumer_tag.bytes, (unsigned) r->consumer_tag.len);
 
-		if (zend_hash_str_find(Z_ARRVAL_P(consumers), key, r->consumer_tag.len) != NULL) {
-			// This should never happen as AMQP server guarantees that consumer tag is unique within channel
-			zend_throw_exception(amqp_exception_class_entry, "Duplicate consumer tag", 0 TSRMLS_CC);
-		    efree(key);
-			return;
-		}
+        if (zend_hash_str_find(Z_ARRVAL_P(consumers), key, r->consumer_tag.len) != NULL) {
+            // This should never happen as AMQP server guarantees that consumer tag is unique within channel
+            zend_throw_exception(amqp_exception_class_entry, "Duplicate consumer tag", 0 TSRMLS_CC);
+            efree(key);
+            return;
+        }
 
-		zval tmp;
+        zval tmp;
 
-		ZVAL_UNDEF(&tmp);
-		ZVAL_COPY(&tmp, getThis());
+        ZVAL_UNDEF(&tmp);
+        ZVAL_COPY(&tmp, getThis());
 
-		zend_hash_str_add(Z_ARRVAL_P(consumers), key, r->consumer_tag.len, &tmp);
-		efree(key);
+        zend_hash_str_add(Z_ARRVAL_P(consumers), key, r->consumer_tag.len, &tmp);
+        efree(key);
 
-		/* Set the consumer tag name, in case it is an autogenerated consumer tag name */
-		zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("consumer_tag"), (const char *) r->consumer_tag.bytes, (size_t) r->consumer_tag.len TSRMLS_CC);
-	}
+        /* Set the consumer tag name, in case it is an autogenerated consumer tag name */
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(getThis()),
+            ZEND_STRL("consumer_tag"),
+            (const char *) r->consumer_tag.bytes,
+            (size_t) r->consumer_tag.len TSRMLS_CC
+        );
+    }
 
-	if (!ZEND_FCI_INITIALIZED(fci)) {
-		/* Callback not set, we have nothing to do - real consuming may happens later */
-		return;
-	}
+    if (!ZEND_FCI_INITIALIZED(fci)) {
+        /* Callback not set, we have nothing to do - real consuming may happens later */
+        return;
+    }
 
-	struct timeval tv = {0};
-	struct timeval *tv_ptr = &tv;
+    struct timeval tv = {0};
+    struct timeval *tv_ptr = &tv;
 
-	double read_timeout = PHP_AMQP_READ_OBJ_PROP_DOUBLE(amqp_connection_class_entry, PHP_AMQP_READ_THIS_PROP("connection"), "read_timeout");
+    double read_timeout = PHP_AMQP_READ_OBJ_PROP_DOUBLE(
+        amqp_connection_class_entry,
+        PHP_AMQP_READ_THIS_PROP("connection"),
+        "read_timeout"
+    );
 
-	if (read_timeout > 0) {
-		tv.tv_sec  = (long int) read_timeout;
-		tv.tv_usec = (long int) ((read_timeout - tv.tv_sec) * 1000000);
-	} else {
-		tv_ptr = NULL;
-	}
+    if (read_timeout > 0) {
+        tv.tv_sec = (long int) read_timeout;
+        tv.tv_usec = (long int) ((read_timeout - tv.tv_sec) * 1000000);
+    } else {
+        tv_ptr = NULL;
+    }
 
-	while(1) {
-		/* Initialize the message */
-		zval message;
+    while (1) {
+        /* Initialize the message */
+        zval message;
 
-		amqp_envelope_t envelope;
+        amqp_envelope_t envelope;
 
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-		amqp_rpc_reply_t res = amqp_consume_message(channel_resource->connection_resource->connection_state, &envelope, tv_ptr, 0);
+        amqp_rpc_reply_t res =
+            amqp_consume_message(channel_resource->connection_resource->connection_state, &envelope, tv_ptr, 0);
 
-		if (AMQP_RESPONSE_LIBRARY_EXCEPTION == res.reply_type && AMQP_STATUS_TIMEOUT == res.library_error) {
-			zend_throw_exception(amqp_queue_exception_class_entry, "Consumer timeout exceed", 0 TSRMLS_CC);
+        if (AMQP_RESPONSE_LIBRARY_EXCEPTION == res.reply_type && AMQP_STATUS_TIMEOUT == res.library_error) {
+            zend_throw_exception(amqp_queue_exception_class_entry, "Consumer timeout exceed", 0 TSRMLS_CC);
 
-			amqp_destroy_envelope(&envelope);
-			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-			return;
-		}
+            amqp_destroy_envelope(&envelope);
+            php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+            return;
+        }
 
-		if (PHP_AMQP_MAYBE_ERROR_RECOVERABLE(res, channel_resource)) {
+        if (PHP_AMQP_MAYBE_ERROR_RECOVERABLE(res, channel_resource)) {
 
-			if (PHP_AMQP_IS_ERROR_RECOVERABLE(res, channel_resource, channel)) {
-				/* In case no message was received, continue the loop */
-				amqp_destroy_envelope(&envelope);
+            if (PHP_AMQP_IS_ERROR_RECOVERABLE(res, channel_resource, channel)) {
+                /* In case no message was received, continue the loop */
+                amqp_destroy_envelope(&envelope);
 
-				continue;
-			} else {
-				/* Mark connection resource as closed to prevent sending any further requests */
-				channel_resource->connection_resource->is_connected = '\0';
+                continue;
+            } else {
+                /* Mark connection resource as closed to prevent sending any further requests */
+                channel_resource->connection_resource->is_connected = '\0';
 
-				/* Close connection with all its channels */
-				php_amqp_disconnect_force(channel_resource->connection_resource TSRMLS_CC);
-			}
+                /* Close connection with all its channels */
+                php_amqp_disconnect_force(channel_resource->connection_resource TSRMLS_CC);
+            }
 
-			php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
+            php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
 
-			amqp_destroy_envelope(&envelope);
-			php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+            amqp_destroy_envelope(&envelope);
+            php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-			return;
-		}
+            return;
+        }
 
-		ZVAL_UNDEF(&message);
-		convert_amqp_envelope_to_zval(&envelope, &message TSRMLS_CC);
+        ZVAL_UNDEF(&message);
+        convert_amqp_envelope_to_zval(&envelope, &message TSRMLS_CC);
 
-		current_channel_resource = channel_resource->connection_resource->slots[envelope.channel - 1];
+        current_channel_resource = channel_resource->connection_resource->slots[envelope.channel - 1];
 
-		if (!current_channel_resource) {
-			// This should never happen, but just in case
-			php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, "Orphaned channel. Please, report a bug.", 0 TSRMLS_CC);
-			amqp_destroy_envelope(&envelope);
-			break;
-		}
+        if (!current_channel_resource) {
+            // This should never happen, but just in case
+            php_amqp_zend_throw_exception(
+                res,
+                amqp_queue_exception_class_entry,
+                "Orphaned channel. Please, report a bug.",
+                0 TSRMLS_CC
+            );
+            amqp_destroy_envelope(&envelope);
+            break;
+        }
 
-		ZVAL_UNDEF(&current_channel_zv);
-		ZVAL_OBJ(&current_channel_zv, &current_channel_resource->parent->zo);
+        ZVAL_UNDEF(&current_channel_zv);
+        ZVAL_OBJ(&current_channel_zv, &current_channel_resource->parent->zo);
 
-		consumers = zend_read_property(amqp_channel_class_entry, PHP_AMQP_COMPAT_OBJ_P(&current_channel_zv), ZEND_STRL("consumers"), 0 , &rv TSRMLS_CC);
+        consumers = zend_read_property(
+            amqp_channel_class_entry,
+            PHP_AMQP_COMPAT_OBJ_P(&current_channel_zv),
+            ZEND_STRL("consumers"),
+            0,
+            &rv TSRMLS_CC
+        );
 
-		if (IS_ARRAY != Z_TYPE_P(consumers)) {
-			zend_throw_exception(amqp_queue_exception_class_entry, "Invalid channel consumers, forgot to call channel constructor?", 0 TSRMLS_CC);
-			amqp_destroy_envelope(&envelope);
-			break;
-		}
+        if (IS_ARRAY != Z_TYPE_P(consumers)) {
+            zend_throw_exception(
+                amqp_queue_exception_class_entry,
+                "Invalid channel consumers, forgot to call channel constructor?",
+                0 TSRMLS_CC
+            );
+            amqp_destroy_envelope(&envelope);
+            break;
+        }
 
-		char *key;
-		key = estrndup((char *)envelope.consumer_tag.bytes, (unsigned) envelope.consumer_tag.len);
+        char *key;
+        key = estrndup((char *) envelope.consumer_tag.bytes, (unsigned) envelope.consumer_tag.len);
 
-		if ((current_queue_zv = zend_hash_str_find(Z_ARRVAL_P(consumers), key, envelope.consumer_tag.len)) == NULL) {
-			zval exception;
-			ZVAL_UNDEF(&exception);
-			object_init_ex(&exception, amqp_envelope_exception_class_entry);
-		    zend_update_property_string(zend_exception_get_default(TSRMLS_C), PHP_AMQP_COMPAT_OBJ_P(&exception),  ZEND_STRL("message"), "Orphaned envelope" TSRMLS_CC);
-			zend_update_property(amqp_envelope_exception_class_entry, PHP_AMQP_COMPAT_OBJ_P(&exception), ZEND_STRL("envelope"), &message TSRMLS_CC);
+        if ((current_queue_zv = zend_hash_str_find(Z_ARRVAL_P(consumers), key, envelope.consumer_tag.len)) == NULL) {
+            zval exception;
+            ZVAL_UNDEF(&exception);
+            object_init_ex(&exception, amqp_envelope_exception_class_entry);
+            zend_update_property_string(
+                zend_exception_get_default(TSRMLS_C),
+                PHP_AMQP_COMPAT_OBJ_P(&exception),
+                ZEND_STRL("message"),
+                "Orphaned envelope" TSRMLS_CC
+            );
+            zend_update_property(
+                amqp_envelope_exception_class_entry,
+                PHP_AMQP_COMPAT_OBJ_P(&exception),
+                ZEND_STRL("envelope"),
+                &message TSRMLS_CC
+            );
 
-			zend_throw_exception_object(&exception TSRMLS_CC);
+            zend_throw_exception_object(&exception TSRMLS_CC);
 
-			zval_ptr_dtor(&message);
+            zval_ptr_dtor(&message);
 
-			amqp_destroy_envelope(&envelope);
-		    efree(key);
-			break;
-		}
+            amqp_destroy_envelope(&envelope);
+            efree(key);
+            break;
+        }
 
-		efree(key);
-		amqp_destroy_envelope(&envelope);
+        efree(key);
+        amqp_destroy_envelope(&envelope);
 
-		/* Make the callback */
-		zval params;
-		zval retval;
+        /* Make the callback */
+        zval params;
+        zval retval;
 
-		/* Build the parameter array */
-		ZVAL_UNDEF(&params);
-		array_init(&params);
+        /* Build the parameter array */
+        ZVAL_UNDEF(&params);
+        array_init(&params);
 
-		/* Dump it into the params array */
-		add_index_zval(&params, 0, &message);
-		Z_ADDREF_P( &message);
+        /* Dump it into the params array */
+        add_index_zval(&params, 0, &message);
+        Z_ADDREF_P(&message);
 
-		/* Add a pointer to the queue: */
-		add_index_zval(&params, 1, current_queue_zv);
-		Z_ADDREF_P(current_queue_zv);
+        /* Add a pointer to the queue: */
+        add_index_zval(&params, 1, current_queue_zv);
+        Z_ADDREF_P(current_queue_zv);
 
 
-		/* Convert everything to be callable */
-		zend_fcall_info_args(&fci, &params TSRMLS_CC);
-		/* Initialize the return value pointer */
+        /* Convert everything to be callable */
+        zend_fcall_info_args(&fci, &params TSRMLS_CC);
+        /* Initialize the return value pointer */
 
-		fci.retval = &retval;
+        fci.retval = &retval;
 
-		/* Call the function, and track the return value */
-		if (zend_call_function(&fci, &fci_cache TSRMLS_CC) == SUCCESS && fci.retval) {
-			RETVAL_ZVAL(&retval, 1, 1);
-  		}
+        /* Call the function, and track the return value */
+        if (zend_call_function(&fci, &fci_cache TSRMLS_CC) == SUCCESS && fci.retval) {
+            RETVAL_ZVAL(&retval, 1, 1);
+        }
 
-		/* Clean up our mess */
-		zend_fcall_info_args_clear(&fci, 1);
-		zval_ptr_dtor(&params);
-		zval_ptr_dtor(&message);
+        /* Clean up our mess */
+        zend_fcall_info_args_clear(&fci, 1);
+        zval_ptr_dtor(&params);
+        zval_ptr_dtor(&message);
 
-		/* Check if user land function wants to bail */
-		if (EG(exception) || Z_TYPE_P(return_value) == IS_FALSE) {
-			break;
-		}
-	}
+        /* Check if user land function wants to bail */
+        if (EG(exception) || Z_TYPE_P(return_value) == IS_FALSE) {
+            break;
+        }
+    }
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-	return;
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    return;
 }
 /* }}} */
 
@@ -747,42 +860,52 @@ static PHP_METHOD(amqp_queue_class, consume)
 */
 static PHP_METHOD(amqp_queue_class, ack)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	zend_long deliveryTag = 0;
-	zend_long flags = AMQP_NOPARAM;
+    zend_long deliveryTag = 0;
+    zend_long flags = AMQP_NOPARAM;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &deliveryTag, &flags ) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &deliveryTag, &flags) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not ack message.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not ack message.");
 
-	/* NOTE: basic.ack is asynchronous and thus will not indicate failure if something goes wrong on the broker */
-	int status = amqp_basic_ack(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		(uint64_t) deliveryTag,
-		(AMQP_MULTIPLE & flags) ? 1 : 0
-	);
+    /* NOTE: basic.ack is asynchronous and thus will not indicate failure if something goes wrong on the broker */
+    int status = amqp_basic_ack(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        (uint64_t) deliveryTag,
+        (AMQP_MULTIPLE & flags) ? 1 : 0
+    );
 
-	if (status != AMQP_STATUS_OK) {
-		/* Emulate library error */
-		amqp_rpc_reply_t res;
-		res.reply_type 	  = AMQP_RESPONSE_LIBRARY_EXCEPTION;
-		res.library_error = status;
+    if (status != AMQP_STATUS_OK) {
+        /* Emulate library error */
+        amqp_rpc_reply_t res;
+        res.reply_type = AMQP_RESPONSE_LIBRARY_EXCEPTION;
+        res.library_error = status;
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_queue_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -792,43 +915,53 @@ static PHP_METHOD(amqp_queue_class, ack)
 */
 static PHP_METHOD(amqp_queue_class, nack)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	zend_long deliveryTag = 0;
-	zend_long flags = AMQP_NOPARAM;
+    zend_long deliveryTag = 0;
+    zend_long flags = AMQP_NOPARAM;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &deliveryTag, &flags ) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &deliveryTag, &flags) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not nack message.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not nack message.");
 
-	/* NOTE: basic.nack is asynchronous and thus will not indicate failure if something goes wrong on the broker */
-	int status = amqp_basic_nack(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		(uint64_t) deliveryTag,
-		(AMQP_MULTIPLE & flags) ? 1 : 0,
-		(AMQP_REQUEUE & flags) ? 1 : 0
-	);
+    /* NOTE: basic.nack is asynchronous and thus will not indicate failure if something goes wrong on the broker */
+    int status = amqp_basic_nack(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        (uint64_t) deliveryTag,
+        (AMQP_MULTIPLE & flags) ? 1 : 0,
+        (AMQP_REQUEUE & flags) ? 1 : 0
+    );
 
-	if (status != AMQP_STATUS_OK) {
-		/* Emulate library error */
-		amqp_rpc_reply_t res;
-		res.reply_type 	  = AMQP_RESPONSE_LIBRARY_EXCEPTION;
-		res.library_error = status;
+    if (status != AMQP_STATUS_OK) {
+        /* Emulate library error */
+        amqp_rpc_reply_t res;
+        res.reply_type = AMQP_RESPONSE_LIBRARY_EXCEPTION;
+        res.library_error = status;
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_queue_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -838,42 +971,52 @@ static PHP_METHOD(amqp_queue_class, nack)
 */
 static PHP_METHOD(amqp_queue_class, reject)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	zend_long deliveryTag = 0;
-	zend_long flags = AMQP_NOPARAM;
+    zend_long deliveryTag = 0;
+    zend_long flags = AMQP_NOPARAM;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &deliveryTag, &flags) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &deliveryTag, &flags) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not reject message.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not reject message.");
 
-	/* NOTE: basic.reject is asynchronous and thus will not indicate failure if something goes wrong on the broker */
-	int status = amqp_basic_reject(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		(uint64_t) deliveryTag,
-		(AMQP_REQUEUE & flags) ? 1 : 0
-	);
+    /* NOTE: basic.reject is asynchronous and thus will not indicate failure if something goes wrong on the broker */
+    int status = amqp_basic_reject(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        (uint64_t) deliveryTag,
+        (AMQP_REQUEUE & flags) ? 1 : 0
+    );
 
-	if (status != AMQP_STATUS_OK) {
-		/* Emulate library error */
-		amqp_rpc_reply_t res;
-		res.reply_type 	  = AMQP_RESPONSE_LIBRARY_EXCEPTION;
-		res.library_error = status;
+    if (status != AMQP_STATUS_OK) {
+        /* Emulate library error */
+        amqp_rpc_reply_t res;
+        res.reply_type = AMQP_RESPONSE_LIBRARY_EXCEPTION;
+        res.library_error = status;
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_queue_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -883,41 +1026,51 @@ purge queue
 */
 static PHP_METHOD(amqp_queue_class, purge)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not purge queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not purge queue.");
 
-	amqp_queue_purge_ok_t *r = amqp_queue_purge(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name"))
-	);
+    amqp_queue_purge_ok_t *r = amqp_queue_purge(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name"))
+    );
 
-	if (!r) {
-		amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    if (!r) {
+        amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_queue_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	/* long message_count = r->message_count; */
+    /* long message_count = r->message_count; */
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	/* RETURN_LONG(message_count) */;
+    /* RETURN_LONG(message_count) */;
 
-	/* BC */
-	RETURN_TRUE;
+    /* BC */
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -927,58 +1080,81 @@ cancel queue to consumer
 */
 static PHP_METHOD(amqp_queue_class, cancel)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	char *consumer_tag = NULL;
-	size_t consumer_tag_len = 0;
+    char *consumer_tag = NULL;
+    size_t consumer_tag_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &consumer_tag, &consumer_tag_len) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &consumer_tag, &consumer_tag_len) == FAILURE) {
+        return;
+    }
 
-	zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
-	zval *consumers = zend_read_property(amqp_channel_class_entry, PHP_AMQP_COMPAT_OBJ_P(channel_zv), ZEND_STRL("consumers"), 0 , &rv TSRMLS_CC);
-	zend_bool previous_consumer_tag_exists = (zend_bool) (IS_STRING == Z_TYPE_P(PHP_AMQP_READ_THIS_PROP("consumer_tag")));
+    zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
+    zval *consumers = zend_read_property(
+        amqp_channel_class_entry,
+        PHP_AMQP_COMPAT_OBJ_P(channel_zv),
+        ZEND_STRL("consumers"),
+        0,
+        &rv TSRMLS_CC
+    );
+    zend_bool previous_consumer_tag_exists =
+        (zend_bool) (IS_STRING == Z_TYPE_P(PHP_AMQP_READ_THIS_PROP("consumer_tag")));
 
-	if (IS_ARRAY != Z_TYPE_P(consumers)) {
-		zend_throw_exception(amqp_queue_exception_class_entry, "Invalid channel consumers, forgot to call channel constructor?", 0 TSRMLS_CC);
-		return;
-	}
+    if (IS_ARRAY != Z_TYPE_P(consumers)) {
+        zend_throw_exception(
+            amqp_queue_exception_class_entry,
+            "Invalid channel consumers, forgot to call channel constructor?",
+            0 TSRMLS_CC
+        );
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channel_zv);
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not cancel queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channel_zv);
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not cancel queue.");
 
-	if (!consumer_tag_len && (!previous_consumer_tag_exists || !PHP_AMQP_READ_THIS_PROP_STRLEN("consumer_tag"))) {
-		return;
-	}
+    if (!consumer_tag_len && (!previous_consumer_tag_exists || !PHP_AMQP_READ_THIS_PROP_STRLEN("consumer_tag"))) {
+        return;
+    }
 
-	amqp_basic_cancel_ok_t *r = amqp_basic_cancel(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		consumer_tag_len > 0 ? amqp_cstring_bytes(consumer_tag) : amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("consumer_tag"))
-	);
+    amqp_basic_cancel_ok_t *r = amqp_basic_cancel(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        consumer_tag_len > 0 ? amqp_cstring_bytes(consumer_tag)
+                             : amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("consumer_tag"))
+    );
 
-	if (!r) {
-		amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    if (!r) {
+        amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_queue_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	if (!consumer_tag_len || (previous_consumer_tag_exists && strcmp(consumer_tag, PHP_AMQP_READ_THIS_PROP_STR("consumer_tag")) == 0)) {
-		zend_update_property_null(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("consumer_tag") TSRMLS_CC);
-	}
+    if (!consumer_tag_len ||
+        (previous_consumer_tag_exists && strcmp(consumer_tag, PHP_AMQP_READ_THIS_PROP_STR("consumer_tag")) == 0)) {
+        zend_update_property_null(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("consumer_tag") TSRMLS_CC);
+    }
 
-	zend_hash_str_del_ind(Z_ARRVAL_P(consumers), r->consumer_tag.bytes, r->consumer_tag.len);
+    zend_hash_str_del_ind(Z_ARRVAL_P(consumers), r->consumer_tag.bytes, r->consumer_tag.len);
 
     php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -988,54 +1164,61 @@ unbind queue from exchange
 */
 static PHP_METHOD(amqp_queue_class, unbind)
 {
-	zval rv;
+    zval rv;
 
-	zval *zvalArguments = NULL;
-	amqp_channel_resource *channel_resource;
+    zval *zvalArguments = NULL;
+    amqp_channel_resource *channel_resource;
 
-	char *exchange_name;		size_t exchange_name_len;
-	char *keyname     = NULL;	size_t keyname_len = 0;
+    char *exchange_name;
+    size_t exchange_name_len;
+    char *keyname = NULL;
+    size_t keyname_len = 0;
 
-	amqp_table_t *arguments = NULL;
+    amqp_table_t *arguments = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|sa",
-							  &exchange_name, &exchange_name_len,
-							  &keyname, &keyname_len,
-							  &zvalArguments) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS() TSRMLS_CC,
+            "s|sa",
+            &exchange_name,
+            &exchange_name_len,
+            &keyname,
+            &keyname_len,
+            &zvalArguments
+        ) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not unbind queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not unbind queue.");
 
-	if (zvalArguments) {
-		arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
-	}
+    if (zvalArguments) {
+        arguments = php_amqp_type_convert_zval_to_amqp_table(zvalArguments TSRMLS_CC);
+    }
 
-	amqp_queue_unbind(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		(exchange_name_len > 0 ? amqp_cstring_bytes(exchange_name) : amqp_empty_bytes),
-		(keyname_len > 0 ? amqp_cstring_bytes(keyname) : amqp_empty_bytes),
-		(arguments ? *arguments : amqp_empty_table)
-	);
+    amqp_queue_unbind(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        (exchange_name_len > 0 ? amqp_cstring_bytes(exchange_name) : amqp_empty_bytes),
+        (keyname_len > 0 ? amqp_cstring_bytes(keyname) : amqp_empty_bytes),
+        (arguments ? *arguments : amqp_empty_table)
+    );
 
-	if (arguments) {
-		php_amqp_type_free_amqp_table(arguments);
-	}
+    if (arguments) {
+        php_amqp_type_free_amqp_table(arguments);
+    }
 
-	amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-	if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-		php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+    if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
+        php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry TSRMLS_CC);
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_TRUE;
+    RETURN_TRUE;
 }
 /* }}} */
 
@@ -1045,44 +1228,54 @@ delete queue and return the number of messages deleted in it
 */
 static PHP_METHOD(amqp_queue_class, delete)
 {
-	zval rv;
+    zval rv;
 
-	amqp_channel_resource *channel_resource;
+    amqp_channel_resource *channel_resource;
 
-	zend_long flags = AMQP_NOPARAM;
+    zend_long flags = AMQP_NOPARAM;
 
-	zend_long message_count;
+    zend_long message_count;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &flags) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &flags) == FAILURE) {
+        return;
+    }
 
-	channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-	PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not delete queue.");
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not delete queue.");
 
-	amqp_queue_delete_ok_t * r = amqp_queue_delete(
-		channel_resource->connection_resource->connection_state,
-		channel_resource->channel_id,
-		amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
-		(AMQP_IFUNUSED & flags) ? 1 : 0,
-		(AMQP_IFEMPTY & flags) ? 1 : 0
-	);
+    amqp_queue_delete_ok_t *r = amqp_queue_delete(
+        channel_resource->connection_resource->connection_state,
+        channel_resource->channel_id,
+        amqp_cstring_bytes(PHP_AMQP_READ_THIS_PROP_STR("name")),
+        (AMQP_IFUNUSED & flags) ? 1 : 0,
+        (AMQP_IFEMPTY & flags) ? 1 : 0
+    );
 
-	if (!r) {
-		amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
+    if (!r) {
+        amqp_rpc_reply_t res = amqp_get_rpc_reply(channel_resource->connection_resource->connection_state);
 
-		php_amqp_error(res, &PHP_AMQP_G(error_message), channel_resource->connection_resource, channel_resource TSRMLS_CC);
+        php_amqp_error(
+            res,
+            &PHP_AMQP_G(error_message),
+            channel_resource->connection_resource,
+            channel_resource TSRMLS_CC
+        );
 
-		php_amqp_zend_throw_exception(res, amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code) TSRMLS_CC);
-		php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-		return;
-	}
+        php_amqp_zend_throw_exception(
+            res,
+            amqp_queue_exception_class_entry,
+            PHP_AMQP_G(error_message),
+            PHP_AMQP_G(error_code) TSRMLS_CC
+        );
+        php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+        return;
+    }
 
-	message_count = r->message_count;
+    message_count = r->message_count;
 
-	php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+    php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-	RETURN_LONG(message_count);
+    RETURN_LONG(message_count);
 }
 /* }}} */
 
@@ -1090,9 +1283,9 @@ static PHP_METHOD(amqp_queue_class, delete)
 Get the AMQPChannel object in use */
 static PHP_METHOD(amqp_queue_class, getChannel)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("channel");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("channel");
 }
 /* }}} */
 
@@ -1100,9 +1293,9 @@ static PHP_METHOD(amqp_queue_class, getChannel)
 Get the AMQPConnection object in use */
 static PHP_METHOD(amqp_queue_class, getConnection)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("connection");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("connection");
 }
 /* }}} */
 
@@ -1110,100 +1303,100 @@ static PHP_METHOD(amqp_queue_class, getConnection)
 Get latest consumer tag*/
 static PHP_METHOD(amqp_queue_class, getConsumerTag)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
-	PHP_AMQP_RETURN_THIS_PROP("consumer_tag");
+    zval rv;
+    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_RETURN_THIS_PROP("consumer_tag");
 }
 
 /* }}} */
 /* amqp_queue_class ARG_INFO definition */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class__construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_OBJ_INFO(0, amqp_channel, AMQPChannel, 0)
+    ZEND_ARG_OBJ_INFO(0, amqp_channel, AMQPChannel, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_getName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_setName, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, queue_name)
+    ZEND_ARG_INFO(0, queue_name)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_getFlags, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_setFlags, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_getArgument, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, argument)
+    ZEND_ARG_INFO(0, argument)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_getArguments, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_setArgument, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
-				ZEND_ARG_INFO(0, key)
-				ZEND_ARG_INFO(0, value)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_hasArgument, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, key)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_setArguments, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_ARRAY_INFO(0, arguments, 0)
+    ZEND_ARG_ARRAY_INFO(0, arguments, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_declareQueue, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_bind, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, exchange_name)
-				ZEND_ARG_INFO(0, routing_key)
-				ZEND_ARG_INFO(0, arguments)
+    ZEND_ARG_INFO(0, exchange_name)
+    ZEND_ARG_INFO(0, routing_key)
+    ZEND_ARG_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_get, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_consume, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, callback)
-				ZEND_ARG_INFO(0, flags)
-				ZEND_ARG_INFO(0, consumer_tag)
+    ZEND_ARG_INFO(0, callback)
+    ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, consumer_tag)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_ack, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, delivery_tag)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, delivery_tag)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_nack, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, delivery_tag)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, delivery_tag)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_reject, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, delivery_tag)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, delivery_tag)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_purge, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_cancel, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
-				ZEND_ARG_INFO(0, consumer_tag)
+    ZEND_ARG_INFO(0, consumer_tag)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_unbind, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
-				ZEND_ARG_INFO(0, exchange_name)
-				ZEND_ARG_INFO(0, routing_key)
-				ZEND_ARG_INFO(0, arguments)
+    ZEND_ARG_INFO(0, exchange_name)
+    ZEND_ARG_INFO(0, routing_key)
+    ZEND_ARG_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_delete, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
-				ZEND_ARG_INFO(0, flags)
+    ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_getChannel, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
@@ -1216,75 +1409,64 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_getConsumerTag, ZEND_SEND_BY_VAL
 ZEND_END_ARG_INFO()
 
 zend_function_entry amqp_queue_class_functions[] = {
-		PHP_ME(amqp_queue_class, __construct,		arginfo_amqp_queue_class__construct,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, __construct,		arginfo_amqp_queue_class__construct,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_queue_class, getName,			arginfo_amqp_queue_class_getName,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, setName,			arginfo_amqp_queue_class_setName,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, getName,			arginfo_amqp_queue_class_getName,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, setName,			arginfo_amqp_queue_class_setName,			ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_queue_class, getFlags,			arginfo_amqp_queue_class_getFlags,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, setFlags,			arginfo_amqp_queue_class_setFlags,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, getFlags,			arginfo_amqp_queue_class_getFlags,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, setFlags,			arginfo_amqp_queue_class_setFlags,			ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_queue_class, getArgument,		arginfo_amqp_queue_class_getArgument,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, getArguments,		arginfo_amqp_queue_class_getArguments,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, setArgument,		arginfo_amqp_queue_class_setArgument,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, setArguments,		arginfo_amqp_queue_class_setArguments,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, hasArgument,		arginfo_amqp_queue_class_hasArgument,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, getArgument,		arginfo_amqp_queue_class_getArgument,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, getArguments,		arginfo_amqp_queue_class_getArguments,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, setArgument,		arginfo_amqp_queue_class_setArgument,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, setArguments,		arginfo_amqp_queue_class_setArguments,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, hasArgument,		arginfo_amqp_queue_class_hasArgument,		ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_queue_class, declareQueue,		arginfo_amqp_queue_class_declareQueue,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, bind,				arginfo_amqp_queue_class_bind,				ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, declareQueue,		arginfo_amqp_queue_class_declareQueue,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, bind,				arginfo_amqp_queue_class_bind,				ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_queue_class, get,				arginfo_amqp_queue_class_get,				ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, consume,			arginfo_amqp_queue_class_consume,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, ack,				arginfo_amqp_queue_class_ack,				ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, nack,				arginfo_amqp_queue_class_nack,				ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, reject,			arginfo_amqp_queue_class_reject,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, purge,				arginfo_amqp_queue_class_purge,				ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, get,				arginfo_amqp_queue_class_get,				ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, consume,			arginfo_amqp_queue_class_consume,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, ack,				arginfo_amqp_queue_class_ack,				ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, nack,				arginfo_amqp_queue_class_nack,				ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, reject,			arginfo_amqp_queue_class_reject,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, purge,				arginfo_amqp_queue_class_purge,				ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_queue_class, cancel,			arginfo_amqp_queue_class_cancel,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, delete,			arginfo_amqp_queue_class_delete,			ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, unbind,			arginfo_amqp_queue_class_unbind,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, cancel,			arginfo_amqp_queue_class_cancel,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, delete,			arginfo_amqp_queue_class_delete,			ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, unbind,			arginfo_amqp_queue_class_unbind,			ZEND_ACC_PUBLIC)
 
-		PHP_ME(amqp_queue_class, getChannel,		arginfo_amqp_queue_class_getChannel,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, getConnection,		arginfo_amqp_queue_class_getConnection,		ZEND_ACC_PUBLIC)
-		PHP_ME(amqp_queue_class, getConsumerTag,	arginfo_amqp_queue_class_getConsumerTag,	ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, getChannel,		arginfo_amqp_queue_class_getChannel,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, getConnection,		arginfo_amqp_queue_class_getConnection,		ZEND_ACC_PUBLIC)
+    PHP_ME(amqp_queue_class, getConsumerTag,	arginfo_amqp_queue_class_getConsumerTag,	ZEND_ACC_PUBLIC)
 
-		PHP_MALIAS(amqp_queue_class, declare, declareQueue, arginfo_amqp_queue_class_declareQueue,	ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+    PHP_MALIAS(amqp_queue_class, declare, declareQueue, arginfo_amqp_queue_class_declareQueue,	ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 
-		{NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 
 PHP_MINIT_FUNCTION(amqp_queue)
 {
-	zend_class_entry ce;
+    zend_class_entry ce;
 
-	INIT_CLASS_ENTRY(ce, "AMQPQueue", amqp_queue_class_functions);
-	this_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    INIT_CLASS_ENTRY(ce, "AMQPQueue", amqp_queue_class_functions);
+    this_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("connection"), ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("channel"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("connection"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("channel"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_stringl(this_ce, ZEND_STRL("name"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_null(this_ce, ZEND_STRL("consumer_tag"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_stringl(this_ce, ZEND_STRL("name"), "", 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("consumer_tag"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_bool(this_ce, ZEND_STRL("passive"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_bool(this_ce, ZEND_STRL("durable"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	zend_declare_property_bool(this_ce, ZEND_STRL("exclusive"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-	/* By default, the auto_delete flag should be set */
-	zend_declare_property_bool(this_ce, ZEND_STRL("auto_delete"), 1, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_bool(this_ce, ZEND_STRL("passive"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_bool(this_ce, ZEND_STRL("durable"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_bool(this_ce, ZEND_STRL("exclusive"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    /* By default, the auto_delete flag should be set */
+    zend_declare_property_bool(this_ce, ZEND_STRL("auto_delete"), 1, ZEND_ACC_PRIVATE TSRMLS_CC);
 
 
+    zend_declare_property_null(this_ce, ZEND_STRL("arguments"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	zend_declare_property_null(this_ce, ZEND_STRL("arguments"), ZEND_ACC_PRIVATE TSRMLS_CC);
-
-	return SUCCESS;
+    return SUCCESS;
 }
-
-/*
-*Local variables:
-*tab-width: 4
-*tabstop: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_queue.h
+++ b/amqp_queue.h
@@ -24,12 +24,3 @@ extern zend_class_entry *amqp_queue_class_entry;
 
 
 PHP_MINIT_FUNCTION(amqp_queue);
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_timestamp.c
+++ b/amqp_timestamp.c
@@ -21,7 +21,7 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
@@ -40,26 +40,36 @@ static const double AMQP_TIMESTAMP_MIN = 0;
  */
 static PHP_METHOD(amqp_timestamp_class, __construct)
 {
-	double timestamp;
+    double timestamp;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &timestamp) == FAILURE) {
-		return;
-	}
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &timestamp) == FAILURE) {
+        return;
+    }
 
-	if (timestamp < AMQP_TIMESTAMP_MIN) {
-		zend_throw_exception_ex(amqp_value_exception_class_entry, 0 TSRMLS_CC, "The timestamp parameter must be greater than %0.f.", AMQP_TIMESTAMP_MIN);
-		return;
-	}
+    if (timestamp < AMQP_TIMESTAMP_MIN) {
+        zend_throw_exception_ex(
+            amqp_value_exception_class_entry,
+            0 TSRMLS_CC,
+            "The timestamp parameter must be greater than %0.f.",
+            AMQP_TIMESTAMP_MIN
+        );
+        return;
+    }
 
-	if (timestamp > AMQP_TIMESTAMP_MAX) {
-		zend_throw_exception_ex(amqp_value_exception_class_entry, 0 TSRMLS_CC, "The timestamp parameter must be less than %0.f.", AMQP_TIMESTAMP_MAX);
-		return;
-	}
+    if (timestamp > AMQP_TIMESTAMP_MAX) {
+        zend_throw_exception_ex(
+            amqp_value_exception_class_entry,
+            0 TSRMLS_CC,
+            "The timestamp parameter must be less than %0.f.",
+            AMQP_TIMESTAMP_MAX
+        );
+        return;
+    }
 
-	zend_string *str;
-	str = _php_math_number_format_ex(timestamp, 0, "", 0, "", 0);
-	zend_update_property_str(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("timestamp"), str);
-	zend_string_delref(str);
+    zend_string *str;
+    str = _php_math_number_format_ex(timestamp, 0, "", 0, "", 0);
+    zend_update_property_str(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("timestamp"), str);
+    zend_string_delref(str);
 }
 /* }}} */
 
@@ -68,10 +78,10 @@ static PHP_METHOD(amqp_timestamp_class, __construct)
 Get timestamp */
 static PHP_METHOD(amqp_timestamp_class, getTimestamp)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
+    zval rv;
+    PHP_AMQP_NOPARAMS();
 
-	PHP_AMQP_RETURN_THIS_PROP("timestamp");
+    PHP_AMQP_RETURN_THIS_PROP("timestamp");
 }
 /* }}} */
 
@@ -80,15 +90,15 @@ static PHP_METHOD(amqp_timestamp_class, getTimestamp)
 Return timestamp as string */
 static PHP_METHOD(amqp_timestamp_class, __toString)
 {
-	zval rv;
-	PHP_AMQP_NOPARAMS();
+    zval rv;
+    PHP_AMQP_NOPARAMS();
 
-	PHP_AMQP_RETURN_THIS_PROP("timestamp");
+    PHP_AMQP_RETURN_THIS_PROP("timestamp");
 }
 /* }}} */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_timestamp_class_construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
-	ZEND_ARG_INFO(0, timestamp)
+    ZEND_ARG_INFO(0, timestamp)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_timestamp_class_getTimestamp, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
@@ -97,7 +107,13 @@ ZEND_END_ARG_INFO()
 #if PHP_MAJOR_VERSION < 8
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_timestamp_class_toString, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_timestamp_class_toString, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(
+    arginfo_amqp_timestamp_class_toString,
+    ZEND_SEND_BY_VAL,
+    ZEND_RETURN_VALUE,
+    IS_STRING,
+    0
+)
 #endif
 ZEND_END_ARG_INFO()
 
@@ -106,36 +122,27 @@ zend_function_entry amqp_timestamp_class_functions[] = {
 	PHP_ME(amqp_timestamp_class, getTimestamp, 	arginfo_amqp_timestamp_class_getTimestamp,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_timestamp_class, __toString, 	arginfo_amqp_timestamp_class_toString,	ZEND_ACC_PUBLIC)
 
-	{NULL, NULL, NULL}
+    {NULL, NULL, NULL}
 };
 
 
 PHP_MINIT_FUNCTION(amqp_timestamp)
 {
-	zend_class_entry ce;
-	char min[21], max[21];
-	int min_len, max_len;
+    zend_class_entry ce;
+    char min[21], max[21];
+    int min_len, max_len;
 
-	INIT_CLASS_ENTRY(ce, "AMQPTimestamp", amqp_timestamp_class_functions);
-	this_ce = zend_register_internal_class(&ce TSRMLS_CC);
-	this_ce->ce_flags = this_ce->ce_flags | ZEND_ACC_FINAL;
+    INIT_CLASS_ENTRY(ce, "AMQPTimestamp", amqp_timestamp_class_functions);
+    this_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    this_ce->ce_flags = this_ce->ce_flags | ZEND_ACC_FINAL;
 
-	zend_declare_property_null(this_ce, ZEND_STRL("timestamp"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(this_ce, ZEND_STRL("timestamp"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
-	max_len = snprintf(max, sizeof(max), "%.0f", AMQP_TIMESTAMP_MAX);
-	zend_declare_class_constant_stringl(this_ce, ZEND_STRL("MAX"), max, max_len TSRMLS_CC);
+    max_len = snprintf(max, sizeof(max), "%.0f", AMQP_TIMESTAMP_MAX);
+    zend_declare_class_constant_stringl(this_ce, ZEND_STRL("MAX"), max, max_len TSRMLS_CC);
 
-	min_len = snprintf(min, sizeof(min), "%.0f", AMQP_TIMESTAMP_MIN);
-	zend_declare_class_constant_stringl(this_ce, ZEND_STRL("MIN"), min, min_len TSRMLS_CC);
+    min_len = snprintf(min, sizeof(min), "%.0f", AMQP_TIMESTAMP_MIN);
+    zend_declare_class_constant_stringl(this_ce, ZEND_STRL("MIN"), min, min_len TSRMLS_CC);
 
-	return SUCCESS;
+    return SUCCESS;
 }
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<6
-*/

--- a/amqp_timestamp.h
+++ b/amqp_timestamp.h
@@ -25,12 +25,3 @@
 extern zend_class_entry *amqp_timestamp_class_entry;
 
 PHP_MINIT_FUNCTION(amqp_timestamp);
-
-/*
-*Local variables:
-*tab-width: 4
-*c-basic-offset: 4
-*End:
-*vim600: noet sw=4 ts=4 fdm=marker
-*vim<600: noet sw=4 ts=4
-*/

--- a/amqp_type.c
+++ b/amqp_type.c
@@ -21,22 +21,21 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
-#include <stdint.h>
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/amqp.h>
 #else
-#include <amqp.h>
+    #include <amqp.h>
 #endif
 #include "Zend/zend_interfaces.h"
-#include "amqp_type.h"
-#include "amqp_timestamp.h"
 #include "amqp_decimal.h"
+#include "amqp_timestamp.h"
+#include "amqp_type.h"
 
 #ifdef PHP_WIN32
-# define strtoimax _strtoi64
+    #define strtoimax _strtoi64
 #endif
 
 static void php_amqp_type_internal_free_amqp_array(amqp_array_t *array);
@@ -44,319 +43,354 @@ static void php_amqp_type_internal_free_amqp_table(amqp_table_t *object, zend_bo
 
 amqp_bytes_t php_amqp_type_char_to_amqp_long(char const *cstr, size_t len)
 {
-	amqp_bytes_t result;
+    amqp_bytes_t result;
 
-	if (len < 1) {
-		return amqp_empty_bytes;
-	}
+    if (len < 1) {
+        return amqp_empty_bytes;
+    }
 
-	result.len   = (size_t)len;
-	result.bytes = (void *) cstr;
+    result.len = (size_t) len;
+    result.bytes = (void *) cstr;
 
-	return result;
+    return result;
 }
 
 char *php_amqp_type_amqp_bytes_to_char(amqp_bytes_t bytes)
 {
-/* We will need up to 4 chars per byte, plus the terminating 0 */
-	char *res = emalloc(bytes.len * 4 + 1);
-	uint8_t *data = bytes.bytes;
-	char *p = res;
-	size_t i;
+    /* We will need up to 4 chars per byte, plus the terminating 0 */
+    char *res = emalloc(bytes.len * 4 + 1);
+    uint8_t *data = bytes.bytes;
+    char *p = res;
+    size_t i;
 
-	for (i = 0; i < bytes.len; i++) {
-		if (data[i] >= 32 && data[i] != 127) {
-			*p++ = data[i];
-		} else {
-			*p++ = '\\';
-			*p++ = '0' + (data[i] >> 6);
-			*p++ = '0' + (data[i] >> 3 & 0x7);
-			*p++ = '0' + (data[i] & 0x7);
-		}
-	}
+    for (i = 0; i < bytes.len; i++) {
+        if (data[i] >= 32 && data[i] != 127) {
+            *p++ = data[i];
+        } else {
+            *p++ = '\\';
+            *p++ = '0' + (data[i] >> 6);
+            *p++ = '0' + (data[i] >> 3 & 0x7);
+            *p++ = '0' + (data[i] & 0x7);
+        }
+    }
 
-	*p = 0;
-	return res;
+    *p = 0;
+    return res;
 }
 
-void php_amqp_type_internal_convert_zval_array(zval *php_array, amqp_field_value_t **field, zend_bool allow_int_keys TSRMLS_DC)
+void php_amqp_type_internal_convert_zval_array(
+    zval *php_array,
+    amqp_field_value_t **field,
+    zend_bool allow_int_keys TSRMLS_DC
+)
 {
-	HashTable *ht;
-	zend_string *key;
+    HashTable *ht;
+    zend_string *key;
 
-	ht = Z_ARRVAL_P(php_array);
+    ht = Z_ARRVAL_P(php_array);
 
-	zend_bool is_amqp_array = 1;
+    zend_bool is_amqp_array = 1;
 
-	ZEND_HASH_FOREACH_STR_KEY(ht, key) {
-		if (key) {
-			is_amqp_array = 0;
-			break;
-		}
-	} ZEND_HASH_FOREACH_END();
+    ZEND_HASH_FOREACH_STR_KEY(ht, key)
+        if (key) {
+            is_amqp_array = 0;
+            break;
+        }
+    ZEND_HASH_FOREACH_END ();
 
-	if (is_amqp_array) {
-		(*field)->kind = AMQP_FIELD_KIND_ARRAY;
-		php_amqp_type_internal_convert_zval_to_amqp_array(php_array, &(*field)->value.array TSRMLS_CC);
-	} else {
-		(*field)->kind = AMQP_FIELD_KIND_TABLE;
-		php_amqp_type_internal_convert_zval_to_amqp_table(php_array, &(*field)->value.table, allow_int_keys TSRMLS_CC);
-	}
+    if (is_amqp_array) {
+        (*field)->kind = AMQP_FIELD_KIND_ARRAY;
+        php_amqp_type_internal_convert_zval_to_amqp_array(php_array, &(*field)->value.array TSRMLS_CC);
+    } else {
+        (*field)->kind = AMQP_FIELD_KIND_TABLE;
+        php_amqp_type_internal_convert_zval_to_amqp_table(php_array, &(*field)->value.table, allow_int_keys TSRMLS_CC);
+    }
 }
 
-void php_amqp_type_internal_convert_zval_to_amqp_table(zval *php_array, amqp_table_t *amqp_table, zend_bool allow_int_keys TSRMLS_DC)
+void php_amqp_type_internal_convert_zval_to_amqp_table(
+    zval *php_array,
+    amqp_table_t *amqp_table,
+    zend_bool allow_int_keys TSRMLS_DC
+)
 {
-	HashTable *ht;
-	zval *value;
-	zend_string *zkey;
-	zend_ulong index;
-	char *key;
-	unsigned key_len;
-	ht = Z_ARRVAL_P(php_array);
+    HashTable *ht;
+    zval *value;
+    zend_string *zkey;
+    zend_ulong index;
+    char *key;
+    unsigned key_len;
+    ht = Z_ARRVAL_P(php_array);
 
-	amqp_table->entries = (amqp_table_entry_t *)ecalloc((size_t)zend_hash_num_elements(ht), sizeof(amqp_table_entry_t));
-	amqp_table->num_entries = 0;
+    amqp_table->entries =
+        (amqp_table_entry_t *) ecalloc((size_t) zend_hash_num_elements(ht), sizeof(amqp_table_entry_t));
+    amqp_table->num_entries = 0;
 
-	ZEND_HASH_FOREACH_KEY_VAL(ht, index, zkey, value) {
-		char *string_key;
-		amqp_table_entry_t *table_entry;
-		amqp_field_value_t *field;
+    ZEND_HASH_FOREACH_KEY_VAL(ht, index, zkey, value)
+        char *string_key;
+        amqp_table_entry_t *table_entry;
+        amqp_field_value_t *field;
 
-		/* Now pull the key */
-		if (!zkey) {
-			if (allow_int_keys) {
-				/* Convert to strings non-string keys */
-				char str[32];
+        /* Now pull the key */
+        if (!zkey) {
+            if (allow_int_keys) {
+                /* Convert to strings non-string keys */
+                char str[32];
 
-				key_len = sprintf(str, "%lu", index);
-				key     = str;
-			} else {
-				/* Skip things that are not strings */
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Ignoring non-string header field '%lu'", index);
+                key_len = sprintf(str, "%lu", index);
+                key = str;
+            } else {
+                /* Skip things that are not strings */
+                php_error_docref(NULL TSRMLS_CC, E_WARNING, "Ignoring non-string header field '%lu'", index);
 
-				continue;
-			}
-		} else {
-			key_len = ZSTR_LEN(zkey);
-			key = ZSTR_VAL(zkey);
-		}
+                continue;
+            }
+        } else {
+            key_len = ZSTR_LEN(zkey);
+            key = ZSTR_VAL(zkey);
+        }
 
-		/* Build the value */
-		table_entry = &amqp_table->entries[amqp_table->num_entries++];
-		field = &table_entry->value;
+        /* Build the value */
+        table_entry = &amqp_table->entries[amqp_table->num_entries++];
+        field = &table_entry->value;
 
-		if (!php_amqp_type_internal_convert_php_to_amqp_field_value(value, &field, key TSRMLS_CC)) {
-			/* Reset entries counter back */
-			amqp_table->num_entries --;
+        if (!php_amqp_type_internal_convert_php_to_amqp_field_value(value, &field, key TSRMLS_CC)) {
+            /* Reset entries counter back */
+            amqp_table->num_entries--;
 
-			continue;
-		}
+            continue;
+        }
 
-		string_key = estrndup(key, key_len);
-		table_entry->key = amqp_cstring_bytes(string_key);
-
-	} ZEND_HASH_FOREACH_END();
+        string_key = estrndup(key, key_len);
+        table_entry->key = amqp_cstring_bytes(string_key);
+    ZEND_HASH_FOREACH_END();
 }
 
 void php_amqp_type_internal_convert_zval_to_amqp_array(zval *zval_arguments, amqp_array_t *arguments TSRMLS_DC)
 {
-	HashTable *ht;
+    HashTable *ht;
 
-	zval *value;
+    zval *value;
 
-	zend_string *zkey;
+    zend_string *zkey;
 
-	ht = Z_ARRVAL_P(zval_arguments);
+    ht = Z_ARRVAL_P(zval_arguments);
 
-	/* Allocate all the memory necessary for storing the arguments */
-	arguments->entries = (amqp_field_value_t *)ecalloc((size_t)zend_hash_num_elements(ht), sizeof(amqp_field_value_t));
-	arguments->num_entries = 0;
+    /* Allocate all the memory necessary for storing the arguments */
+    arguments->entries =
+        (amqp_field_value_t *) ecalloc((size_t) zend_hash_num_elements(ht), sizeof(amqp_field_value_t));
+    arguments->num_entries = 0;
 
-	ZEND_HASH_FOREACH_STR_KEY_VAL(ht, zkey, value) {
-		amqp_field_value_t *field = &arguments->entries[arguments->num_entries++];
+    ZEND_HASH_FOREACH_STR_KEY_VAL(ht, zkey, value)
+        amqp_field_value_t *field = &arguments->entries[arguments->num_entries++];
 
-		if (!php_amqp_type_internal_convert_php_to_amqp_field_value(value, &field, ZSTR_VAL(zkey) TSRMLS_CC)) {
-			/* Reset entries counter back */
-			arguments->num_entries --;
+        if (!php_amqp_type_internal_convert_php_to_amqp_field_value(value, &field, ZSTR_VAL(zkey) TSRMLS_CC)) {
+            /* Reset entries counter back */
+            arguments->num_entries--;
 
-			continue;
-		}
-	} ZEND_HASH_FOREACH_END();
+            continue;
+        }
+    ZEND_HASH_FOREACH_END ();
 }
 
-zend_bool php_amqp_type_internal_convert_php_to_amqp_field_value(zval *value, amqp_field_value_t **fieldPtr, char *key TSRMLS_DC)
+zend_bool php_amqp_type_internal_convert_php_to_amqp_field_value(
+    zval *value,
+    amqp_field_value_t **fieldPtr,
+    char *key TSRMLS_DC
+)
 {
-	zend_bool result;
-	char type[16];
-	amqp_field_value_t *field;
+    zend_bool result;
+    char type[16];
+    amqp_field_value_t *field;
 
-	result = 1;
-	field = *fieldPtr;
+    result = 1;
+    field = *fieldPtr;
 
-	switch (Z_TYPE_P(value)) {
-		case IS_TRUE:
-		case IS_FALSE:
-			field->kind = AMQP_FIELD_KIND_BOOLEAN;
-			field->value.boolean = (amqp_boolean_t) Z_TYPE_P(value) != IS_FALSE;
-			break;
-		case IS_DOUBLE:
-			field->kind = AMQP_FIELD_KIND_F64;
-			field->value.f64 = Z_DVAL_P(value);
-			break;
-		case IS_LONG:
-			field->kind = AMQP_FIELD_KIND_I64;
-			field->value.i64 = Z_LVAL_P(value);
-			break;
-		case IS_STRING:
-			field->kind = AMQP_FIELD_KIND_UTF8;
+    switch (Z_TYPE_P(value)) {
+        case IS_TRUE:
+        case IS_FALSE:
+            field->kind = AMQP_FIELD_KIND_BOOLEAN;
+            field->value.boolean = (amqp_boolean_t) Z_TYPE_P(value) != IS_FALSE;
+            break;
+        case IS_DOUBLE:
+            field->kind = AMQP_FIELD_KIND_F64;
+            field->value.f64 = Z_DVAL_P(value);
+            break;
+        case IS_LONG:
+            field->kind = AMQP_FIELD_KIND_I64;
+            field->value.i64 = Z_LVAL_P(value);
+            break;
+        case IS_STRING:
+            field->kind = AMQP_FIELD_KIND_UTF8;
 
-			if (Z_STRLEN_P(value)) {
-				amqp_bytes_t bytes;
-				bytes.len = (size_t) Z_STRLEN_P(value);
-				bytes.bytes = estrndup(Z_STRVAL_P(value), (unsigned) Z_STRLEN_P(value));
+            if (Z_STRLEN_P(value)) {
+                amqp_bytes_t bytes;
+                bytes.len = (size_t) Z_STRLEN_P(value);
+                bytes.bytes = estrndup(Z_STRVAL_P(value), (unsigned) Z_STRLEN_P(value));
 
-				field->value.bytes = bytes;
-			} else {
-				field->value.bytes = amqp_empty_bytes;
-			}
+                field->value.bytes = bytes;
+            } else {
+                field->value.bytes = amqp_empty_bytes;
+            }
 
-			break;
-		case IS_ARRAY:
-			php_amqp_type_internal_convert_zval_array(value, &field, 1 TSRMLS_CC);
-			break;
-		case IS_NULL:
-			field->kind = AMQP_FIELD_KIND_VOID;
-			break;
-		case IS_OBJECT:
-			if (instanceof_function(Z_OBJCE_P(value), amqp_timestamp_class_entry TSRMLS_CC)) {
+            break;
+        case IS_ARRAY:
+            php_amqp_type_internal_convert_zval_array(value, &field, 1 TSRMLS_CC);
+            break;
+        case IS_NULL:
+            field->kind = AMQP_FIELD_KIND_VOID;
+            break;
+        case IS_OBJECT:
+            if (instanceof_function(Z_OBJCE_P(value), amqp_timestamp_class_entry TSRMLS_CC)) {
                 zval result_zv;
 
-                zend_call_method_with_0_params(PHP_AMQP_COMPAT_OBJ_P(value), amqp_timestamp_class_entry, NULL, "gettimestamp", &result_zv);
+                zend_call_method_with_0_params(
+                    PHP_AMQP_COMPAT_OBJ_P(value),
+                    amqp_timestamp_class_entry,
+                    NULL,
+                    "gettimestamp",
+                    &result_zv
+                );
 
                 field->kind = AMQP_FIELD_KIND_TIMESTAMP;
                 field->value.u64 = strtoimax(Z_STRVAL(result_zv), NULL, 10);
 
-				zval_ptr_dtor(&result_zv);
+                zval_ptr_dtor(&result_zv);
 
-				break;
-			} else if (instanceof_function(Z_OBJCE_P(value), amqp_decimal_class_entry TSRMLS_CC)) {
-				field->kind = AMQP_FIELD_KIND_DECIMAL;
-				zval result_zv;
+                break;
+            } else if (instanceof_function(Z_OBJCE_P(value), amqp_decimal_class_entry TSRMLS_CC)) {
+                field->kind = AMQP_FIELD_KIND_DECIMAL;
+                zval result_zv;
 
-				zend_call_method_with_0_params(PHP_AMQP_COMPAT_OBJ_P(value), amqp_decimal_class_entry, NULL, "getexponent", &result_zv);
-				field->value.decimal.decimals = (uint8_t)Z_LVAL(result_zv);
-				zval_ptr_dtor(&result_zv);
+                zend_call_method_with_0_params(
+                    PHP_AMQP_COMPAT_OBJ_P(value),
+                    amqp_decimal_class_entry,
+                    NULL,
+                    "getexponent",
+                    &result_zv
+                );
+                field->value.decimal.decimals = (uint8_t) Z_LVAL(result_zv);
+                zval_ptr_dtor(&result_zv);
 
-				zend_call_method_with_0_params(PHP_AMQP_COMPAT_OBJ_P(value), amqp_decimal_class_entry, NULL, "getsignificand", &result_zv);
-				field->value.decimal.value = (uint32_t)Z_LVAL(result_zv);
-				zval_ptr_dtor(&result_zv);
+                zend_call_method_with_0_params(
+                    PHP_AMQP_COMPAT_OBJ_P(value),
+                    amqp_decimal_class_entry,
+                    NULL,
+                    "getsignificand",
+                    &result_zv
+                );
+                field->value.decimal.value = (uint32_t) Z_LVAL(result_zv);
+                zval_ptr_dtor(&result_zv);
 
-				break;
-			}
-		default:
-			switch(Z_TYPE_P(value)) {
-				case IS_OBJECT:
-					strcpy(type, "object");
-					break;
-				case IS_RESOURCE:
-					strcpy(type, "resource");
-					break;
-				default:
-					strcpy(type, "unknown");
-					break;
-			}
+                break;
+            }
+        default:
+            switch (Z_TYPE_P(value)) {
+                case IS_OBJECT:
+                    strcpy(type, "object");
+                    break;
+                case IS_RESOURCE:
+                    strcpy(type, "resource");
+                    break;
+                default:
+                    strcpy(type, "unknown");
+                    break;
+            }
 
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Ignoring field '%s' due to unsupported value type (%s)", key, type);
-			result = 0;
-			break;
-	}
+            php_error_docref(
+                NULL TSRMLS_CC,
+                E_WARNING,
+                "Ignoring field '%s' due to unsupported value type (%s)",
+                key,
+                type
+            );
+            result = 0;
+            break;
+    }
 
-	return result;
+    return result;
 }
 
 amqp_table_t *php_amqp_type_convert_zval_to_amqp_table(zval *php_array TSRMLS_DC)
 {
-	amqp_table_t *amqp_table;
-	/* In setArguments, we are overwriting all the existing values */
-	amqp_table = (amqp_table_t *)emalloc(sizeof(amqp_table_t));
+    amqp_table_t *amqp_table;
+    /* In setArguments, we are overwriting all the existing values */
+    amqp_table = (amqp_table_t *) emalloc(sizeof(amqp_table_t));
 
-	php_amqp_type_internal_convert_zval_to_amqp_table(php_array, amqp_table, 0 TSRMLS_CC);
+    php_amqp_type_internal_convert_zval_to_amqp_table(php_array, amqp_table, 0 TSRMLS_CC);
 
-	return amqp_table;
+    return amqp_table;
 }
 
 
-static void php_amqp_type_internal_free_amqp_array(amqp_array_t *array) {
-	if (!array) {
-		return;
-	}
+static void php_amqp_type_internal_free_amqp_array(amqp_array_t *array)
+{
+    if (!array) {
+        return;
+    }
 
-	int macroEntryCounter;
-	for (macroEntryCounter = 0; macroEntryCounter < array->num_entries; macroEntryCounter++) {
+    int macroEntryCounter;
+    for (macroEntryCounter = 0; macroEntryCounter < array->num_entries; macroEntryCounter++) {
 
-		amqp_field_value_t *entry = &array->entries[macroEntryCounter];
+        amqp_field_value_t *entry = &array->entries[macroEntryCounter];
 
-		switch (entry->kind) {
-			case AMQP_FIELD_KIND_TABLE:
-				php_amqp_type_internal_free_amqp_table(&entry->value.table, 0);
-				break;
-			case AMQP_FIELD_KIND_ARRAY:
-				php_amqp_type_internal_free_amqp_array(&entry->value.array);
-				break;
-			case AMQP_FIELD_KIND_UTF8:
-				if (entry->value.bytes.bytes) {
-					efree(entry->value.bytes.bytes);
-				}
-				break;
-				//
-			default:
-				break;
-		}
-	}
+        switch (entry->kind) {
+            case AMQP_FIELD_KIND_TABLE:
+                php_amqp_type_internal_free_amqp_table(&entry->value.table, 0);
+                break;
+            case AMQP_FIELD_KIND_ARRAY:
+                php_amqp_type_internal_free_amqp_array(&entry->value.array);
+                break;
+            case AMQP_FIELD_KIND_UTF8:
+                if (entry->value.bytes.bytes) {
+                    efree(entry->value.bytes.bytes);
+                }
+                break;
+                //
+            default:
+                break;
+        }
+    }
 
-	if (array->entries) {
-		efree(array->entries);
-	}
+    if (array->entries) {
+        efree(array->entries);
+    }
 }
 
 static void php_amqp_type_internal_free_amqp_table(amqp_table_t *object, zend_bool clear_root)
 {
-	if (!object) {
-		return;
-	}
+    if (!object) {
+        return;
+    }
 
-	if (object->entries) {
-		int macroEntryCounter;
-		for (macroEntryCounter = 0; macroEntryCounter < object->num_entries; macroEntryCounter++) {
+    if (object->entries) {
+        int macroEntryCounter;
+        for (macroEntryCounter = 0; macroEntryCounter < object->num_entries; macroEntryCounter++) {
 
-			amqp_table_entry_t *entry = &object->entries[macroEntryCounter];
-			efree(entry->key.bytes);
+            amqp_table_entry_t *entry = &object->entries[macroEntryCounter];
+            efree(entry->key.bytes);
 
-			switch (entry->value.kind) {
-				case AMQP_FIELD_KIND_TABLE:
-					php_amqp_type_internal_free_amqp_table(&entry->value.value.table, 0);
-					break;
-				case AMQP_FIELD_KIND_ARRAY:
-					php_amqp_type_internal_free_amqp_array(&entry->value.value.array);
-					break;
-				case AMQP_FIELD_KIND_UTF8:
-					if (entry->value.value.bytes.bytes) {
-						efree(entry->value.value.bytes.bytes);
-					}
-					break;
-				default:
-					break;
-			}
-		}
-		efree(object->entries);
-	}
+            switch (entry->value.kind) {
+                case AMQP_FIELD_KIND_TABLE:
+                    php_amqp_type_internal_free_amqp_table(&entry->value.value.table, 0);
+                    break;
+                case AMQP_FIELD_KIND_ARRAY:
+                    php_amqp_type_internal_free_amqp_array(&entry->value.value.array);
+                    break;
+                case AMQP_FIELD_KIND_UTF8:
+                    if (entry->value.value.bytes.bytes) {
+                        efree(entry->value.value.bytes.bytes);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        efree(object->entries);
+    }
 
-	if (clear_root) {
-		efree(object);
-	}
+    if (clear_root) {
+        efree(object);
+    }
 }
 
-void php_amqp_type_free_amqp_table(amqp_table_t *object)
-{
-	php_amqp_type_internal_free_amqp_table(object, 1);
-}
+void php_amqp_type_free_amqp_table(amqp_table_t *object) { php_amqp_type_internal_free_amqp_table(object, 1); }

--- a/amqp_type.h
+++ b/amqp_type.h
@@ -21,15 +21,15 @@
   +----------------------------------------------------------------------+
 */
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 #include "php.h"
 
 #if AMQP_VERSION_MINOR >= 13
-#include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/amqp.h>
 #else
-#include <amqp.h>
+    #include <amqp.h>
 #endif
 #include "php_amqp.h"
 
@@ -42,7 +42,19 @@ amqp_table_t *php_amqp_type_convert_zval_to_amqp_table(zval *php_array TSRMLS_DC
 void php_amqp_type_free_amqp_table(amqp_table_t *object);
 
 /** Internal functions */
-zend_bool php_amqp_type_internal_convert_php_to_amqp_field_value(zval *value, amqp_field_value_t **fieldPtr, char *key TSRMLS_DC);
-void php_amqp_type_internal_convert_zval_array(zval *php_array, amqp_field_value_t **field, zend_bool allow_int_keys TSRMLS_DC);
-void php_amqp_type_internal_convert_zval_to_amqp_table(zval *php_array, amqp_table_t *amqp_table, zend_bool allow_int_keys TSRMLS_DC);
+zend_bool php_amqp_type_internal_convert_php_to_amqp_field_value(
+    zval *value,
+    amqp_field_value_t **fieldPtr,
+    char *key TSRMLS_DC
+);
+void php_amqp_type_internal_convert_zval_array(
+    zval *php_array,
+    amqp_field_value_t **field,
+    zend_bool allow_int_keys TSRMLS_DC
+);
+void php_amqp_type_internal_convert_zval_to_amqp_table(
+    zval *php_array,
+    amqp_table_t *amqp_table,
+    zend_bool allow_int_keys TSRMLS_DC
+);
 void php_amqp_type_internal_convert_zval_to_amqp_array(zval *php_array, amqp_array_t *amqp_array TSRMLS_DC);

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -24,17 +24,13 @@
 #define PHP_AMQP_H
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+    #include "config.h"
 #endif
 
 /* True global resources - no need for thread safety here */
-extern zend_class_entry *amqp_exception_class_entry,
-		*amqp_connection_exception_class_entry,
-		*amqp_channel_exception_class_entry,
-		*amqp_exchange_exception_class_entry,
-		*amqp_queue_exception_class_entry,
-		*amqp_envelope_exception_class_entry,
-		*amqp_value_exception_class_entry;
+extern zend_class_entry *amqp_exception_class_entry, *amqp_connection_exception_class_entry,
+    *amqp_channel_exception_class_entry, *amqp_exchange_exception_class_entry, *amqp_queue_exception_class_entry,
+    *amqp_envelope_exception_class_entry, *amqp_value_exception_class_entry;
 
 
 typedef struct _amqp_connection_resource amqp_connection_resource;
@@ -45,27 +41,27 @@ typedef struct _amqp_channel_callbacks amqp_channel_callbacks;
 typedef struct _amqp_callback_bucket amqp_callback_bucket;
 
 #if PHP_VERSION_ID < 50600
-// should never get her, but just in case
-#error PHP >= 5.6 required
+    // should never get her, but just in case
+    #error PHP >= 5.6 required
 #endif
 
 #if HAVE_LIBRABBITMQ_NEW_LAYOUT
-#include <rabbitmq-c/amqp.h>
+    #include <rabbitmq-c/amqp.h>
 #else
-#include <amqp.h>
+    #include <amqp.h>
 #endif
 
 extern zend_module_entry amqp_module_entry;
 #define phpext_amqp_ptr &amqp_module_entry
 
 #ifdef PHP_WIN32
-#define PHP_AMQP_API __declspec(dllexport)
+    #define PHP_AMQP_API __declspec(dllexport)
 #else
-#define PHP_AMQP_API
+    #define PHP_AMQP_API
 #endif
 
 #ifdef ZTS
-#include "TSRM.h"
+    #include "TSRM.h"
 #endif
 
 /* Small change to let it build after a major internal change for php8.0
@@ -73,114 +69,114 @@ extern zend_module_entry amqp_module_entry;
  * https://github.com/php/php-src/blob/php-8.0.0alpha3/UPGRADING.INTERNALS#L47
  */
 #if PHP_MAJOR_VERSION >= 8
-#define TSRMLS_DC
-#define TSRMLS_D
-#define TSRMLS_CC
-#define TSRMLS_C
-#define PHP_AMQP_COMPAT_OBJ_P(zv) Z_OBJ_P(zv)
+    #define TSRMLS_DC
+    #define TSRMLS_D
+    #define TSRMLS_CC
+    #define TSRMLS_C
+    #define PHP_AMQP_COMPAT_OBJ_P(zv) Z_OBJ_P(zv)
 #else
-#define PHP_AMQP_COMPAT_OBJ_P(zv) (zv)
+    #define PHP_AMQP_COMPAT_OBJ_P(zv) (zv)
 #endif
 #if PHP_VERSION_ID < 80200
-#define zend_ini_parse_quantity_warn(v, name) (zend_atol(ZSTR_VAL(v), ZSTR_LEN(v)))
+    #define zend_ini_parse_quantity_warn(v, name) (zend_atol(ZSTR_VAL(v), ZSTR_LEN(v)))
 #endif
 
 #include "amqp_connection_resource.h"
 
-#define AMQP_NOPARAM		0
+#define AMQP_NOPARAM 0
 /* Where is 1?*/
-#define AMQP_JUST_CONSUME	1
-#define AMQP_DURABLE		2
-#define AMQP_PASSIVE		4
-#define AMQP_EXCLUSIVE		8
-#define AMQP_AUTODELETE		16
-#define AMQP_INTERNAL		32
-#define AMQP_NOLOCAL		64
-#define AMQP_AUTOACK		128
-#define AMQP_IFEMPTY		256
-#define AMQP_IFUNUSED		512
-#define AMQP_MANDATORY		1024
-#define AMQP_IMMEDIATE		2048
-#define AMQP_MULTIPLE		4096
-#define AMQP_NOWAIT			8192
-#define AMQP_REQUEUE		16384
+#define AMQP_JUST_CONSUME 1
+#define AMQP_DURABLE 2
+#define AMQP_PASSIVE 4
+#define AMQP_EXCLUSIVE 8
+#define AMQP_AUTODELETE 16
+#define AMQP_INTERNAL 32
+#define AMQP_NOLOCAL 64
+#define AMQP_AUTOACK 128
+#define AMQP_IFEMPTY 256
+#define AMQP_IFUNUSED 512
+#define AMQP_MANDATORY 1024
+#define AMQP_IMMEDIATE 2048
+#define AMQP_MULTIPLE 4096
+#define AMQP_NOWAIT 8192
+#define AMQP_REQUEUE 16384
 
 /* passive, durable, auto-delete, internal, no-wait (see https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.declare) */
-#define PHP_AMQP_EXCHANGE_FLAGS     (AMQP_PASSIVE | AMQP_DURABLE | AMQP_AUTODELETE | AMQP_INTERNAL)
+#define PHP_AMQP_EXCHANGE_FLAGS (AMQP_PASSIVE | AMQP_DURABLE | AMQP_AUTODELETE | AMQP_INTERNAL)
 
 /* passive, durable, exclusive, auto-delete, no-wait (see https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.declare) */
 /* We don't support no-wait flag */
-#define PHP_AMQP_QUEUE_FLAGS        (AMQP_PASSIVE | AMQP_DURABLE | AMQP_EXCLUSIVE | AMQP_AUTODELETE)
+#define PHP_AMQP_QUEUE_FLAGS (AMQP_PASSIVE | AMQP_DURABLE | AMQP_EXCLUSIVE | AMQP_AUTODELETE)
 
-#define AMQP_EX_TYPE_DIRECT		"direct"
-#define AMQP_EX_TYPE_FANOUT		"fanout"
-#define AMQP_EX_TYPE_TOPIC		"topic"
-#define AMQP_EX_TYPE_HEADERS	"headers"
+#define AMQP_EX_TYPE_DIRECT "direct"
+#define AMQP_EX_TYPE_FANOUT "fanout"
+#define AMQP_EX_TYPE_TOPIC "topic"
+#define AMQP_EX_TYPE_HEADERS "headers"
 
 #define PHP_AMQP_CONNECTION_RES_NAME "AMQP Connection Resource"
 
 struct _amqp_channel_resource {
-	char is_connected;
-	amqp_channel_t channel_id;
-	amqp_connection_resource *connection_resource;
+    char is_connected;
+    amqp_channel_t channel_id;
+    amqp_connection_resource *connection_resource;
     amqp_channel_object *parent;
 };
 
 struct _amqp_callback_bucket {
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
 };
 
 struct _amqp_channel_callbacks {
-	amqp_callback_bucket basic_return;
-	amqp_callback_bucket basic_ack;
-	amqp_callback_bucket basic_nack;
+    amqp_callback_bucket basic_return;
+    amqp_callback_bucket basic_ack;
+    amqp_callback_bucket basic_nack;
 };
 
 
 /* NOTE: due to how internally PHP works with custom object, zend_object position in structure matters */
 struct _amqp_channel_object {
-	amqp_channel_callbacks callbacks;
-	zval *gc_data;
-    int   gc_data_count;
-	amqp_channel_resource *channel_resource;
-	zend_object zo;
+    amqp_channel_callbacks callbacks;
+    zval *gc_data;
+    int gc_data_count;
+    amqp_channel_resource *channel_resource;
+    zend_object zo;
 };
 
 struct _amqp_connection_resource {
-	zend_bool is_connected;
-	zend_bool is_persistent;
-	zend_bool is_dirty;
-	zend_resource *resource;
-	amqp_connection_object *parent;
-	amqp_channel_t max_slots;
-	amqp_channel_t used_slots;
-	amqp_channel_resource **slots;
-	amqp_connection_state_t connection_state;
-	amqp_socket_t *socket;
+    zend_bool is_connected;
+    zend_bool is_persistent;
+    zend_bool is_dirty;
+    zend_resource *resource;
+    amqp_connection_object *parent;
+    amqp_channel_t max_slots;
+    amqp_channel_t used_slots;
+    amqp_channel_resource **slots;
+    amqp_connection_state_t connection_state;
+    amqp_socket_t *socket;
 };
 
 struct _amqp_connection_object {
-	amqp_connection_resource *connection_resource;
-	zend_object zo;
+    amqp_connection_resource *connection_resource;
+    zend_object zo;
 };
 
-#define DEFAULT_PORT					"5672"		/* default AMQP port */
-#define DEFAULT_HOST					"localhost"
-#define DEFAULT_TIMEOUT					""
-#define DEFAULT_READ_TIMEOUT			"0"
-#define DEFAULT_WRITE_TIMEOUT			"0"
-#define DEFAULT_CONNECT_TIMEOUT			"0"
-#define DEFAULT_RPC_TIMEOUT				"0"
-#define DEFAULT_VHOST					"/"
-#define DEFAULT_LOGIN					"guest"
-#define DEFAULT_PASSWORD				"guest"
-#define DEFAULT_AUTOACK					"0"			/* These are all strings to facilitate setting default ini values */
-#define DEFAULT_PREFETCH_COUNT			"3"
-#define DEFAULT_PREFETCH_SIZE			"0"
-#define DEFAULT_GLOBAL_PREFETCH_COUNT	"0"
-#define DEFAULT_GLOBAL_PREFETCH_SIZE	"0"
-#define DEFAULT_SASL_METHOD     		"0"
+#define DEFAULT_PORT "5672" /* default AMQP port */
+#define DEFAULT_HOST "localhost"
+#define DEFAULT_TIMEOUT ""
+#define DEFAULT_READ_TIMEOUT "0"
+#define DEFAULT_WRITE_TIMEOUT "0"
+#define DEFAULT_CONNECT_TIMEOUT "0"
+#define DEFAULT_RPC_TIMEOUT "0"
+#define DEFAULT_VHOST "/"
+#define DEFAULT_LOGIN "guest"
+#define DEFAULT_PASSWORD "guest"
+#define DEFAULT_AUTOACK "0" /* These are all strings to facilitate setting default ini values */
+#define DEFAULT_PREFETCH_COUNT "3"
+#define DEFAULT_PREFETCH_SIZE "0"
+#define DEFAULT_GLOBAL_PREFETCH_COUNT "0"
+#define DEFAULT_GLOBAL_PREFETCH_SIZE "0"
+#define DEFAULT_SASL_METHOD "0"
 
 /* Usually, default is 0 which means 65535, but underlying rabbitmq-c library pool allocates minimal pool for each channel,
  * so it takes a lot of memory to keep all that channels. Even after channel closing that buffer still keep memory allocation.
@@ -191,9 +187,10 @@ struct _amqp_connection_object {
 /* AMQP_DEFAULT_FRAME_SIZE 131072 */
 
 #if PHP_AMQP_PROTOCOL_MAX_CHANNELS > 0
-	#define PHP_AMQP_MAX_CHANNELS PHP_AMQP_PROTOCOL_MAX_CHANNELS
+    #define PHP_AMQP_MAX_CHANNELS PHP_AMQP_PROTOCOL_MAX_CHANNELS
 #else
-	#define PHP_AMQP_MAX_CHANNELS 65535 // Note that the maximum number of channels the protocol supports is 65535 (2^16, with the 0-channel reserved)
+    #define PHP_AMQP_MAX_CHANNELS                                                                                      \
+        65535// Note that the maximum number of channels the protocol supports is 65535 (2^16, with the 0-channel reserved)
 #endif
 
 #define PHP_AMQP_MAX_FRAME_SIZE INT_MAX
@@ -213,47 +210,59 @@ struct _amqp_connection_object {
 #define PHP_AMQP_TO_STRING(value) #value
 
 
-#define DEFAULT_CHANNEL_MAX					PHP_AMQP_STRINGIFY(PHP_AMQP_MAX_CHANNELS)
-#define DEFAULT_FRAME_MAX					PHP_AMQP_STRINGIFY(PHP_AMQP_DEFAULT_FRAME_MAX)
-#define DEFAULT_HEARTBEAT					PHP_AMQP_STRINGIFY(PHP_AMQP_DEFAULT_HEARTBEAT)
-#define DEFAULT_CACERT	""
-#define DEFAULT_CERT	""
-#define DEFAULT_KEY	""
-#define DEFAULT_VERIFY	"1"
+#define DEFAULT_CHANNEL_MAX PHP_AMQP_STRINGIFY(PHP_AMQP_MAX_CHANNELS)
+#define DEFAULT_FRAME_MAX PHP_AMQP_STRINGIFY(PHP_AMQP_DEFAULT_FRAME_MAX)
+#define DEFAULT_HEARTBEAT PHP_AMQP_STRINGIFY(PHP_AMQP_DEFAULT_HEARTBEAT)
+#define DEFAULT_CACERT ""
+#define DEFAULT_CERT ""
+#define DEFAULT_KEY ""
+#define DEFAULT_VERIFY "1"
 
 
-#define IS_PASSIVE(bitmask)		(AMQP_PASSIVE & (bitmask)) ? 1 : 0
-#define IS_DURABLE(bitmask)		(AMQP_DURABLE & (bitmask)) ? 1 : 0
-#define IS_EXCLUSIVE(bitmask)	(AMQP_EXCLUSIVE & (bitmask)) ? 1 : 0
-#define IS_AUTODELETE(bitmask)	(AMQP_AUTODELETE & (bitmask)) ? 1 : 0
-#define IS_INTERNAL(bitmask)	(AMQP_INTERNAL & (bitmask)) ? 1 : 0
-#define IS_NOWAIT(bitmask)		(AMQP_NOWAIT & (bitmask)) ? 1 : 0 /* NOTE: always 0 in rabbitmq-c internals, so don't use it unless you are clearly understand aftermath*/
+#define IS_PASSIVE(bitmask) (AMQP_PASSIVE & (bitmask)) ? 1 : 0
+#define IS_DURABLE(bitmask) (AMQP_DURABLE & (bitmask)) ? 1 : 0
+#define IS_EXCLUSIVE(bitmask) (AMQP_EXCLUSIVE & (bitmask)) ? 1 : 0
+#define IS_AUTODELETE(bitmask) (AMQP_AUTODELETE & (bitmask)) ? 1 : 0
+#define IS_INTERNAL(bitmask) (AMQP_INTERNAL & (bitmask)) ? 1 : 0
+#define IS_NOWAIT(bitmask)                                                                                             \
+    (AMQP_NOWAIT & (bitmask))                                                                                          \
+        ? 1                                                                                                            \
+        : 0 /* NOTE: always 0 in rabbitmq-c internals, so don't use it unless you are clearly understand aftermath*/
 
-#define PHP_AMQP_NOPARAMS() if (zend_parse_parameters_none() == FAILURE) { return; }
+#define PHP_AMQP_NOPARAMS()                                                                                            \
+    if (zend_parse_parameters_none() == FAILURE) {                                                                     \
+        return;                                                                                                        \
+    }
 
-#define PHP_AMQP_RETURN_THIS_PROP(prop_name) \
-    zval * _zv = zend_read_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(prop_name), 0 , &rv TSRMLS_CC); \
+#define PHP_AMQP_RETURN_THIS_PROP(prop_name)                                                                           \
+    zval *_zv = zend_read_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(prop_name), 0, &rv TSRMLS_CC); \
     RETURN_ZVAL(_zv, 1, 0);
 
-#define PHP_AMQP_READ_OBJ_PROP(cls, obj, name) zend_read_property((cls), PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL(name), 0 , &rv TSRMLS_CC)
+#define PHP_AMQP_READ_OBJ_PROP(cls, obj, name)                                                                         \
+    zend_read_property((cls), PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL(name), 0, &rv TSRMLS_CC)
 #define PHP_AMQP_READ_OBJ_PROP_DOUBLE(cls, obj, name) Z_DVAL_P(PHP_AMQP_READ_OBJ_PROP((cls), (obj), (name)))
 
-#define PHP_AMQP_READ_THIS_PROP_CE(name, ce) zend_read_property((ce), PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), 0 , &rv TSRMLS_CC)
-#define PHP_AMQP_READ_THIS_PROP(name) zend_read_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), 0 , &rv TSRMLS_CC)
+#define PHP_AMQP_READ_THIS_PROP_CE(name, ce)                                                                           \
+    zend_read_property((ce), PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), 0, &rv TSRMLS_CC)
+#define PHP_AMQP_READ_THIS_PROP(name)                                                                                  \
+    zend_read_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), 0, &rv TSRMLS_CC)
 #define PHP_AMQP_READ_THIS_PROP_BOOL(name) Z_TYPE_P(PHP_AMQP_READ_THIS_PROP(name)) == IS_TRUE
 #define PHP_AMQP_READ_THIS_PROP_STR(name) Z_STRVAL_P(PHP_AMQP_READ_THIS_PROP(name))
-#define PHP_AMQP_READ_THIS_PROP_STRLEN(name) (Z_TYPE_P(PHP_AMQP_READ_THIS_PROP(name)) == IS_STRING ? Z_STRLEN_P(PHP_AMQP_READ_THIS_PROP(name)) : 0)
+#define PHP_AMQP_READ_THIS_PROP_STRLEN(name)                                                                           \
+    (Z_TYPE_P(PHP_AMQP_READ_THIS_PROP(name)) == IS_STRING ? Z_STRLEN_P(PHP_AMQP_READ_THIS_PROP(name)) : 0)
 #define PHP_AMQP_READ_THIS_PROP_ARR(name) Z_ARRVAL_P(PHP_AMQP_READ_THIS_PROP(name))
 #define PHP_AMQP_READ_THIS_PROP_LONG(name) Z_LVAL_P(PHP_AMQP_READ_THIS_PROP(name))
 #define PHP_AMQP_READ_THIS_PROP_DOUBLE(name) Z_DVAL_P(PHP_AMQP_READ_THIS_PROP(name))
 
 
-static inline amqp_connection_object *php_amqp_connection_object_fetch(zend_object *obj) {
-	return (amqp_connection_object *)((char *)obj - XtOffsetOf(amqp_connection_object, zo));
+static inline amqp_connection_object *php_amqp_connection_object_fetch(zend_object *obj)
+{
+    return (amqp_connection_object *) ((char *) obj - XtOffsetOf(amqp_connection_object, zo));
 }
 
-static inline amqp_channel_object *php_amqp_channel_object_fetch(zend_object *obj) {
-	return (amqp_channel_object *)((char *)obj - XtOffsetOf(amqp_channel_object, zo));
+static inline amqp_channel_object *php_amqp_channel_object_fetch(zend_object *obj)
+{
+    return (amqp_channel_object *) ((char *) obj - XtOffsetOf(amqp_channel_object, zo));
 }
 
 #define PHP_AMQP_GET_CONNECTION(obj) php_amqp_connection_object_fetch(Z_OBJ_P(obj))
@@ -262,79 +271,98 @@ static inline amqp_channel_object *php_amqp_channel_object_fetch(zend_object *ob
 #define PHP_AMQP_FETCH_CONNECTION(obj) php_amqp_connection_object_fetch(obj)
 #define PHP_AMQP_FETCH_CHANNEL(obj) php_amqp_channel_object_fetch(obj)
 
-#define PHP_AMQP_GET_CHANNEL_RESOURCE(obj) (IS_OBJECT == Z_TYPE_P(obj) ? (PHP_AMQP_GET_CHANNEL(obj))->channel_resource : NULL)
+#define PHP_AMQP_GET_CHANNEL_RESOURCE(obj)                                                                             \
+    (IS_OBJECT == Z_TYPE_P(obj) ? (PHP_AMQP_GET_CHANNEL(obj))->channel_resource : NULL)
 
-#define PHP_AMQP_VERIFY_CONNECTION_ERROR(error, reason) \
-		char verify_connection_error_tmp[255]; \
-		snprintf(verify_connection_error_tmp, 255, "%s %s", error, reason); \
-		zend_throw_exception(amqp_connection_exception_class_entry, verify_connection_error_tmp, 0 TSRMLS_CC); \
-		return; \
+#define PHP_AMQP_VERIFY_CONNECTION_ERROR(error, reason)                                                                \
+    char verify_connection_error_tmp[255];                                                                             \
+    snprintf(verify_connection_error_tmp, 255, "%s %s", error, reason);                                                \
+    zend_throw_exception(amqp_connection_exception_class_entry, verify_connection_error_tmp, 0 TSRMLS_CC);             \
+    return;
 
-#define PHP_AMQP_VERIFY_CONNECTION(connection, error) \
-	if (!connection) { \
-		PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "Stale reference to the connection object.") \
-	} \
-	if (!(connection)->connection_resource || !(connection)->connection_resource->is_connected) { \
-		PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "No connection available.") \
-	} \
+#define PHP_AMQP_VERIFY_CONNECTION(connection, error)                                                                  \
+    if (!connection) {                                                                                                 \
+        PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "Stale reference to the connection object.")                           \
+    }                                                                                                                  \
+    if (!(connection)->connection_resource || !(connection)->connection_resource->is_connected) {                      \
+        PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "No connection available.")                                            \
+    }
 
-#define PHP_AMQP_VERIFY_CHANNEL_ERROR(error, reason) \
-		char verify_channel_error_tmp[255]; \
-		snprintf(verify_channel_error_tmp, 255, "%s %s", error, reason); \
-		zend_throw_exception(amqp_channel_exception_class_entry, verify_channel_error_tmp, 0 TSRMLS_CC); \
-		return; \
+#define PHP_AMQP_VERIFY_CHANNEL_ERROR(error, reason)                                                                   \
+    char verify_channel_error_tmp[255];                                                                                \
+    snprintf(verify_channel_error_tmp, 255, "%s %s", error, reason);                                                   \
+    zend_throw_exception(amqp_channel_exception_class_entry, verify_channel_error_tmp, 0 TSRMLS_CC);                   \
+    return;
 
-#define PHP_AMQP_VERIFY_CHANNEL_RESOURCE(resource, error) \
-	if (!resource) { \
-		PHP_AMQP_VERIFY_CHANNEL_ERROR(error, "Stale reference to the channel object.") \
-	} \
-	if (!(resource)->is_connected) { \
-		PHP_AMQP_VERIFY_CHANNEL_ERROR(error, "No channel available.") \
-	} \
-	if (!(resource)->connection_resource) { \
-		PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "Stale reference to the connection object.") \
-	} \
-	if (!(resource)->connection_resource->is_connected) { \
-		PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "No connection available.") \
-	} \
+#define PHP_AMQP_VERIFY_CHANNEL_RESOURCE(resource, error)                                                              \
+    if (!resource) {                                                                                                   \
+        PHP_AMQP_VERIFY_CHANNEL_ERROR(error, "Stale reference to the channel object.")                                 \
+    }                                                                                                                  \
+    if (!(resource)->is_connected) {                                                                                   \
+        PHP_AMQP_VERIFY_CHANNEL_ERROR(error, "No channel available.")                                                  \
+    }                                                                                                                  \
+    if (!(resource)->connection_resource) {                                                                            \
+        PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "Stale reference to the connection object.")                           \
+    }                                                                                                                  \
+    if (!(resource)->connection_resource->is_connected) {                                                              \
+        PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "No connection available.")                                            \
+    }
 
-#define PHP_AMQP_VERIFY_CHANNEL_CONNECTION_RESOURCE(resource, error) \
-	if (!resource) { \
-		PHP_AMQP_VERIFY_CHANNEL_ERROR(error, "Stale reference to the channel object.") \
-	} \
-	if (!(resource)->connection_resource) { \
-		PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "Stale reference to the connection object.") \
-	} \
-	if (!(resource)->connection_resource->is_connected) { \
-		PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "No connection available.") \
-	} \
+#define PHP_AMQP_VERIFY_CHANNEL_CONNECTION_RESOURCE(resource, error)                                                   \
+    if (!resource) {                                                                                                   \
+        PHP_AMQP_VERIFY_CHANNEL_ERROR(error, "Stale reference to the channel object.")                                 \
+    }                                                                                                                  \
+    if (!(resource)->connection_resource) {                                                                            \
+        PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "Stale reference to the connection object.")                           \
+    }                                                                                                                  \
+    if (!(resource)->connection_resource->is_connected) {                                                              \
+        PHP_AMQP_VERIFY_CONNECTION_ERROR(error, "No connection available.")                                            \
+    }
 
-#define PHP_AMQP_MAYBE_ERROR(res, channel_resource) (\
-	  (AMQP_RESPONSE_NORMAL != (res).reply_type) \
-	&& \
-	  PHP_AMQP_RESOURCE_RESPONSE_OK != php_amqp_error(res, &PHP_AMQP_G(error_message), (channel_resource)->connection_resource, (channel_resource) TSRMLS_CC) \
-	)
+#define PHP_AMQP_MAYBE_ERROR(res, channel_resource)                                                                    \
+    ((AMQP_RESPONSE_NORMAL != (res).reply_type) &&                                                                     \
+     PHP_AMQP_RESOURCE_RESPONSE_OK != php_amqp_error(                                                                  \
+                                          res,                                                                         \
+                                          &PHP_AMQP_G(error_message),                                                  \
+                                          (channel_resource)->connection_resource,                                     \
+                                          (channel_resource) TSRMLS_CC                                                 \
+                                      ))
 
-#define PHP_AMQP_MAYBE_ERROR_RECOVERABLE(res, channel_resource) (\
-	  (AMQP_RESPONSE_NORMAL != (res).reply_type) \
-	&& \
-	  PHP_AMQP_RESOURCE_RESPONSE_OK != php_amqp_error_advanced(res, &PHP_AMQP_G(error_message), (channel_resource)->connection_resource, (channel_resource), 0 TSRMLS_CC) \
-	)
+#define PHP_AMQP_MAYBE_ERROR_RECOVERABLE(res, channel_resource)                                                        \
+    ((AMQP_RESPONSE_NORMAL != (res).reply_type) &&                                                                     \
+     PHP_AMQP_RESOURCE_RESPONSE_OK != php_amqp_error_advanced(                                                         \
+                                          res,                                                                         \
+                                          &PHP_AMQP_G(error_message),                                                  \
+                                          (channel_resource)->connection_resource,                                     \
+                                          (channel_resource),                                                          \
+                                          0 TSRMLS_CC                                                                  \
+                                      ))
 
-#define PHP_AMQP_IS_ERROR_RECOVERABLE(res, channel_resource, channel_object) ( \
-	AMQP_RESPONSE_LIBRARY_EXCEPTION == (res).reply_type && AMQP_STATUS_UNEXPECTED_STATE == (res).library_error \
-	&& (0 <= php_amqp_connection_resource_error_advanced(res, &PHP_AMQP_G(error_message), (channel_resource)->connection_resource, (amqp_channel_t)(channel_resource ? (channel_resource)->channel_id : 0), (channel_object) TSRMLS_CC)) \
-)
+#define PHP_AMQP_IS_ERROR_RECOVERABLE(res, channel_resource, channel_object)                                           \
+    (AMQP_RESPONSE_LIBRARY_EXCEPTION == (res).reply_type && AMQP_STATUS_UNEXPECTED_STATE == (res).library_error &&     \
+     (0 <= php_amqp_connection_resource_error_advanced(                                                                \
+               res,                                                                                                    \
+               &PHP_AMQP_G(error_message),                                                                             \
+               (channel_resource)->connection_resource,                                                                \
+               (amqp_channel_t) (channel_resource ? (channel_resource)->channel_id : 0),                               \
+               (channel_object) TSRMLS_CC                                                                              \
+           )))
 
 
 #if ZEND_MODULE_API_NO >= 20100000
-	#define AMQP_OBJECT_PROPERTIES_INIT(obj, ce) object_properties_init(&(obj), ce);
+    #define AMQP_OBJECT_PROPERTIES_INIT(obj, ce) object_properties_init(&(obj), ce);
 #else
-	#define AMQP_OBJECT_PROPERTIES_INIT(obj, ce) \
-		do { \
-			zval *tmp; \
-			zend_hash_copy((obj).properties, &(ce)->default_properties, (copy_ctor_func_t) zval_add_ref, (void *) &tmp, sizeof(zval *)); \
-		} while (0);
+    #define AMQP_OBJECT_PROPERTIES_INIT(obj, ce)                                                                       \
+        do {                                                                                                           \
+            zval *tmp;                                                                                                 \
+            zend_hash_copy(                                                                                            \
+                (obj).properties,                                                                                      \
+                &(ce)->default_properties,                                                                             \
+                (copy_ctor_func_t) zval_add_ref,                                                                       \
+                (void *) &tmp,                                                                                         \
+                sizeof(zval *)                                                                                         \
+            );                                                                                                         \
+        } while (0);
 #endif
 
 
@@ -342,49 +370,68 @@ static inline amqp_channel_object *php_amqp_channel_object_fetch(zend_object *ob
 
 
 #ifdef PHP_WIN32
-# define AMQP_OS_SOCKET_TIMEOUT_ERRNO AMQP_ERROR_CATEGORY_MASK | WSAETIMEDOUT
+    #define AMQP_OS_SOCKET_TIMEOUT_ERRNO AMQP_ERROR_CATEGORY_MASK | WSAETIMEDOUT
 #else
-# define AMQP_OS_SOCKET_TIMEOUT_ERRNO AMQP_ERROR_CATEGORY_MASK | EAGAIN
+    #define AMQP_OS_SOCKET_TIMEOUT_ERRNO AMQP_ERROR_CATEGORY_MASK | EAGAIN
 #endif
 
 ZEND_BEGIN_MODULE_GLOBALS(amqp)
-    char *error_message;
-    zend_long error_code;
+char *error_message;
+zend_long error_code;
 ZEND_END_MODULE_GLOBALS(amqp)
 
 ZEND_EXTERN_MODULE_GLOBALS(amqp)
 
 #ifdef ZEND_MODULE_GLOBALS_ACCESSOR
-	#define PHP_AMQP_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(amqp, v)
+    #define PHP_AMQP_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(amqp, v)
 
-	#if defined(ZTS) && defined(COMPILE_DL_WEAK)
-		ZEND_TSRMLS_CACHE_EXTERN();
-	#endif
+    #if defined(ZTS) && defined(COMPILE_DL_WEAK)
+ZEND_TSRMLS_CACHE_EXTERN();
+    #endif
 #else
-	#ifdef ZTS
-		#define PHP_AMQP_G(v) TSRMG(amqp_globals_id, zend_amqp_globals *, v)
-	#else
-		#define PHP_AMQP_G(v) (amqp_globals.v)
-	#endif
+    #ifdef ZTS
+        #define PHP_AMQP_G(v) TSRMG(amqp_globals_id, zend_amqp_globals *, v)
+    #else
+        #define PHP_AMQP_G(v) (amqp_globals.v)
+    #endif
 #endif
 
 #ifndef PHP_AMQP_VERSION
-#define PHP_AMQP_VERSION "1.12.0dev"
+    #define PHP_AMQP_VERSION "1.12.0dev"
 #endif
 
 #ifndef PHP_AMQP_REVISION
-#define PHP_AMQP_REVISION "release"
+    #define PHP_AMQP_REVISION "release"
 #endif
 
-int php_amqp_error(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *connection_resource, amqp_channel_resource *channel_resource TSRMLS_DC);
-int php_amqp_error_advanced(amqp_rpc_reply_t reply, char **message, amqp_connection_resource *connection_resource, amqp_channel_resource *channel_resource, int fail_on_errors TSRMLS_DC);
+int php_amqp_error(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *connection_resource,
+    amqp_channel_resource *channel_resource TSRMLS_DC
+);
+int php_amqp_error_advanced(
+    amqp_rpc_reply_t reply,
+    char **message,
+    amqp_connection_resource *connection_resource,
+    amqp_channel_resource *channel_resource,
+    int fail_on_errors TSRMLS_DC
+);
 
 /**
  * @deprecated
  */
-void php_amqp_zend_throw_exception(amqp_rpc_reply_t reply, zend_class_entry *exception_ce, const char *message, zend_long code TSRMLS_DC);
+void php_amqp_zend_throw_exception(
+    amqp_rpc_reply_t reply,
+    zend_class_entry *exception_ce,
+    const char *message,
+    zend_long code TSRMLS_DC
+);
 void php_amqp_zend_throw_exception_short(amqp_rpc_reply_t reply, zend_class_entry *exception_ce TSRMLS_DC);
-void php_amqp_maybe_release_buffers_on_channel(amqp_connection_resource *connection_resource, amqp_channel_resource *channel_resource);
+void php_amqp_maybe_release_buffers_on_channel(
+    amqp_connection_resource *connection_resource,
+    amqp_channel_resource *channel_resource
+);
 
 zend_bool php_amqp_is_valid_identifier(zend_string *val);
 zend_bool php_amqp_is_valid_credential(zend_string *val);
@@ -396,14 +443,4 @@ zend_bool php_amqp_is_valid_heartbeat(zend_long val);
 zend_bool php_amqp_is_valid_prefetch_count(zend_long val);
 zend_bool php_amqp_is_valid_prefetch_size(zend_long val);
 
-#endif	/* PHP_AMQP_H */
-
-
-/*
- * Local variables:
- * tab-width: 4
- * c-basic-offset: 4
- * End:
- * vim600: noet sw=4 ts=4 fdm=marker
- * vim<600: noet sw=4 ts=4
- */
+#endif /* PHP_AMQP_H */

--- a/tools/dev-build.sh
+++ b/tools/dev-build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+phpize
+CFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wall -Werror" ./configure
+make clean all

--- a/tools/dev-format.sh
+++ b/tools/dev-format.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -e
+clang-format-17 -i *.c *.h


### PR DESCRIPTION
Introduces clang-format to auto-format the codebase. Formatting is verified on CI. Reformats the whole codebase.