### PR TITLE
Skip SSL tests if certificates are missing

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 PHP_AMQP_SSL_HOST=rabbitmq.example.org
+MAKEOPTS="-j16"
+CFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wall -Werror"
+TEST_PHP_ARGS="-j16"

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PHP_AMQP_SSL_HOST=rabbitmq.example.org
-MAKEOPTS="-j16"
+MAKEFLAGS="-j16"
 CFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wall -Werror"
 TEST_PHP_ARGS="-j16"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ env:
   TEST_TIMEOUT: 120
   CFLAGS: -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wall -Werror
   PHP_AMQP_SSL_HOST: rabbitmq.example.org
+  MAKEFLAGS: -j4
 
 jobs:
   dedup:

--- a/infra/php/Dockerfile
+++ b/infra/php/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get install -yqq gdb
 RUN apt-get install -yqq valgrind
 
 RUN echo 'PATH=$PATH:/src/infra/tools' >> /etc/bash.bashrc
-RUN echo 'CFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wall -Werror"' >> /etc/bash.bashrc
 
 CMD PHP_AMQP_DOCKER_ENTRYPOINT=1 php /src/infra/tools/pamqp-docker-setup && \
     # Forward localhost:5672 to rabbitmq:5672 (Plain TCP) so that the testsuite can access RabbitMQ on localhost

--- a/infra/tools/pamqp-build
+++ b/infra/tools/pamqp-build
@@ -20,4 +20,4 @@ if test "$mode" = "clean"; then
   make clean
 fi
 
-make ${MAKEOPTS:-}
+make

--- a/infra/tools/pamqp-build
+++ b/infra/tools/pamqp-build
@@ -20,4 +20,4 @@ if test "$mode" = "clean"; then
   make clean
 fi
 
-make
+make ${MAKEOPTS:-}

--- a/tests/amqpconnection_tls_basic.phpt
+++ b/tests/amqpconnection_tls_basic.phpt
@@ -1,7 +1,10 @@
 --TEST--
 AMQPConnection - TLS - CA validation only
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php
+if (!extension_loaded("amqp")) print "skip";
+if (!file_exists(__DIR__ . "/../infra/tls/certificates/testca/cacert.pem")) print "skip";
+?>
 --FILE--
 <?php
 $credentials = array(

--- a/tests/amqpconnection_tls_mtls.phpt
+++ b/tests/amqpconnection_tls_mtls.phpt
@@ -1,7 +1,12 @@
 --TEST--
 AMQPConnection - TLS - mTLS support
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php
+if (!extension_loaded("amqp")) print "skip";
+if (!file_exists(__DIR__ . "/../infra/tls/certificates/testca/cacert.pem")) print "skip";
+if (!file_exists(__DIR__ . "/../infra/tls/certificates/client/cert.pem")) print "skip";
+if (!file_exists(__DIR__ . "/../infra/tls/certificates/client/key.pem")) print "skip";
+?>
 --FILE--
 <?php
 $credentials = array(

--- a/tests/amqpconnection_tls_sasl.phpt
+++ b/tests/amqpconnection_tls_sasl.phpt
@@ -1,7 +1,12 @@
 --TEST--
 AMQPConnection - TLS - SASL authentication
 --SKIPIF--
-<?php if (!extension_loaded("amqp")) print "skip"; ?>
+<?php
+if (!extension_loaded("amqp")) print "skip";
+if (!file_exists(__DIR__ . "/../infra/tls/certificates/testca/cacert.pem")) print "skip";
+if (!file_exists(__DIR__ . "/../infra/tls/certificates/sasl-client/cert.pem")) print "skip";
+if (!file_exists(__DIR__ . "/../infra/tls/certificates/sasl-client/key.pem")) print "skip";
+?>
 --FILE--
 <?php
 $credentials = array(


### PR DESCRIPTION
Fixes #448 

As test certificates are not generated (not to speak about a proper RabbitMQ setup) when running tests locally. So let’s skip the SSL tests if the certificates do not exist.