### PR TITLE
Prevent reuse of channel ID of broken channels

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -29,6 +29,8 @@ Macros:
   - "ZEND_HASH_FOREACH_STR_KEY(a, b)=do {"
   - "ZEND_HASH_FOREACH_STR_KEY_VAL(a, b, c)=do {"
   - "ZEND_HASH_FOREACH_END=} while(true)"
+StatementMacros:
+  - PHP_AMQP_NOPARAMS
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false

--- a/.clang-format
+++ b/.clang-format
@@ -29,6 +29,7 @@ Macros:
   - "ZEND_HASH_FOREACH_STR_KEY(a, b)=do {"
   - "ZEND_HASH_FOREACH_STR_KEY_VAL(a, b, c)=do {"
   - "ZEND_HASH_FOREACH_END=} while(true)"
+  - "PHP_AMQP_MAYBE_ERROR(a, b)=(a && b)"
 StatementMacros:
   - PHP_AMQP_NOPARAMS
 BraceWrapping:

--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -226,7 +226,7 @@ static PHP_METHOD(AMQPBasicProperties, __construct)
 static PHP_METHOD(AMQPBasicProperties, getContentType)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("contentType");
 }
 /* }}} */
@@ -235,7 +235,7 @@ static PHP_METHOD(AMQPBasicProperties, getContentType)
 static PHP_METHOD(AMQPBasicProperties, getContentEncoding)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("contentEncoding");
 }
 /* }}} */
@@ -244,7 +244,7 @@ static PHP_METHOD(AMQPBasicProperties, getContentEncoding)
 static PHP_METHOD(AMQPBasicProperties, getHeaders)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("headers");
 }
 /* }}} */
@@ -253,7 +253,7 @@ static PHP_METHOD(AMQPBasicProperties, getHeaders)
 static PHP_METHOD(AMQPBasicProperties, getDeliveryMode)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("deliveryMode");
 }
 /* }}} */
@@ -262,7 +262,7 @@ static PHP_METHOD(AMQPBasicProperties, getDeliveryMode)
 static PHP_METHOD(AMQPBasicProperties, getPriority)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("priority");
 }
 /* }}} */
@@ -271,7 +271,7 @@ static PHP_METHOD(AMQPBasicProperties, getPriority)
 static PHP_METHOD(AMQPBasicProperties, getCorrelationId)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("correlationId");
 }
 /* }}} */
@@ -280,7 +280,7 @@ static PHP_METHOD(AMQPBasicProperties, getCorrelationId)
 static PHP_METHOD(AMQPBasicProperties, getReplyTo)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("replyTo");
 }
 /* }}} */
@@ -290,7 +290,7 @@ check amqp envelope */
 static PHP_METHOD(AMQPBasicProperties, getExpiration)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("expiration");
 }
 /* }}} */
@@ -299,7 +299,7 @@ static PHP_METHOD(AMQPBasicProperties, getExpiration)
 static PHP_METHOD(AMQPBasicProperties, getMessageId)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("messageId");
 }
 /* }}} */
@@ -308,7 +308,7 @@ static PHP_METHOD(AMQPBasicProperties, getMessageId)
 static PHP_METHOD(AMQPBasicProperties, getTimestamp)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("timestamp");
 }
 /* }}} */
@@ -317,7 +317,7 @@ static PHP_METHOD(AMQPBasicProperties, getTimestamp)
 static PHP_METHOD(AMQPBasicProperties, getType)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("type");
 }
 /* }}} */
@@ -326,7 +326,7 @@ static PHP_METHOD(AMQPBasicProperties, getType)
 static PHP_METHOD(AMQPBasicProperties, getUserId)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("userId");
 }
 /* }}} */
@@ -335,7 +335,7 @@ static PHP_METHOD(AMQPBasicProperties, getUserId)
 static PHP_METHOD(AMQPBasicProperties, getAppId)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("appId");
 }
 /* }}} */
@@ -344,7 +344,7 @@ static PHP_METHOD(AMQPBasicProperties, getAppId)
 static PHP_METHOD(AMQPBasicProperties, getClusterId)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("clusterId");
 }
 /* }}} */

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -444,7 +444,7 @@ static PHP_METHOD(amqp_channel_class, isConnected)
 {
     amqp_channel_resource *channel_resource;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
 
@@ -458,7 +458,7 @@ static PHP_METHOD(amqp_channel_class, close)
 {
     amqp_channel_resource *channel_resource;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
 
@@ -474,7 +474,7 @@ static PHP_METHOD(amqp_channel_class, getChannelId)
 {
     amqp_channel_resource *channel_resource;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
 
@@ -569,7 +569,7 @@ get the number of prefetches */
 static PHP_METHOD(amqp_channel_class, getPrefetchCount)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("prefetchCount")
 }
 /* }}} */
@@ -656,7 +656,7 @@ get the number of prefetches */
 static PHP_METHOD(amqp_channel_class, getPrefetchSize)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("prefetchSize")
 }
 /* }}} */
@@ -723,7 +723,7 @@ get the number of prefetches */
 static PHP_METHOD(amqp_channel_class, getGlobalPrefetchCount)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("globalPrefetchCount")
 }
 /* }}} */
