### PR TITLE
Validate argument parsing, add AMQPExchange::removeArgument() and AMQPQueue::removeArgument()

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,8 @@ jobs:
         run: ./infra/tools/pamqp-stubs-format-check
 
       - name: Validate argument parsing
-        run: php -d extension=modules/amqp.so ./infra/tools/pamqp-arguments-validate
+        run: ./infra/tools/pamqp-php-cli-deterministic -d extension=modules/amqp.so ./infra/tools/pamqp-arguments-validate
+        if: php-version == '8.2'
 
   test:
     name: ${{ matrix.test-php-args == '-m' && 'Memtest' || 'Test' }} php-${{ matrix.php-version }}${{ matrix.php-thread-safe && '-ts' || '-nts' }} librabbitmq-${{ matrix.librabbitmq-version }}
@@ -158,7 +159,7 @@ jobs:
         run: docker compose logs
 
       - name: Benchmark PHP extension
-        run: php -n -c './tmp-php.ini' -d "extension_dir=./modules/" -d "extension=amqp.so" benchmark.php
+        run: ./infra/tools/pamqp-php-cli-deterministic -d extension=modules/amqp.so benchmark.php
 
       - name: Dump report
         run: ./infra/tools/pamqp-test-report

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Validate argument parsing
         run: ./infra/tools/pamqp-php-cli-deterministic -d extension=modules/amqp.so ./infra/tools/pamqp-arguments-validate