@@ -790,7 +790,7 @@ get the number of prefetches */
 static PHP_METHOD(amqp_channel_class, getGlobalPrefetchSize)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("globalPrefetchSize")
 }
 /* }}} */
@@ -980,7 +980,7 @@ Get the AMQPConnection object in use */
 static PHP_METHOD(amqp_channel_class, getConnection)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("connection")
 }
 /* }}} */
@@ -1366,7 +1366,7 @@ PHP_METHOD(amqp_channel_class, waitForConfirm)
 static PHP_METHOD(amqp_channel_class, getConsumers)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("consumers");
 }
 /* }}} */

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -65,7 +65,7 @@ zend_class_entry *amqp_channel_class_entry;
 
 zend_object_handlers amqp_channel_object_handlers;
 
-void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool check_errors)
+void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool throw)
 {
     assert(channel_resource != NULL);
 
@@ -90,16 +90,35 @@ void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool c
     if (connection_resource && connection_resource->is_connected && channel_resource->channel_id > 0) {
         assert(connection_resource != NULL);
 
-        amqp_channel_close(connection_resource->connection_state, channel_resource->channel_id, AMQP_REPLY_SUCCESS);
+        amqp_rpc_reply_t close_res =
+            amqp_channel_close(connection_resource->connection_state, channel_resource->channel_id, AMQP_REPLY_SUCCESS);
 
-        amqp_rpc_reply_t res = amqp_get_rpc_reply(connection_resource->connection_state);
-
-        if (check_errors && PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
-            php_amqp_zend_throw_exception_short(res, amqp_channel_exception_class_entry);
-            return;
+        if (throw && PHP_AMQP_MAYBE_ERROR(close_res, channel_resource)) {
+            php_amqp_zend_throw_exception_short(close_res, amqp_channel_exception_class_entry);
+            goto err;
         }
 
-        php_amqp_maybe_release_buffers_on_channel(connection_resource, channel_resource);
+		if (close_res.reply_type != AMQP_RESPONSE_NORMAL) {
+			goto err;
+		}
+
+        amqp_rpc_reply_t reply_res = amqp_get_rpc_reply(connection_resource->connection_state);
+        if (throw && PHP_AMQP_MAYBE_ERROR(reply_res, channel_resource)) {
+            php_amqp_zend_throw_exception_short(reply_res, amqp_channel_exception_class_entry);
+            goto err;
+        }
+
+		if (reply_res.reply_type != AMQP_RESPONSE_NORMAL) {
+			goto err;
+		}
+
+		php_amqp_maybe_release_buffers_on_channel(connection_resource, channel_resource);
+		return;
+
+		err:
+			// Mark failed slot as used
+			connection_resource->used_slots++;
+			return;
     }
 }
 

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -98,9 +98,9 @@ void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool t
             goto err;
         }
 
-		if (close_res.reply_type != AMQP_RESPONSE_NORMAL) {
-			goto err;
-		}
+        if (close_res.reply_type != AMQP_RESPONSE_NORMAL) {
+            goto err;
+        }
 
         amqp_rpc_reply_t reply_res = amqp_get_rpc_reply(connection_resource->connection_state);
         if (throw && PHP_AMQP_MAYBE_ERROR(reply_res, channel_resource)) {
@@ -108,17 +108,17 @@ void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool t
             goto err;
         }
 
-		if (reply_res.reply_type != AMQP_RESPONSE_NORMAL) {
-			goto err;
-		}
+        if (reply_res.reply_type != AMQP_RESPONSE_NORMAL) {
+            goto err;
+        }
 
-		php_amqp_maybe_release_buffers_on_channel(connection_resource, channel_resource);
-		return;
+        php_amqp_maybe_release_buffers_on_channel(connection_resource, channel_resource);
+        return;
 
-		err:
-			// Mark failed slot as used
-			connection_resource->used_slots++;
-			return;
+    err:
+        // Mark failed slot as used
+        connection_resource->used_slots++;
+        return;
     }
 }
 

--- a/amqp_channel.h
+++ b/amqp_channel.h
@@ -24,6 +24,6 @@
 
 extern zend_class_entry *amqp_channel_class_entry;
 
-void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool check_errors);
+void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool throw);
 
 PHP_MINIT_FUNCTION(amqp_channel);

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -1710,8 +1710,6 @@ static PHP_METHOD(amqp_connection_class, setConnectionName)
 }
 /* }}} */
 
-static PHP_METHOD(amqp_connection_class, tune) { PHP_AMQP_NOPARAMS() }
-
 /* amqp_connection_class ARG_INFO definition */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class__construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, credentials, IS_ARRAY, 0, "[]")

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -814,7 +814,7 @@ static PHP_METHOD(amqp_connection_class, isConnected)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -830,7 +830,7 @@ static PHP_METHOD(amqp_connection_class, connect)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -859,7 +859,7 @@ static PHP_METHOD(amqp_connection_class, pconnect)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -892,7 +892,7 @@ static PHP_METHOD(amqp_connection_class, pdisconnect)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -927,7 +927,7 @@ static PHP_METHOD(amqp_connection_class, disconnect)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -962,7 +962,7 @@ static PHP_METHOD(amqp_connection_class, reconnect)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -997,7 +997,7 @@ static PHP_METHOD(amqp_connection_class, preconnect)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -1033,7 +1033,7 @@ get the login */
 static PHP_METHOD(amqp_connection_class, getLogin)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("login");
 }
 /* }}} */
@@ -1071,7 +1071,7 @@ get the password */
 static PHP_METHOD(amqp_connection_class, getPassword)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("password");
 }
 /* }}} */
@@ -1116,7 +1116,7 @@ get the host */
 static PHP_METHOD(amqp_connection_class, getHost)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("host");
 }
 /* }}} */
@@ -1155,7 +1155,7 @@ get the port */
 static PHP_METHOD(amqp_connection_class, getPort)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("port");
 }
 /* }}} */
@@ -1193,7 +1193,7 @@ get the vhost */
 static PHP_METHOD(amqp_connection_class, getVhost)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("vhost");
 }
 /* }}} */
@@ -1237,7 +1237,7 @@ static PHP_METHOD(amqp_connection_class, getTimeout)
     );
 
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("readTimeout");
 }
 /* }}} */
@@ -1293,7 +1293,7 @@ get the read timeout */
 static PHP_METHOD(amqp_connection_class, getReadTimeout)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("readTimeout");
 }
 /* }}} */
@@ -1341,7 +1341,7 @@ get write timeout */
 static PHP_METHOD(amqp_connection_class, getWriteTimeout)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("writeTimeout");
 }
 /* }}} */
@@ -1389,7 +1389,7 @@ get rpc timeout */
 static PHP_METHOD(amqp_connection_class, getConnectTimeout)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("connectTimeout");
 }
 /* }}} */
@@ -1399,7 +1399,7 @@ get rpc timeout */
 static PHP_METHOD(amqp_connection_class, getRpcTimeout)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("rpcTimeout");
 }
 /* }}} */
@@ -1449,7 +1449,7 @@ static PHP_METHOD(amqp_connection_class, getUsedChannels)
     amqp_connection_object *connection;
 
     /* Get the timeout from the method params */
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -1471,7 +1471,7 @@ PHP_METHOD(amqp_connection_class, getMaxChannels)
     zval rv;
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -1491,7 +1491,7 @@ static PHP_METHOD(amqp_connection_class, getMaxFrameSize)
     zval rv;
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -1511,7 +1511,7 @@ static PHP_METHOD(amqp_connection_class, getHeartbeatInterval)
     zval rv;
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* Get the connection object out of the store */
     connection = PHP_AMQP_GET_CONNECTION(getThis());
@@ -1530,7 +1530,7 @@ static PHP_METHOD(amqp_connection_class, isPersistent)
 {
     amqp_connection_object *connection;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     connection = PHP_AMQP_GET_CONNECTION(getThis());
 
@@ -1543,7 +1543,7 @@ static PHP_METHOD(amqp_connection_class, isPersistent)
 static PHP_METHOD(amqp_connection_class, getCACert)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("cacert");
 }
 /* }}} */
@@ -1570,7 +1570,7 @@ static PHP_METHOD(amqp_connection_class, setCACert)
 static PHP_METHOD(amqp_connection_class, getCert)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("cert");
 }
 /* }}} */
@@ -1597,7 +1597,7 @@ static PHP_METHOD(amqp_connection_class, setCert)
 static PHP_METHOD(amqp_connection_class, getKey)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("key");
 }
 /* }}} */