-        if: php-version == '8.2'
+        if: matrix.php-version == '8.2'
 
   test:
     name: ${{ matrix.test-php-args == '-m' && 'Memtest' || 'Test' }} php-${{ matrix.php-version }}${{ matrix.php-thread-safe && '-ts' || '-nts' }} librabbitmq-${{ matrix.librabbitmq-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,6 +87,9 @@ jobs:
       - name: Check stub coding style
         run: ./infra/tools/pamqp-stubs-format-check
 
+      - name: Validate argument parsing
+        run: php -d extension=modules/amqp.so ./infra/tools/pamqp-arguments-validate
+
   test:
     name: ${{ matrix.test-php-args == '-m' && 'Memtest' || 'Test' }} php-${{ matrix.php-version }}${{ matrix.php-thread-safe && '-ts' || '-nts' }} librabbitmq-${{ matrix.librabbitmq-version }}
     # librabbitmq < 0.11 needs older OpenSSL version

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -156,6 +156,12 @@
 
 ## `AMQPConnection` breaking changes
 
+### Public method additions
+
+* `getConnectTimeout(): float`
+* `setConnectionName(?string $connectionName): void`
+* `getConnectionName(): ?string`
+
 ### Public method type changes
 
 ```diff
@@ -303,7 +309,7 @@
 
 ```
 ```diff
-- getHeader(string $header_key): string|bool
+- getHeader(string $header_key): bool|string
 + getHeader(string $headerName): ?string
 
 ```
@@ -317,7 +323,23 @@
 ```
 
 
+## `AMQPEnvelopeException` breaking changes
+
+### Public method additions
+
+* `getEnvelope(): AMQPEnvelope`
+
 ## `AMQPExchange` breaking changes
+
+### Change in semantics
+
+* `setArgument(string $argumentName, null)` no longer unsets the argument `$key` but sets it to `null` instead. To remove an argument use `removeArgument(string $argumentName)` instead
+* `getArgument(string $argumentName)` now throws an `AMQPExchangeException` if the argument does not exist. It returned false previously 
+
+### Public method additions
+
+* `declare(): void`
+* `removeArgument(string $argumentName): void`
 
 ### Public method type changes
 
@@ -342,6 +364,11 @@
 
 ```
 ```diff
+- getArgument(string $key): bool|int|string
++ getArgument(string $argumentName): bool|float|int|string|null
+
+```
+```diff
 - getName(): string
 + getName(): ?string
 
@@ -357,8 +384,8 @@
 
 ```
 ```diff
-- setArgument(string $key, string|int $value): bool
-+ setArgument(string $argumentName, string|int $argumentValue): void
+- setArgument(string $key, int|string $value): bool
++ setArgument(string $argumentName, bool|float|int|string|null $argumentValue): void
 
 ```
 ```diff
@@ -386,12 +413,6 @@
 ```
 
 ```diff
-- getArgument(string $key): string|int|bool
-+ getArgument(string $argumentName): string|int|bool
-
-```
-
-```diff
 - hasArgument(string $key): bool
 + hasArgument(string $argumentName): bool
 
@@ -399,6 +420,16 @@
 
 
 ## `AMQPQueue` breaking changes
+
+### Change in semantics
+
+* `setArgument(string $key, null)` no longer unsets the argument `$key` but sets it to `null` instead. To remove an argument use `removeArgument(string $key)` instead
+* `getArgument(string $argumentName)` now throws an `AMQPQueueException` if the argument does not exist. It returned false previously
+
+### Public method additions
+
+* `declare(): int`
+* `removeArgument(string $argumentName): void`
 
 ### Public method type changes
 
@@ -428,8 +459,8 @@
 
 ```
 ```diff
-- getArgument(string $key): string|int|bool
-+ getArgument(string $argumentName): ?string|?int
+- getArgument(string $key): bool|int|string
++ getArgument(string $argumentName): bool|float|int|string|null
 
 ```
 ```diff
@@ -454,7 +485,7 @@
 ```
 ```diff
 - setArgument(string $key, mixed $value): bool
-+ setArgument(string $argumentName, mixed $argumentValue): void
++ setArgument(string $argumentName, bool|float|int|string|null $argumentValue): void
 
 ```
 ```diff
@@ -464,7 +495,7 @@
 ```
 ```diff
 - setFlags(int $flags): bool
-+ setFlags(int $flags): void
++ setFlags(?int $flags): void
 
 ```
 ```diff
@@ -522,4 +553,3 @@
 + getTimestamp(): float
 
 ```
-

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -499,7 +499,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
             zend_throw_exception_ex(
                 amqp_connection_exception_class_entry,
                 0,
-                "Parameter 'port' must be a valid port number  between %d and %d.",
+                "Parameter 'port' must be a valid port number between %d and %d.",
                 PHP_AMQP_MIN_PORT,
                 PHP_AMQP_MAX_PORT
             );
@@ -1165,36 +1165,21 @@ static PHP_METHOD(amqp_connection_class, getPort)
 set the port */
 static PHP_METHOD(amqp_connection_class, setPort)
 {
-    zval *zvalPort;
     int port;
 
     /* Get the port from the method params */
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z/", &zvalPort) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &port) == FAILURE) {
         return;
     }
 
-    /* Parse out the port*/
-    switch (Z_TYPE_P(zvalPort)) {
-        case IS_DOUBLE:
-            port = (int) Z_DVAL_P(zvalPort);
-            break;
-        case IS_LONG:
-            port = (int) Z_LVAL_P(zvalPort);
-            break;
-        case IS_STRING:
-            convert_to_long(zvalPort);
-            port = (int) Z_LVAL_P(zvalPort);
-            break;
-        default:
-            port = 0;
-    }
-
     /* Check the port value */
-    if (port <= 0 || port > 65535) {
-        zend_throw_exception(
+    if (!php_amqp_is_valid_port(port)) {
+        zend_throw_exception_ex(
             amqp_connection_exception_class_entry,
-            "Invalid port given. Value must be between 1 and 65535.",
-            0
+            0,
+            "Parameter 'port' must be a valid port number between %d and %d.",
+            PHP_AMQP_MIN_PORT,
+            PHP_AMQP_MAX_PORT
         );
         return;
     }

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -304,8 +304,6 @@ static PHP_METHOD(amqp_exchange_class, setArgument)
 
     switch (Z_TYPE_P(value)) {
         case IS_NULL:
-            zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
-            break;
         case IS_TRUE:
         case IS_FALSE:
         case IS_LONG:
@@ -325,6 +323,22 @@ static PHP_METHOD(amqp_exchange_class, setArgument)
 }
 /* }}} */
 
+
+/* {{{ proto AMQPExchange::removeArgument(key) */
+static PHP_METHOD(amqp_exchange_class, removeArgument)
+{
+    zval rv;
+
+    char *key = NULL;
+    size_t key_len = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
+        return;
+    }
+
+    zend_hash_str_del(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
+}
+/* }}} */
 
 /* {{{ proto AMQPExchange::declareExchange();
 declare Exchange
@@ -403,7 +417,7 @@ static PHP_METHOD(amqp_exchange_class, delete)
     size_t name_len = 0;
     zend_long flags = AMQP_NOPARAM;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|sl", &name, &name_len, &flags) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!l", &name, &name_len, &flags) == FAILURE) {
         return;
     }
 
@@ -837,6 +851,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_exchange_class_setArgument,
     ZEND_ARG_INFO(0, argumentValue)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_exchange_class_removeArgument, ZEND_SEND_BY_VAL, 1, IS_VOID, 0)
+    ZEND_ARG_TYPE_INFO(0, argumentName, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_exchange_class_setArguments, ZEND_SEND_BY_VAL, 1, IS_VOID, 0)
     ZEND_ARG_ARRAY_INFO(0, arguments, 0)
 ZEND_END_ARG_INFO()
@@ -889,6 +907,7 @@ zend_function_entry amqp_exchange_class_functions[] = {
     PHP_ME(amqp_exchange_class, getArgument,	arginfo_amqp_exchange_class_getArgument,	ZEND_ACC_PUBLIC)
     PHP_ME(amqp_exchange_class, getArguments,	arginfo_amqp_exchange_class_getArguments,	ZEND_ACC_PUBLIC)
     PHP_ME(amqp_exchange_class, setArgument,	arginfo_amqp_exchange_class_setArgument,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_exchange_class, removeArgument,	arginfo_amqp_exchange_class_removeArgument,	ZEND_ACC_PUBLIC)
     PHP_ME(amqp_exchange_class, setArguments,	arginfo_amqp_exchange_class_setArguments,	ZEND_ACC_PUBLIC)
     PHP_ME(amqp_exchange_class, hasArgument,	arginfo_amqp_exchange_class_hasArgument,	ZEND_ACC_PUBLIC)
 

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -241,7 +241,8 @@ static PHP_METHOD(amqp_exchange_class, getArgument)
     }
 
     if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
-        RETURN_FALSE;
+        zend_throw_exception_ex(amqp_exchange_exception_class_entry, 0, "The argument \"%s\" does not exist", key);
+        return;
     }
 
     RETURN_ZVAL(tmp, 1, 0);

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -278,8 +278,6 @@ static PHP_METHOD(amqp_queue_class, setArgument)
 
     switch (Z_TYPE_P(value)) {
         case IS_NULL:
-            zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
-            break;
         case IS_TRUE:
         case IS_FALSE:
         case IS_LONG:
@@ -299,6 +297,23 @@ static PHP_METHOD(amqp_queue_class, setArgument)
 }
 /* }}} */
 
+
+/* {{{ proto AMQPQueue::removeArgument(key)
+Get the queue name */
+static PHP_METHOD(amqp_queue_class, removeArgument)
+{
+    zval rv;
+
+    char *key = NULL;
+    size_t key_len = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
+        return;
+    }
+
+    zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
+}
+/* }}} */
 
 /* {{{ proto int AMQPQueue::declareQueue();
 declare queue
@@ -533,7 +548,7 @@ static PHP_METHOD(amqp_queue_class, consume)
     size_t consumer_tag_len = 0;
     zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|f!ls", &fci, &fci_cache, &flags, &consumer_tag, &consumer_tag_len) ==
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|f!ls!", &fci, &fci_cache, &flags, &consumer_tag, &consumer_tag_len) ==
         FAILURE) {
         return;
     }
@@ -1069,7 +1084,7 @@ static PHP_METHOD(amqp_queue_class, unbind)
 
     if (zend_parse_parameters(
             ZEND_NUM_ARGS(),
-            "s|sa",
+            "s|s!a",
             &exchange_name,
             &exchange_name_len,
             &keyname,
@@ -1209,7 +1224,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_getFlags, ZEND_
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_setFlags, ZEND_SEND_BY_VAL, 1, IS_VOID, 0)
-    ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+    ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_queue_class_getArgument, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
@@ -1222,6 +1237,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_setArgument, ZEND_SEND_BY_VAL, 2, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO(0, argumentName, IS_STRING, 0)
     ZEND_ARG_INFO(0, argumentValue)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_removeArgument, ZEND_SEND_BY_VAL, 1, IS_VOID, 0)
+    ZEND_ARG_TYPE_INFO(0, argumentName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_hasArgument, ZEND_SEND_BY_VAL, 1, _IS_BOOL, 0)
@@ -1304,6 +1323,7 @@ zend_function_entry amqp_queue_class_functions[] = {
     PHP_ME(amqp_queue_class, getArgument,		arginfo_amqp_queue_class_getArgument,		ZEND_ACC_PUBLIC)
     PHP_ME(amqp_queue_class, getArguments,		arginfo_amqp_queue_class_getArguments,		ZEND_ACC_PUBLIC)
     PHP_ME(amqp_queue_class, setArgument,		arginfo_amqp_queue_class_setArgument,		ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_queue_class, removeArgument,		arginfo_amqp_queue_class_removeArgument,		ZEND_ACC_PUBLIC)
     PHP_ME(amqp_queue_class, setArguments,		arginfo_amqp_queue_class_setArguments,		ZEND_ACC_PUBLIC)
     PHP_ME(amqp_queue_class, hasArgument,		arginfo_amqp_queue_class_hasArgument,		ZEND_ACC_PUBLIC)
 

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -213,7 +213,8 @@ static PHP_METHOD(amqp_queue_class, getArgument)
     }
 
     if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
-        RETURN_NULL();
+        zend_throw_exception_ex(amqp_queue_exception_class_entry, 0, "The argument \"%s\" does not exist", key);
+        return;
     }
 
     RETURN_ZVAL(tmp, 1, 0);
@@ -288,8 +289,8 @@ static PHP_METHOD(amqp_queue_class, setArgument)
             break;
         default:
             zend_throw_exception(
-                amqp_exchange_exception_class_entry,
-                "The value parameter must be of type NULL, int, double or string.",
+                amqp_queue_exception_class_entry,
+                "The value parameter must be of type bool, int, double, string, or null.",
                 0
             );
             return;

--- a/infra/tools/pamqp-arguments-validate
+++ b/infra/tools/pamqp-arguments-validate
@@ -1,0 +1,185 @@
+#!/usr/bin/env php
+<?php
+const CLASSES = [
+    'AMQPBasicProperties',
+    'AMQPChannel',
+    'AMQPChannelException',
+    'AMQPConnection',
+    'AMQPConnectionException',
+    'AMQPDecimal',
+    'AMQPEnvelope',
+    'AMQPEnvelopeException',
+    'AMQPException',
+    'AMQPExchange',
+    'AMQPExchangeException',
+    'AMQPQueue',
+    'AMQPQueueException',
+    'AMQPTimestamp',
+    'AMQPValueException',
+];
+
+function getSource(string $class): ?string
+{
+    assert(preg_match('/([A-Z]+?)([A-Z][a-z]+)+/', $class, $matches) == 1);
+    $fileName = implode('_', array_map('strtolower', array_slice($matches, 1))) . '.c';
+
+    $path = __DIR__ . '/../../' . $fileName;
+
+    if (file_exists($path)) {
+        return file_get_contents($path);
+    }
+
+    return null;
+}
+
+function validate(string $class)
+{
+    $refl = new ReflectionClass($class);
+
+    $source = getSource($class);
+
+    if ($source === null) {
+        // WARNING
+        return;
+    }
+
+    foreach ($refl->getMethods() as $method) {
+        if ($method->getName() == 'declare') {
+            continue;
+        }
+
+        if ($method->getDeclaringClass()->getName() !== $class) {
+            continue;
+        }
+
+        assert(preg_match('/
+                PHP_METHOD\(.*?,\s*' . preg_quote($method->getName(), '/') . '\).*?
+                \{.*?
+                ((?<func>zend_parse_parameters)\(.+?,\s*\"(?<def>.*?)\"|PHP_AMQP_NOPARAMS|zend_parse_parameters_none)
+        /xs', $source, $matches), $class . ' ' . $method->getName());
+
+        $parametersString = $matches['def'] ?? '';
+
+        try {
+            [$types, $numberOfRequiredParameters] = parseParameterString($parametersString);
+        } catch (Throwable $t) {
+            throw new RuntimeException(sprintf(
+                'Could not parse parameter string "%s" for %s::%s',
+                $parametersString,
+                $class,
+                $method->getName()
+            ), 0, $t);
+        }
+
+        if ($method->getNumberOfRequiredParameters() !== $numberOfRequiredParameters) {
+            error(
+                '%s::%s(): Number of required parameters do not match. Parameter parsing: %d (%s). Reflection: %d',
+                $class,
+                $method->getName(),
+                $numberOfRequiredParameters,
+                $parametersString,
+                $method->getNumberOfRequiredParameters()
+            );
+        }
+
+        if ($method->getNumberOfParameters() !== count($types)) {
+            error(
+                '%s::%s(): Number of parameters do not match. Parameter parsing: %d (%s). Reflection: %d',
+                $class,
+                $method->getName(),
+                count($types),
+                $parametersString,
+                $method->getNumberOfParameters()
+            );
+        }
+
+        foreach ($method->getParameters() as $pos => $parameter) {
+            $reflectionType = $parameter->hasType() ? ($parameter->getType()->isBuiltin() ? $parameter->getType()->getName() : 'object') : 'mixed';
+
+            if ($reflectionType !== $types[$pos]['type']) {
+                error(
+                    '%s::%s(): type parsing and Reflection info do not match. Parameter parsing: %s (%s). Reflection: %s',
+                    $class,
+                    $method->getName(),
+                    $types[$pos]['type'],
+                    $parametersString,
+                    $reflectionType
+                );
+            }
+
+            $reflectionNullable = $parameter->allowsNull();
+            if ($reflectionNullable !== $types[$pos]['nullable']) {
+                error(
+                    '%s::%s(%s): type parsing and Reflection nullability differs. Parameter parsing: %s (%s). Reflection: %s',
+                    $class,
+                    $method->getName(),
+                    $parameter->getName(),
+                    $types[$pos]['nullable'] ? 'nullable' : 'not nullable',
+                    $parametersString,
+                    $reflectionNullable ? 'nullable' : 'not nullable'
+                );
+            }
+        }
+    }
+}
+
+$isError = false;
+function error(string $message, ...$args): void
+{
+    global $isError;
+    $isError = true;
+    vprintf('ERROR: ' . $message . PHP_EOL, $args);
+}
+
+function parseParameterString(string $str): array
+{
+    $types = [
+        's' => 'string',
+        'O' => 'object',
+        'l' => 'int',
+        'a' => 'array',
+        'f' => 'callable',
+        'd' => 'float',
+        'b' => 'bool',
+        'z' => 'mixed',
+    ];
+    $parameters = [];
+    $requiredCount = null;
+    $count = 0;
+    foreach (str_split($str) as $pos => $char) {
+        if (isset($types[$char])) {
+            if (isset($currentInfo)) {
+                $parameters[] = $currentInfo;
+            }
+            $currentInfo = [
+                'type' => $types[$char],
+                'nullable' => $types[$char] === 'mixed',
+            ];
+            $count++;
+        } elseif ($char == '!') {
+            $currentInfo['nullable'] = true;
+        } elseif ($char === '|') {
+            $requiredCount = $count;
+        } elseif ($char === '/') {
+            // Ignored
+        } else {
+            throw new InvalidArgumentException($char);
+        }
+    }
+
+    if ($requiredCount === null) {
+        $requiredCount = $count;
+    }
+
+    if (isset($currentInfo)) {
+        $parameters[] = $currentInfo;
+    }
+
+    return [$parameters, $requiredCount];
+}
+
+foreach (CLASSES as $class) {
+    validate($class);
+}
+
+exit((int) $isError);

--- a/infra/tools/pamqp-diff-bc
+++ b/infra/tools/pamqp-diff-bc
@@ -53,21 +53,30 @@ function compare(string $className)
 
     $prevConstantNames = array_keys($prev->getConstants());
     $nextConstantNames = array_keys($prev->getConstants());
-
     $removedConstantNames = array_diff($prevConstantNames, $nextConstantNames);
+    $addedConstantNames = array_diff($nextConstantNames, $prevConstantNames);
 
     $removedConstants = [];
     foreach ($removedConstantNames as $removedConstantName) {
         $removedConstants[] = sprintf(' * `%s`', $removedConstantName);
     }
 
+    $addedConstants = [];
+    foreach ($addedConstantNames as $addedConstantName) {
+        $addedConstants[] = sprintf(' * `%s`', $addedConstantName);
+    }
+
     $prevMethodNames = getMethodNames($prev);
     $nextMethodNames = getMethodNames($next);
-    $removedMethodNames = array_diff($prevMethodNames, $nextMethodNames);
 
     $removedMethods = [];
-    foreach ($removedMethodNames as $removedMethodName) {
+    foreach (array_diff($prevMethodNames, $nextMethodNames) as $removedMethodName) {
         $removedMethods[] = sprintf(' * `%s()`', $removedMethodName);
+    }
+
+    $addedMethods = [];
+    foreach (array_diff($nextMethodNames, $prevMethodNames) as $addedMethodName) {
+        $addedMethods[] = sprintf(' * `%s`', getParameterString($className, $next->getMethod($addedMethodName)));
     }
 
     $constantChanges = [];
@@ -107,9 +116,11 @@ function compare(string $className)
     }
 
     $report = [
+        ...($addedConstants ? ["### Constant additions\n", ...$addedConstants, ''] : []),
         ...($removedConstants ? ["### Constant removals\n", ...$removedConstants, ''] : []),
-        ...($removedMethods ? ["### Public method removals\n", ...$removedMethods, ''] : []),
         ...($constantChanges ? ["### Public constant changes\n", ...$constantChanges, ''] : []),
+        ...($addedMethods ? ["### Public method additions\n", ...$addedMethods, ''] : []),
+        ...($removedMethods ? ["### Public method removals\n", ...$removedMethods, ''] : []),
         ...($methodTypeChanges ? ["### Public method type changes\n", ...$methodTypeChanges, ''] : []),
         ...($methodParameterNameChanges ? ["### Parameter name changes\n", ...$methodParameterNameChanges, ''] : []),
     ];
@@ -230,12 +241,20 @@ function normalizeType(string $type): string
         $types[] = $actualType;
     }
 
-    if (count($types) > 1 && in_array('null', $types, true)) {
+    if (count($types) == 2 && in_array('null', $types, true)) {
         $types = array_map(static function ($type) {
             return '?' . $type;
         }, array_filter($types, static function ($type) {
             return $type !== 'null';
         }));
+    }
+
+    sort($types);
+    $index = array_search('null', $types, true);
+    if ($index !== false) {
+        unset($types[$index]);
+        // Sort to the end
+        $types[] = 'null';
     }
 
     return implode('|', $types);

--- a/infra/tools/pamqp-docker-setup
+++ b/infra/tools/pamqp-docker-setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
-function path(string ...$args): string {
+function path(string ...$args): string
+{
     return implode(DIRECTORY_SEPARATOR, $args);
 }
 

--- a/infra/tools/pamqp-dump-reflection
+++ b/infra/tools/pamqp-dump-reflection
@@ -6,25 +6,24 @@ $symbols = [
     'classNames' => [],
 ];
 
-function sortByName(array $array): array {
-    usort(
-        $array,
-        function (array $left, array $right) {
-            return $left['name'] <=> $right['name'];
-        }
-    );
+function sortByName(array $array): array
+{
+    usort($array, static function (array $left, array $right) {
+        return $left['name'] <=> $right['name'];
+    });
 
     return $array;
 }
 
-function getTypeMetadata(?ReflectionNamedType $type): ?array {
+function getTypeMetadata(?ReflectionNamedType $type): ?array
+{
     if ($type == null) {
         return null;
     }
 
     return [
         'name' => $type->getName(),
-        'nullable' => $type->allowsNull()
+        'nullable' => $type->allowsNull(),
     ];
 }
 
@@ -36,19 +35,15 @@ function error(string $message, ...$args): void
     $error = true;
 }
 
-const MAGIC_METHODS = [
-    '__construct',
-    '__toString',
-    '__wakeup',
-    '__clone',
-];
+const MAGIC_METHODS = ['__construct', '__toString', '__wakeup', '__clone'];
 
-function getClassMetadata(string $class): array {
+function getClassMetadata(string $class): array
+{
     $refl = new ReflectionClass($class);
     $classMetadata = [
         'name' => $refl->getName(),
         'constants' => [],
-        'properties' =>  [],
+        'properties' => [],
         'methods' => [],
     ];
 
@@ -58,7 +53,7 @@ function getClassMetadata(string $class): array {
         }
 
         $classMetadata['constants'][] = [
-            'name' => $class. '::' . $constant->getName(),
+            'name' => $class . '::' . $constant->getName(),
             'value' => $constant->getValue(),
             'visibility' => $constant->isPublic() ? 'public' : ($constant->isProtected() ? 'protected' : ($constant->isPrivate() ? 'private' : 'unknown')),
         ];
@@ -70,7 +65,7 @@ function getClassMetadata(string $class): array {
         }
 
         $methodMetadata = [
-            'name' => $class. '::' . $method->getName(),
+            'name' => $class . '::' . $method->getName(),
             'visibility' => $method->isPublic() ? 'public' : ($method->isProtected() ? 'protected' : ($method->isPrivate() ? 'private' : 'unknown')),
             'final' => $method->isFinal(),
             'static' => $method->isStatic(),
@@ -81,44 +76,72 @@ function getClassMetadata(string $class): array {
         ];
 
         if (!in_array($method->getName(), MAGIC_METHODS, true) && strpos($method->getName(), '_') !== false) {
-            error("%s::%s contains underscore", $class, $method->getName());
+            error('%s::%s contains underscore', $class, $method->getName());
         }
 
         $prefix = substr($method->getName(), 0, 3);
-        if (in_array($prefix, ['set', 'has', 'get'], true) && !in_array($method->getName(), ['set', 'has', 'get'], true)) {
+        if (in_array($prefix, ['set', 'has', 'get'], true) && !in_array(
+            $method->getName(),
+            ['set', 'has', 'get'],
+            true
+        )) {
             $hasPlural = $refl->hasMethod($method->getName() . 's');
             $isPlural = substr($method->getName(), -1) === 's';
 
             if ($prefix === 'get' && $method->getNumberOfParameters() !== 0 && !$hasPlural) {
-                error("%s::%s() should have no arguments", $class, $method->getName());
+                error('%s::%s() should have no arguments', $class, $method->getName());
             }
 
             if ($prefix === 'set' && $isPlural) {
-                if ($method->getParameters()[0]->getName() !== ($expectedName = lcfirst(substr($method->getName(), 3)))) {
-                    error("%s::%s(%s) must be \"%s\"", $class, $method->getName(), $method->getParameters()[0]->getName(), $expectedName);
+                if ($method->getParameters()[0]->getName() !== ($expectedName = lcfirst(
+                    substr($method->getName(), 3)
+                ))) {
+                    error(
+                        '%s::%s(%s) must be "%s"',
+                        $class,
+                        $method->getName(),
+                        $method->getParameters()[0]->getName(),
+                        $expectedName
+                    );
                 }
             }
 
             if ($prefix === 'get' && $hasPlural) {
                 if ($method->getNumberOfRequiredParameters() !== 1 || $method->getNumberOfParameters() !== 1) {
-                    error("%s::%s() should have exactly one required parameter", $class, $method->getName());
+                    error('%s::%s() should have exactly one required parameter', $class, $method->getName());
                 }
             }
 
             if ($hasPlural) {
-                if ($method->getParameters()[0]->getName() !== ($expectedName = lcfirst(substr($method->getName(), 3) . 'Name'))) {
-                    error("%s::%s(%s) must be \"%s\"", $class, $method->getName(), $method->getParameters()[0]->getName(), $expectedName);
+                if ($method->getParameters()[0]->getName() !== ($expectedName = lcfirst(
+                    substr($method->getName(), 3) . 'Name'
+                ))) {
+                    error(
+                        '%s::%s(%s) must be "%s"',
+                        $class,
+                        $method->getName(),
+                        $method->getParameters()[0]->getName(),
+                        $expectedName
+                    );
                 }
 
-                if ($prefix === 'set' && $method->getParameters()[1]->getName() !== ($expectedName = lcfirst(substr($method->getName(), 3) . 'Value'))) {
-                    error("%s::%s(…, %s) must be \"%s\"", $class, $method->getName(), $method->getParameters()[1]->getName(), $expectedName);
+                if ($prefix === 'set' && $method->getParameters()[1]->getName() !== ($expectedName = lcfirst(
+                    substr($method->getName(), 3) . 'Value'
+                ))) {
+                    error(
+                        '%s::%s(…, %s) must be "%s"',
+                        $class,
+                        $method->getName(),
+                        $method->getParameters()[1]->getName(),
+                        $expectedName
+                    );
                 }
             }
         }
 
         foreach ($method->getParameters() as $parameter) {
             if (strpos($parameter->getName(), '_') !== false) {
-                error("%s::%s(…%s…) contains underscore", $class, $method->getName(), $parameter->getName());
+                error('%s::%s(…%s…) contains underscore', $class, $method->getName(), $parameter->getName());
             }
 
             $default = 'unknown';
@@ -128,7 +151,7 @@ function getClassMetadata(string $class): array {
             }
 
             $methodMetadata['parameters'][] = [
-                'method' => $class. '::' . $method->getName(),
+                'method' => $class . '::' . $method->getName(),
                 'name' => sprintf('$%s', $parameter->getName()),
                 'default' => $default,
                 'type' => getTypeMetadata($parameter->getType()),
@@ -173,7 +196,7 @@ function getClassMetadata(string $class): array {
 }
 
 
-spl_autoload_register(function(string $class) {
+spl_autoload_register(function (string $class) {
     require_once __DIR__ . '/../../stubs/' . $class . '.php';
 });
 
@@ -200,7 +223,7 @@ foreach (get_defined_constants() as $constant => $value) {
     if (strpos($constant, 'AMQP_') === 0) {
         $symbols['constants'][] = [
             'name' => $constant,
-            'value' => $value
+            'value' => $value,
         ];
     }
 }

--- a/infra/tools/pamqp-dump-reflection
+++ b/infra/tools/pamqp-dump-reflection
@@ -100,7 +100,8 @@ function getClassMetadata(string $class): array
                         '%s::%s(%s) must be "%s"',
                         $class,
                         $method->getName(),
-                        $method->getParameters()[0]->getName(),
+                        $method->getParameters()[0]
+                            ->getName(),
                         $expectedName
                     );
                 }
@@ -120,7 +121,8 @@ function getClassMetadata(string $class): array
                         '%s::%s(%s) must be "%s"',
                         $class,
                         $method->getName(),
-                        $method->getParameters()[0]->getName(),
+                        $method->getParameters()[0]
+                            ->getName(),
                         $expectedName
                     );
                 }
@@ -132,7 +134,8 @@ function getClassMetadata(string $class): array
                         '%s::%s(…, %s) must be "%s"',
                         $class,
                         $method->getName(),
-                        $method->getParameters()[1]->getName(),
+                        $method->getParameters()[1]
+                            ->getName(),
                         $expectedName
                     );
                 }

--- a/infra/tools/pamqp-release-cut
+++ b/infra/tools/pamqp-release-cut
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 namespace phpamqp;
 
 use DateTimeImmutable;

--- a/infra/tools/pamqp-release-finalize
+++ b/infra/tools/pamqp-release-finalize
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 namespace phpamqp;
 
 use DateTimeImmutable;

--- a/stubs/AMQPExchange.php
+++ b/stubs/AMQPExchange.php
@@ -119,10 +119,8 @@ class AMQPExchange
      * Get the argument associated with the given key.
      *
      * @param string $argumentName The key to look up.
-     *
-     * @return string|integer|boolean The string or integer value associated
-     *                                with the given key, or FALSE if the key
-     *                                is not set.
+     * @throws AMQPExchangeException If key does not exist
+     * @return bool|int|double|string|null
      */
     public function getArgument(string $argumentName)
     {
@@ -206,7 +204,7 @@ class AMQPExchange
      * Set the value for the given key.
      *
      * @param string $argumentName Name of the argument to set.
-     * @param string|integer $argumentValue Value of the argument to set.
+     * @param bool|int|double|string|null $argumentValue Value of the argument to set.
      */
     public function setArgument(string $argumentName, $argumentValue): void
     {
@@ -215,7 +213,7 @@ class AMQPExchange
     /**
      * Set the value for the given key.
      *
-     * @param string $argumentName Name of the argument to set.
+     * @param string $argumentName Name of the argument to remove.
      */
     public function removeArgument(string $argumentName): void
     {

--- a/stubs/AMQPExchange.php
+++ b/stubs/AMQPExchange.php
@@ -213,6 +213,15 @@ class AMQPExchange
     }
 
     /**
+     * Set the value for the given key.
+     *
+     * @param string $argumentName Name of the argument to set.
+     */
+    public function removeArgument(string $argumentName): void
+    {
+    }
+
+    /**
      * Set all arguments on the exchange.
      *
      * @param array $arguments An array of key/value pairs of arguments.

--- a/stubs/AMQPQueue.php
+++ b/stubs/AMQPQueue.php
@@ -206,10 +206,8 @@ class AMQPQueue
      * Get the argument associated with the given key.
      *
      * @param string $argumentName The key to look up.
-     *
-     * @return string|integer|null The string or integer value associated
-     *                             with the given key, or false if the key
-     *                             is not set.
+     * @throws AMQPQueueException If key does not exist
+     * @return bool|int|double|string|null
      */
     public function getArgument(string $argumentName)
     {
@@ -300,8 +298,8 @@ class AMQPQueue
     /**
      * Set a queue argument.
      *
-     * @param string $argumentName The key to set.
-     * @param mixed $argumentValue The value to set.
+     * @param string $argumentName The argument name to set.
+     * @param bool|int|double|string|null $argumentValue The argument value to set.
      */
     public function setArgument(string $argumentName, $argumentValue): void
     {
@@ -310,7 +308,7 @@ class AMQPQueue
     /**
      * Set a queue argument.
      *
-     * @param string $argumentName The key to set.
+     * @param string $argumentName The argument name to set.
      */
     public function removeArgument(string $argumentName): void
     {
@@ -321,7 +319,7 @@ class AMQPQueue
      *
      * All other argument settings will be wiped.
      *
-     * @param array $arguments An array of key/value pairs of arguments.
+     * @param array $arguments An array of name/value pairs of arguments.
      */
     public function setArguments(array $arguments): void
     {
@@ -330,7 +328,7 @@ class AMQPQueue
     /**
      * Check whether a queue has specific argument.
      *
-     * @param string $argumentName The key to check.
+     * @param string $argumentName The argument name to check.
      *
      * @return boolean
      */

--- a/stubs/AMQPQueue.php
+++ b/stubs/AMQPQueue.php
@@ -342,8 +342,8 @@ class AMQPQueue
      * Set the flags on the queue.
      *
      * @param integer|null $flags A bitmask of flags:
-     *                       AMQP_DURABLE, AMQP_PASSIVE,
-     *                       AMQP_EXCLUSIVE, AMQP_AUTODELETE.
+     *                            AMQP_DURABLE, AMQP_PASSIVE,
+     *                            AMQP_EXCLUSIVE, AMQP_AUTODELETE.
      */
     public function setFlags(?int $flags): void
     {

--- a/stubs/AMQPQueue.php
+++ b/stubs/AMQPQueue.php
@@ -308,6 +308,15 @@ class AMQPQueue
     }
 
     /**
+     * Set a queue argument.
+     *
+     * @param string $argumentName The key to set.
+     */
+    public function removeArgument(string $argumentName): void
+    {
+    }
+
+    /**
      * Set all arguments on the given queue.
      *
      * All other argument settings will be wiped.
@@ -332,11 +341,11 @@ class AMQPQueue
     /**
      * Set the flags on the queue.
      *
-     * @param integer $flags A bitmask of flags:
+     * @param integer|null $flags A bitmask of flags:
      *                       AMQP_DURABLE, AMQP_PASSIVE,
      *                       AMQP_EXCLUSIVE, AMQP_AUTODELETE.
      */
-    public function setFlags(int $flags): void
+    public function setFlags(?int $flags): void
     {
     }
 

--- a/tests/amqpconnection_setPort_out_of_range.phpt
+++ b/tests/amqpconnection_setPort_out_of_range.phpt
@@ -12,4 +12,4 @@ try {
 }
 ?>
 --EXPECT--
-Invalid port given. Value must be between 1 and 65535.
+Parameter 'port' must be a valid port number between 1 and 65535.

--- a/tests/amqpconnection_validation.phpt
+++ b/tests/amqpconnection_validation.phpt
@@ -75,10 +75,10 @@ AMQPConnectionException: Parameter 'vhost' exceeds 512 character limit.
 AMQPConnectionException: Parameter 'vhost' exceeds 512 characters limit.
 getVhost after constructor: vhost
 getVhost after setter: vhost
-AMQPConnectionException: Parameter 'port' must be a valid port number  between 1 and 65535.
-AMQPConnectionException: Invalid port given. Value must be between 1 and 65535.
-AMQPConnectionException: Parameter 'port' must be a valid port number  between 1 and 65535.
-AMQPConnectionException: Invalid port given. Value must be between 1 and 65535.
+AMQPConnectionException: Parameter 'port' must be a valid port number between 1 and 65535.
+AMQPConnectionException: Parameter 'port' must be a valid port number between 1 and 65535.
+AMQPConnectionException: Parameter 'port' must be a valid port number between 1 and 65535.
+AMQPConnectionException: Parameter 'port' must be a valid port number between 1 and 65535.
 getPort after constructor: 1234
 getPort after setter: 1234
 

--- a/tests/amqpexchange_attributes.phpt
+++ b/tests/amqpexchange_attributes.phpt
@@ -15,20 +15,21 @@ $ch = new AMQPChannel($cnn);
 
 $ex = new AMQPExchange($ch);
 
-$ex->setArguments($arr = array('existent' => 'value', 'false' => false));
+$ex->setArguments($arr = array('existent' => 'value', 'false' => false, 'null' => null));
 
 echo 'Initial args: ', count($arr), ', exchange args: ', count($ex->getArguments()), PHP_EOL;
 $ex->setArgument('foo', 'bar');
 echo 'Initial args: ', count($arr), ', exchange args: ', count($ex->getArguments()), PHP_EOL;
 
-foreach (array('existent', 'false', 'nonexistent') as $key) {
+foreach (array('existent', 'false', 'null', 'nonexistent') as $key) {
     echo "$key: ", var_export($ex->hasArgument($key), true), ', ', var_export($ex->getArgument($key)), PHP_EOL;
 }
 
 ?>
 --EXPECT--
-Initial args: 2, exchange args: 2
-Initial args: 2, exchange args: 3
+Initial args: 3, exchange args: 3
+Initial args: 3, exchange args: 4
 existent: true, 'value'
 false: true, false
+null: true, NULL
 nonexistent: false, false

--- a/tests/amqpexchange_attributes.phpt
+++ b/tests/amqpexchange_attributes.phpt
@@ -22,7 +22,15 @@ $ex->setArgument('foo', 'bar');
 echo 'Initial args: ', count($arr), ', exchange args: ', count($ex->getArguments()), PHP_EOL;
 
 foreach (array('existent', 'false', 'null', 'nonexistent') as $key) {
-    echo "$key: ", var_export($ex->hasArgument($key), true), ', ', var_export($ex->getArgument($key)), PHP_EOL;
+    echo "$key: ";
+    var_export($ex->hasArgument($key));
+    echo ', ';
+    try {
+        var_export($ex->getArgument($key));
+    } catch (AMQPExchangeException $e) {
+        echo "Ex: " . $e->getMessage();
+    }
+    echo PHP_EOL;
 }
 
 ?>
@@ -32,4 +40,4 @@ Initial args: 3, exchange args: 4
 existent: true, 'value'
 false: true, false
 null: true, NULL
-nonexistent: false, false
+nonexistent: false, Ex: The argument "nonexistent" does not exist

--- a/tests/amqpexchange_delete_null_name.phpt
+++ b/tests/amqpexchange_delete_null_name.phpt
@@ -1,0 +1,25 @@
+--TEST--
+AMQPExchange::delete with explicit null as exchange name
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$con = new AMQPConnection();
+$con->connect();
+$chan = new AMQPChannel($con);
+
+$ex = new AMQPExchange($chan);
+$ex->setName('test.queue.' . bin2hex(random_bytes(32)));
+$ex->setType(AMQP_EX_TYPE_DIRECT);
+$ex->declareExchange();
+
+$ex->delete(null);
+
+// Deleting with explicit null deleted the current exchange, so we should be able to redeclare
+$ex->setType(AMQP_EX_TYPE_FANOUT);
+$ex->declare();
+$ex->delete();
+?>
+==DONE==
+--EXPECT--
+==DONE==

--- a/tests/amqpexchange_setArgument.phpt
+++ b/tests/amqpexchange_setArgument.phpt
@@ -35,10 +35,12 @@ $ex->setArgument("alternate-exchange", $e_name_ae);
 $ex->setArgument('x-empty-string', '');
 $ex->setArgument('x-alternate-exchange-one-more-time', $e_name_ae);
 $ex->setArgument('x-numeric-argument', $heartbeat * 10 * 1000);
+$ex->setArgument('x-null-argument', null);
 $ex->declareExchange();
 
 var_dump($ex);
-$ex->setArgument('x-alternate-exchange-one-more-time', null); // remov key
+$ex->removeArgument('x-null-argument');
+$ex->removeArgument('x-does-not-exist');
 var_dump($ex);
 ?>
 --EXPECTF--
@@ -81,7 +83,7 @@ object(AMQPExchange)#4 (9) {
   ["internal":"AMQPExchange":private]=>
   bool(false)
   ["arguments":"AMQPExchange":private]=>
-  array(5) {
+  array(6) {
     ["x-ha-policy"]=>
     string(3) "all"
     ["alternate-exchange"]=>
@@ -92,6 +94,8 @@ object(AMQPExchange)#4 (9) {
     string(%d) "test.exchange.ae.%s"
     ["x-numeric-argument"]=>
     int(100000)
+    ["x-null-argument"]=>
+    NULL
   }
 }
 object(AMQPExchange)#4 (9) {
@@ -112,13 +116,15 @@ object(AMQPExchange)#4 (9) {
   ["internal":"AMQPExchange":private]=>
   bool(false)
   ["arguments":"AMQPExchange":private]=>
-  array(4) {
+  array(5) {
     ["x-ha-policy"]=>
     string(3) "all"
     ["alternate-exchange"]=>
     string(%d) "test.exchange.ae.%s"
     ["x-empty-string"]=>
     string(0) ""
+    ["x-alternate-exchange-one-more-time"]=>
+    string(%d) "test.exchange.ae.%s"
     ["x-numeric-argument"]=>
     int(100000)
   }

--- a/tests/amqpqueue_attributes.phpt
+++ b/tests/amqpqueue_attributes.phpt
@@ -18,7 +18,15 @@ var_dump($q->setArgument('foo', 'bar'));
 echo 'Initial args: ', count($arr), ', queue args: ', count($q->getArguments()), PHP_EOL;
 
 foreach (array('existent', 'false', 'nonexistent') as $key) {
-    echo "$key: ", var_export($q->hasArgument($key), true), ', ', var_export($q->getArgument($key)), PHP_EOL;
+    echo "$key: ";
+    var_export($q->hasArgument($key));
+    echo ', ';
+    try {
+        var_export($q->getArgument($key));
+    } catch (AMQPQueueException $e) {
+        echo 'Ex: ', $e->getMessage();
+    }
+    echo PHP_EOL;
 }
 
 ?>
@@ -29,4 +37,4 @@ NULL
 Initial args: 2, queue args: 3
 existent: true, 'value'
 false: true, false
-nonexistent: false, NULL
+nonexistent: false, Ex: The argument "nonexistent" does not exist

--- a/tests/amqpqueue_bind_null_routing_key.phpt
+++ b/tests/amqpqueue_bind_null_routing_key.phpt
@@ -1,5 +1,5 @@
 --TEST--
-AMQPQueue
+AMQPQueue bind/unbind with explicit null routing key
 --SKIPIF--
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
@@ -18,6 +18,7 @@ $queue = new AMQPQueue($ch);
 $queue->setName("queue-" . bin2hex(random_bytes(32)));
 var_dump($queue->declareQueue());
 var_dump($queue->bind($ex->getName(), null));
+var_dump($queue->unbind($ex->getName(), null));
 
 var_dump($queue->delete());
 var_dump($ex->delete());
@@ -25,6 +26,7 @@ var_dump($ex->delete());
 --EXPECT--
 NULL
 int(0)
+NULL
 NULL
 int(0)
 NULL

--- a/tests/amqpqueue_consume_null_consumer_key.phpt
+++ b/tests/amqpqueue_consume_null_consumer_key.phpt
@@ -1,0 +1,46 @@
+--TEST--
+AMQPQueue::consume basic
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+require '_test_helpers.php.inc';
+
+$cnn = new AMQPConnection();
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+// Declare a new exchange
+$ex = new AMQPExchange($ch);
+$ex->setName('exchange-' . bin2hex(random_bytes(32)));
+$ex->setType(AMQP_EX_TYPE_FANOUT);
+$ex->declareExchange();
+
+// Create a new queue
+$q = new AMQPQueue($ch);
+$q->setName('queue-' . bin2hex(random_bytes(32)));
+$q->declareQueue();
+
+// Bind it on the exchange to routing.key
+$q->bind($ex->getName());
+
+// Publish a message to the exchange with a routing key
+$ex->publish('message1');
+
+$count = 0;
+
+function consume($message, $queue) {
+	global $count;
+	var_dump($count++);
+	return false;
+}
+
+$q->consume(null, AMQP_AUTOACK, null);
+
+$q->delete();
+$ex->delete();
+?>
+==DONE==
+--EXPECTF--
+==DONE==

--- a/tests/amqpqueue_setArgument.phpt
+++ b/tests/amqpqueue_setArgument.phpt
@@ -28,11 +28,13 @@ $q_dead->setName($q_dead_name);
 $q_dead->setArgument('x-dead-letter-exchange', '');
 $q_dead->setArgument('x-dead-letter-routing-key', $q_name);
 $q_dead->setArgument('x-message-ttl', $heartbeat * 10 * 1000);
+$q_dead->setArgument('x-null', null);
 $q_dead->setFlags(AMQP_AUTODELETE);
 $q_dead->declareQueue();
 
 var_dump($q_dead);
-$q_dead->setArgument('x-dead-letter-routing-key', null); // removes this key
+$q_dead->removeArgument('x-null');
+$q_dead->removeArgument('x-does-not-exist');
 var_dump($q_dead);
 ?>
 --EXPECTF--
@@ -75,13 +77,15 @@ object(AMQPQueue)#4 (9) {
   ["autoDelete":"AMQPQueue":private]=>
   bool(true)
   ["arguments":"AMQPQueue":private]=>
-  array(3) {
+  array(4) {
     ["x-dead-letter-exchange"]=>
     string(0) ""
     ["x-dead-letter-routing-key"]=>
     string(%d) "test.queue.%s"
     ["x-message-ttl"]=>
     int(100000)
+    ["x-null"]=>
+    NULL
   }
 }
 object(AMQPQueue)#4 (9) {
@@ -102,9 +106,11 @@ object(AMQPQueue)#4 (9) {
   ["autoDelete":"AMQPQueue":private]=>
   bool(true)
   ["arguments":"AMQPQueue":private]=>
-  array(2) {
+  array(3) {
     ["x-dead-letter-exchange"]=>
     string(0) ""
+    ["x-dead-letter-routing-key"]=>
+    string(%d) "test.queue.%s"
     ["x-message-ttl"]=>
     int(100000)
   }

--- a/tests/amqpqueue_setFlags.phpt
+++ b/tests/amqpqueue_setFlags.phpt
@@ -1,0 +1,20 @@
+--TEST--
+AMQPQueue::setFlags(null)
+--SKIPIF--
+<?php if (!extension_loaded("amqp")) print "skip"; ?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+$q = new AMQPQueue($ch);
+$q->setFlags(null);
+var_dump($q->getFlags())
+
+?>
+==DONE==
+--EXPECTF--
+int(0)
+==DONE==

--- a/tests/amqpqueue_unbind_basic_empty_routing_key.phpt
+++ b/tests/amqpqueue_unbind_basic_empty_routing_key.phpt
@@ -20,9 +20,14 @@ $queue->declareQueue();
 var_dump($queue->bind($ex->getName()));
 var_dump($queue->unbind($ex->getName()));
 
+var_dump($queue->bind($ex->getName(), null));
+var_dump($queue->unbind($ex->getName(), null));
+
 $queue->delete();
 $ex->delete();
 ?>
 --EXPECT--
+NULL
+NULL
 NULL
 NULL


### PR DESCRIPTION
Adds validation for argument parsing and fixes all the issues uncovered. Most notably:

  - `AMQPQueue::setArgument($key, null)` no longer removes the argument, `AMQPQueue::removeArgument($key)` has been introduced for that use-case
  - `AMQPExchange::setArgument($key, null)` no longer removes the argument, `AMQPExchange::removeArgument($key)` has been introduced for that use-case