@@ -1625,7 +1625,7 @@ static PHP_METHOD(amqp_connection_class, setKey)
 static PHP_METHOD(amqp_connection_class, getVerify)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("verify");
 }
 /* }}} */
@@ -1648,7 +1648,7 @@ get sasl method */
 static PHP_METHOD(amqp_connection_class, getSaslMethod)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("saslMethod");
 }
 /* }}} */
@@ -1682,7 +1682,7 @@ static PHP_METHOD(amqp_connection_class, setSaslMethod)
 static PHP_METHOD(amqp_connection_class, getConnectionName)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("connectionName");
 }
 /* }}} */
@@ -1709,6 +1709,8 @@ static PHP_METHOD(amqp_connection_class, setConnectionName)
     }
 }
 /* }}} */
+
+static PHP_METHOD(amqp_connection_class, tune) { PHP_AMQP_NOPARAMS() }
 
 /* amqp_connection_class ARG_INFO definition */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_connection_class__construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -422,7 +422,7 @@ amqp_channel_t php_amqp_connection_resource_get_available_channel_id(amqp_connec
 
     amqp_channel_t slot;
 
-    for (slot = 0; slot < resource->max_slots; slot++) {
+    for (slot = resource->used_slots; slot < resource->max_slots; slot++) {
         if (resource->slots[slot] == 0) {
             return (amqp_channel_t) (slot + 1);
         }

--- a/amqp_decimal.c
+++ b/amqp_decimal.c
@@ -86,7 +86,7 @@ Get exponent */
 static PHP_METHOD(amqp_decimal_class, getExponent)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     PHP_AMQP_RETURN_THIS_PROP("exponent");
 }
@@ -97,7 +97,7 @@ Get E */
 static PHP_METHOD(amqp_decimal_class, getSignificand)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     PHP_AMQP_RETURN_THIS_PROP("significand");
 }

--- a/amqp_envelope.c
+++ b/amqp_envelope.c
@@ -118,7 +118,7 @@ void convert_amqp_envelope_to_zval(amqp_envelope_t *amqp_envelope, zval *envelop
 /* {{{ proto AMQPEnvelope::__construct() */
 static PHP_METHOD(amqp_envelope_class, __construct)
 {
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     /* BC */
     php_amqp_basic_properties_set_empty_headers(getThis());
@@ -131,7 +131,7 @@ static PHP_METHOD(amqp_envelope_class, getBody)
 {
     zval rv;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     zval *zv = PHP_AMQP_READ_THIS_PROP("body");
 
@@ -147,7 +147,7 @@ static PHP_METHOD(amqp_envelope_class, getBody)
 static PHP_METHOD(amqp_envelope_class, getRoutingKey)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("routingKey");
 }
 /* }}} */
@@ -156,7 +156,7 @@ static PHP_METHOD(amqp_envelope_class, getRoutingKey)
 static PHP_METHOD(amqp_envelope_class, getDeliveryTag)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("deliveryTag");
 }
 /* }}} */
@@ -165,7 +165,7 @@ static PHP_METHOD(amqp_envelope_class, getDeliveryTag)
 static PHP_METHOD(amqp_envelope_class, getConsumerTag)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("consumerTag");
 }
 /* }}} */
@@ -174,7 +174,7 @@ static PHP_METHOD(amqp_envelope_class, getConsumerTag)
 static PHP_METHOD(amqp_envelope_class, getExchangeName)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("exchangeName");
 }
 /* }}} */
@@ -183,7 +183,7 @@ static PHP_METHOD(amqp_envelope_class, getExchangeName)
 static PHP_METHOD(amqp_envelope_class, isRedelivery)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("isRedelivery");
 }
 /* }}} */

--- a/amqp_envelope_exception.c
+++ b/amqp_envelope_exception.c
@@ -36,7 +36,7 @@ Get AMQPEnvelope object */
 static PHP_METHOD(amqp_envelope_exception_class, getEnvelope)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     PHP_AMQP_RETURN_THIS_PROP("envelope");
 }

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -101,7 +101,7 @@ static PHP_METHOD(amqp_exchange_class, getName)
 {
     zval rv;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") > 0) {
         PHP_AMQP_RETURN_THIS_PROP("name");
@@ -147,7 +147,7 @@ static PHP_METHOD(amqp_exchange_class, getFlags)
 
     zend_long flags = AMQP_NOPARAM;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     if (PHP_AMQP_READ_THIS_PROP_BOOL("passive")) {
         flags |= AMQP_PASSIVE;
@@ -198,7 +198,7 @@ static PHP_METHOD(amqp_exchange_class, getType)
 {
     zval rv;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     if (PHP_AMQP_READ_THIS_PROP_STRLEN("type") > 0) {
         PHP_AMQP_RETURN_THIS_PROP("type");
@@ -269,7 +269,7 @@ Get the exchange arguments */
 static PHP_METHOD(amqp_exchange_class, getArguments)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("arguments");
 }
 /* }}} */
@@ -351,9 +351,7 @@ static PHP_METHOD(amqp_exchange_class, declareExchange)
     amqp_channel_resource *channel_resource;
     amqp_table_t *arguments;
 
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
     PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not declare exchange.");
@@ -795,7 +793,7 @@ Get the AMQPChannel object in use */
 static PHP_METHOD(amqp_exchange_class, getChannel)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("channel");
 }
 /* }}} */
@@ -805,7 +803,7 @@ Get the AMQPConnection object in use */
 static PHP_METHOD(amqp_exchange_class, getConnection)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("connection");
 }
 /* }}} */

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -108,7 +108,7 @@ static PHP_METHOD(amqp_queue_class, getName)
 {
     zval rv;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     if (PHP_AMQP_READ_THIS_PROP_STRLEN("name") > 0) {
         PHP_AMQP_RETURN_THIS_PROP("name");
@@ -154,7 +154,7 @@ static PHP_METHOD(amqp_queue_class, getFlags)
 
     zend_long flags = 0;
 
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     if (PHP_AMQP_READ_THIS_PROP_BOOL("passive")) {
         flags |= AMQP_PASSIVE;
@@ -243,7 +243,7 @@ Get the queue arguments */
 static PHP_METHOD(amqp_queue_class, getArguments)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("arguments");
 }
 /* }}} */
@@ -329,9 +329,7 @@ static PHP_METHOD(amqp_queue_class, declareQueue)
     amqp_table_t *arguments;
     zend_long message_count;
 
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
     PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not declare queue.");
@@ -959,9 +957,7 @@ static PHP_METHOD(amqp_queue_class, purge)
 
     amqp_channel_resource *channel_resource;
 
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
     PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not purge queue.");
@@ -1184,7 +1180,7 @@ Get the AMQPChannel object in use */
 static PHP_METHOD(amqp_queue_class, getChannel)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("channel");
 }
 /* }}} */
@@ -1194,7 +1190,7 @@ Get the AMQPConnection object in use */
 static PHP_METHOD(amqp_queue_class, getConnection)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("connection");
 }
 /* }}} */
@@ -1204,7 +1200,7 @@ Get latest consumer tag*/
 static PHP_METHOD(amqp_queue_class, getConsumerTag)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
     PHP_AMQP_RETURN_THIS_PROP("consumerTag");
 }
 

--- a/amqp_timestamp.c
+++ b/amqp_timestamp.c
@@ -75,7 +75,7 @@ Get timestamp */
 static PHP_METHOD(amqp_timestamp_class, getTimestamp)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     PHP_AMQP_RETURN_THIS_PROP("timestamp");
 }
@@ -87,7 +87,7 @@ Return timestamp as string */
 static PHP_METHOD(amqp_timestamp_class, __toString)
 {
     zval rv;
-    PHP_AMQP_NOPARAMS();
+    PHP_AMQP_NOPARAMS()
 
     zval *timestamp = zend_read_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("timestamp"), 0, &rv);
 

--- a/infra/php/Dockerfile
+++ b/infra/php/Dockerfile
@@ -24,7 +24,7 @@ CMD PHP_AMQP_DOCKER_ENTRYPOINT=1 php /src/infra/tools/pamqp-docker-setup && \
 
 FROM dev AS dev-all
 RUN apt-get install -yqq gnupg2
-RUN echo "deb https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" > /etc/apt/sources.list.d/llvm.list
+RUN echo "deb https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main" > /etc/apt/sources.list.d/llvm.list
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN apt-get update -yqq
 RUN apt-get install -yqq clang-format-17

--- a/tests/bug_gh50-1.phpt
+++ b/tests/bug_gh50-1.phpt
@@ -23,5 +23,5 @@ for ($i = 0; $i < 3; $i++) {
 --EXPECT--
 int(1)
 int(2)
-int(1)
+int(3)
 ==DONE==

--- a/tests/bug_gh50-3.phpt
+++ b/tests/bug_gh50-3.phpt
@@ -40,8 +40,8 @@ for ($i = 0; $i < 3; $i++) {
 --EXPECT--
 int(1)
 int(2)
-int(1)
+int(3)
 int(1)
 int(2)
-int(1)
+int(3)
 ==DONE==


### PR DESCRIPTION
When a channel close does not work, mark the slot as used and carry on.

Fixes #297