### PR TITLE
Allow flags arguments to be null where previously AMQP_NOPARAM was required

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -162,9 +162,9 @@
 
 ### Public method additions
 
-* `getConnectTimeout(): float`
-* `setConnectionName(?string $connectionName): void`
-* `getConnectionName(): ?string`
+ * `getConnectTimeout(): float`
+ * `setConnectionName(?string $connectionName): void`
+ * `getConnectionName(): ?string`
 
 ### Public method type changes
 
@@ -331,7 +331,7 @@
 
 ### Public method additions
 
-* `getEnvelope(): AMQPEnvelope`
+ * `getEnvelope(): AMQPEnvelope`
 
 ## `AMQPExchange` breaking changes
 
@@ -365,7 +365,7 @@
 ```
 ```diff
 - delete(string $exchangeName = null, int $flags = 0): bool
-+ delete(?string $exchangeName = null, int $flags = 0): void
++ delete(?string $exchangeName = null, ?int $flags = null): void
 
 ```
 ```diff
@@ -385,7 +385,7 @@
 ```
 ```diff
 - publish(string $message, string $routing_key = null, int $flags = 0, array $attributes = []): bool
-+ publish(string $message, ?string $routingKey = null, int $flags = 0, array $headers = []): void
++ publish(string $message, ?string $routingKey = null, ?int $flags = null, array $headers = []): void
 
 ```
 ```diff
@@ -442,7 +442,7 @@
 
 ```diff
 - ack(string $delivery_tag, int $flags = 0): bool
-+ ack(int $deliveryTag, int $flags = 0): void
++ ack(int $deliveryTag, ?int $flags = null): void
 
 ```
 ```diff
@@ -457,12 +457,17 @@
 ```
 ```diff
 - consume(?callable $callback = null, int $flags = 0, string $consumerTag = null): void
-+ consume(?callable $callback = null, int $flags = 0, ?string $consumerTag = null): void
++ consume(?callable $callback = null, ?int $flags = null, ?string $consumerTag = null): void
+
+```
+```diff
+- delete(int $flags = 0): int
++ delete(?int $flags = null): int
 
 ```
 ```diff
 - get(int $flags = 0): AMQPEnvelope|bool
-+ get(int $flags = 0): ?AMQPEnvelope
++ get(?int $flags = null): ?AMQPEnvelope
 
 ```
 ```diff
@@ -477,12 +482,12 @@
 ```
 ```diff
 - nack(string $delivery_tag, int $flags = 0): bool
-+ nack(int $deliveryTag, int $flags = 0): void
++ nack(int $deliveryTag, ?int $flags = null): void
 
 ```
 ```diff
 - reject(string $delivery_tag, int $flags = 0): bool
-+ reject(int $deliveryTag, int $flags = 0): void
++ reject(int $deliveryTag, ?int $flags = null): void
 
 ```
 ```diff

--- a/amqp.c
+++ b/amqp.c
@@ -83,29 +83,29 @@ zend_function_entry amqp_functions[] = {
 };
 /* }}} */
 
-zend_bool php_amqp_is_valid_identifier(zend_string *val)
+bool php_amqp_is_valid_identifier(zend_string *val)
 {
     return ZSTR_LEN(val) > 0 && ZSTR_LEN(val) <= PHP_AMQP_MAX_IDENTIFIER_LENGTH;
 }
 
-zend_bool php_amqp_is_valid_credential(zend_string *val)
+bool php_amqp_is_valid_credential(zend_string *val)
 {
     return ZSTR_LEN(val) > 0 && ZSTR_LEN(val) <= PHP_AMQP_MAX_CREDENTIALS_LENGTH;
 }
 
-zend_bool php_amqp_is_valid_port(zend_long val) { return val >= PHP_AMQP_MIN_PORT && val <= PHP_AMQP_MAX_PORT; }
+bool php_amqp_is_valid_port(zend_long val) { return val >= PHP_AMQP_MIN_PORT && val <= PHP_AMQP_MAX_PORT; }
 
-zend_bool php_amqp_is_valid_timeout(double timeout) { return timeout >= 0; }
+bool php_amqp_is_valid_timeout(double timeout) { return timeout >= 0; }
 
-zend_bool php_amqp_is_valid_channel_max(zend_long val) { return val > 0 && val <= PHP_AMQP_DEFAULT_CHANNEL_MAX; }
+bool php_amqp_is_valid_channel_max(zend_long val) { return val > 0 && val <= PHP_AMQP_DEFAULT_CHANNEL_MAX; }
 
-zend_bool php_amqp_is_valid_frame_size_max(zend_long val) { return val > 0 && val <= PHP_AMQP_MAX_FRAME_SIZE; }
+bool php_amqp_is_valid_frame_size_max(zend_long val) { return val > 0 && val <= PHP_AMQP_MAX_FRAME_SIZE; }
 
-zend_bool php_amqp_is_valid_heartbeat(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_HEARTBEAT; }
+bool php_amqp_is_valid_heartbeat(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_HEARTBEAT; }
 
-zend_bool php_amqp_is_valid_prefetch_size(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_SIZE; }
+bool php_amqp_is_valid_prefetch_size(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_SIZE; }
 
-zend_bool php_amqp_is_valid_prefetch_count(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_COUNT; }
+bool php_amqp_is_valid_prefetch_count(zend_long val) { return val >= 0 && val <= PHP_AMQP_MAX_PREFETCH_COUNT; }
 
 static ZEND_INI_MH(onUpdateIdentifier)
 {

--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -62,7 +62,7 @@
 
 void php_amqp_basic_properties_table_to_zval_internal(amqp_table_t *table, zval *result, uint8_t depth);
 void php_amqp_basic_properties_array_to_zval_internal(amqp_array_t *array, zval *result, uint8_t depth);
-zend_bool php_amqp_basic_properties_value_to_zval_internal(amqp_field_value_t *value, zval *result, uint8_t depth);
+bool php_amqp_basic_properties_value_to_zval_internal(amqp_field_value_t *value, zval *result, uint8_t depth);
 
 zend_class_entry *amqp_basic_properties_class_entry;
 #define this_ce amqp_basic_properties_class_entry
@@ -562,7 +562,7 @@ PHP_MINIT_FUNCTION(amqp_basic_properties)
     return SUCCESS;
 }
 
-zend_bool php_amqp_basic_properties_value_to_zval_internal(amqp_field_value_t *value, zval *result, uint8_t depth)
+bool php_amqp_basic_properties_value_to_zval_internal(amqp_field_value_t *value, zval *result, uint8_t depth)
 {
     if (depth >= PHP_AMQP_RECURSION_DEPTH_LIMIT) {
         zend_throw_exception_ex(

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -65,7 +65,7 @@ zend_class_entry *amqp_channel_class_entry;
 
 zend_object_handlers amqp_channel_object_handlers;
 
-void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool throw)
+void php_amqp_close_channel(amqp_channel_resource *channel_resource, bool throw)
 {
     assert(channel_resource != NULL);
 
@@ -823,7 +823,7 @@ static PHP_METHOD(amqp_channel_class, qos)
     amqp_channel_resource *channel_resource;
     zend_long prefetch_size;
     zend_long prefetch_count;
-    zend_bool global = 0;
+    bool global = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll|b", &prefetch_size, &prefetch_count, &global) == FAILURE) {
         return;
@@ -1012,7 +1012,7 @@ static PHP_METHOD(amqp_channel_class, basicRecover)
 
     amqp_rpc_reply_t res;
 
-    zend_bool requeue = 1;
+    bool requeue = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &requeue) == FAILURE) {
         return;

--- a/amqp_channel.h
+++ b/amqp_channel.h
@@ -24,6 +24,6 @@
 
 extern zend_class_entry *amqp_channel_class_entry;
 
-void php_amqp_close_channel(amqp_channel_resource *channel_resource, zend_bool throw);
+void php_amqp_close_channel(amqp_channel_resource *channel_resource, bool throw);
 
 PHP_MINIT_FUNCTION(amqp_channel);

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -176,7 +176,7 @@ void php_amqp_disconnect_force(amqp_connection_resource *resource)
  *	handles connecting to amqp
  *	called by connect(), pconnect(), reconnect(), preconnect()
  */
-int php_amqp_connect(amqp_connection_object *connection, zend_bool persistent, INTERNAL_FUNCTION_PARAMETERS)
+int php_amqp_connect(amqp_connection_object *connection, bool persistent, INTERNAL_FUNCTION_PARAMETERS)
 {
     zval rv;
 
@@ -1633,7 +1633,7 @@ static PHP_METHOD(amqp_connection_class, getVerify)
 /* {{{ proto amqp::setVerify(bool verify) */
 static PHP_METHOD(amqp_connection_class, setVerify)
 {
-    zend_bool verify = 1;
+    bool verify = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &verify) == FAILURE) {
         return;

--- a/amqp_connection.h
+++ b/amqp_connection.h
@@ -24,7 +24,7 @@
 
 extern zend_class_entry *amqp_connection_class_entry;
 
-int php_amqp_connect(amqp_connection_object *amqp_connection, zend_bool persistent, INTERNAL_FUNCTION_PARAMETERS);
+int php_amqp_connect(amqp_connection_object *amqp_connection, bool persistent, INTERNAL_FUNCTION_PARAMETERS);
 void php_amqp_disconnect_force(amqp_connection_resource *resource);
 
 

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -471,7 +471,7 @@ int php_amqp_connection_resource_unregister_channel(amqp_connection_resource *re
 
 /* Creating and destroying resource */
 
-amqp_connection_resource *connection_resource_constructor(amqp_connection_params *params, zend_bool persistent)
+amqp_connection_resource *connection_resource_constructor(amqp_connection_params *params, bool persistent)
 {
     struct timeval tv = {0};
     struct timeval *tv_ptr = &tv;

--- a/amqp_connection_resource.h
+++ b/amqp_connection_resource.h
@@ -94,7 +94,7 @@ int php_amqp_connection_resource_register_channel(
 );
 
 /* Creating and destroying resource */
-amqp_connection_resource *connection_resource_constructor(amqp_connection_params *params, zend_bool persistent);
+amqp_connection_resource *connection_resource_constructor(amqp_connection_params *params, bool persistent);
 ZEND_RSRC_DTOR_FUNC(amqp_connection_resource_dtor_persistent);
 ZEND_RSRC_DTOR_FUNC(amqp_connection_resource_dtor);
 

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -181,8 +181,7 @@ static PHP_METHOD(amqp_exchange_class, setFlags)
         return;
     }
 
-    /* Set the flags based on the bitmask we were given */
-    flags = flags ? flags & PHP_AMQP_EXCHANGE_FLAGS : flags;
+    flags = flags & PHP_AMQP_EXCHANGE_FLAGS;
 
     zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("passive"), IS_PASSIVE(flags));
     zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("durable"), IS_DURABLE(flags));

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -175,7 +175,7 @@ Set the exchange parameters */
 static PHP_METHOD(amqp_exchange_class, setFlags)
 {
     zend_long flags = AMQP_NOPARAM;
-    zend_bool flags_is_null = 1;
+    bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l!", &flags, &flags_is_null) == FAILURE) {
         return;
@@ -415,8 +415,9 @@ static PHP_METHOD(amqp_exchange_class, delete)
     char *name = NULL;
     size_t name_len = 0;
     zend_long flags = AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!l", &name, &name_len, &flags) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!l!", &name, &name_len, &flags, &flags_is_null) == FAILURE) {
         return;
     }
 
@@ -464,6 +465,7 @@ static PHP_METHOD(amqp_exchange_class, publish)
     char *msg = NULL;
     size_t msg_len = 0;
     zend_long flags = AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
 #ifndef PHP_WIN32
     /* Storage for previous signal handler during SIGPIPE override */
@@ -472,8 +474,17 @@ static PHP_METHOD(amqp_exchange_class, publish)
 
     amqp_basic_properties_t props;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s!la/", &msg, &msg_len, &key_name, &key_len, &flags, &ini_arr) ==
-        FAILURE) {
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS(),
+            "s|s!l!a/",
+            &msg,
+            &msg_len,
+            &key_name,
+            &key_len,
+            &flags,
+            &flags_is_null,
+            &ini_arr
+        ) == FAILURE) {
         return;
     }
 
@@ -875,13 +886,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_exchange_class_delete, ZEND_RETURN_VALUE, 0, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, exchangeName, IS_STRING, 1, "null")
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_exchange_class_publish, ZEND_RETURN_VALUE, 1, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, routingKey, IS_STRING, 1, "null")
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, headers, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -181,15 +181,14 @@ static PHP_METHOD(amqp_queue_class, getFlags)
 Set the queue parameters */
 static PHP_METHOD(amqp_queue_class, setFlags)
 {
-    zend_long flags;
+    zend_long flags = AMQP_NOPARAM;
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l!", &flags, &flags_is_null) == FAILURE) {
         return;
     }
 
-    /* Set the flags based on the bitmask we were given */
-    flags = flags ? flags & PHP_AMQP_QUEUE_FLAGS : flags;
+    flags = flags & PHP_AMQP_QUEUE_FLAGS;
 
     zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("passive"), IS_PASSIVE(flags));
     zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("durable"), IS_DURABLE(flags));

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -182,7 +182,7 @@ Set the queue parameters */
 static PHP_METHOD(amqp_queue_class, setFlags)
 {
     zend_long flags;
-    zend_bool flags_is_null = 1;
+    bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l!", &flags, &flags_is_null) == FAILURE) {
         return;
@@ -454,9 +454,9 @@ static PHP_METHOD(amqp_queue_class, get)
     zval message;
 
     zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
-    /* Parse out the method parameters */
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &flags) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l!", &flags, &flags_is_null) == FAILURE) {
         return;
     }
 
@@ -546,9 +546,18 @@ static PHP_METHOD(amqp_queue_class, consume)
     char *consumer_tag = NULL;
     size_t consumer_tag_len = 0;
     zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|f!ls!", &fci, &fci_cache, &flags, &consumer_tag, &consumer_tag_len) ==
-        FAILURE) {
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS(),
+            "|f!l!s!",
+            &fci,
+            &fci_cache,
+            &flags,
+            &flags_is_null,
+            &consumer_tag,
+            &consumer_tag_len
+        ) == FAILURE) {
         return;
     }
 
@@ -814,8 +823,9 @@ static PHP_METHOD(amqp_queue_class, ack)
 
     zend_long deliveryTag = 0;
     zend_long flags = AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &deliveryTag, &flags) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l!", &deliveryTag, &flags, &flags_is_null) == FAILURE) {
         return;
     }
 
@@ -862,8 +872,9 @@ static PHP_METHOD(amqp_queue_class, nack)
 
     zend_long deliveryTag = 0;
     zend_long flags = AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &deliveryTag, &flags) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l!", &deliveryTag, &flags, &flags_is_null) == FAILURE) {
         return;
     }
 
@@ -911,8 +922,9 @@ static PHP_METHOD(amqp_queue_class, reject)
 
     zend_long deliveryTag = 0;
     zend_long flags = AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &deliveryTag, &flags) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l!", &deliveryTag, &flags, &flags_is_null) == FAILURE) {
         return;
     }
 
@@ -1009,8 +1021,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
     zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
     zval *consumers =
         zend_read_property(amqp_channel_class_entry, PHP_AMQP_COMPAT_OBJ_P(channel_zv), ZEND_STRL("consumers"), 0, &rv);
-    zend_bool previous_consumer_tag_exists =
-        (zend_bool) (IS_STRING == Z_TYPE_P(PHP_AMQP_READ_THIS_PROP("consumerTag")));
+    bool previous_consumer_tag_exists = (bool) (IS_STRING == Z_TYPE_P(PHP_AMQP_READ_THIS_PROP("consumerTag")));
 
     if (IS_ARRAY != Z_TYPE_P(consumers)) {
         zend_throw_exception(
@@ -1134,10 +1145,11 @@ static PHP_METHOD(amqp_queue_class, delete)
     amqp_channel_resource *channel_resource;
 
     zend_long flags = AMQP_NOPARAM;
+    bool flags_is_null = 1;
 
     zend_long message_count;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &flags) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l!", &flags, &flags_is_null) == FAILURE) {
         return;
     }
 
@@ -1258,28 +1270,28 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_bind, ZEND_RETU
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_amqp_queue_class_get, ZEND_SEND_BY_VAL, 0, AMQPEnvelope, 1)
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_consume, ZEND_SEND_BY_VAL, 0, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, consumerTag, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_ack, ZEND_SEND_BY_VAL, 1, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO(0, deliveryTag, IS_LONG, 0)
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_nack, ZEND_SEND_BY_VAL, 1, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO(0, deliveryTag, IS_LONG, 0)
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_reject, ZEND_SEND_BY_VAL, 1, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO(0, deliveryTag, IS_LONG, 0)
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_purge, ZEND_SEND_BY_VAL, 0, IS_LONG, 0)
@@ -1296,7 +1308,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_unbind, ZEND_RE
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_queue_class_delete, ZEND_SEND_BY_VAL, 0, IS_LONG, 0)
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "AMQP_NOPARAM")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO(arginfo_amqp_queue_class_getChannel, AMQPChannel, 0)

--- a/amqp_type.c
+++ b/amqp_type.c
@@ -40,11 +40,11 @@
 #endif
 
 static void php_amqp_type_free_amqp_array_internal(amqp_array_t *array);
-static void php_amqp_type_free_amqp_table_internal(amqp_table_t *object, zend_bool clear_root);
+static void php_amqp_type_free_amqp_table_internal(amqp_table_t *object, bool clear_root);
 void php_amqp_type_internal_zval_to_amqp_array(zval *value, amqp_array_t *arguments, uint8_t depth);
 void php_amqp_type_zval_to_amqp_container_internal(zval *array, amqp_field_value_t **field, uint8_t depth);
 void php_amqp_type_zval_to_amqp_table_internal(zval *array, amqp_table_t *amqp_table, uint8_t depth);
-zend_bool php_amqp_zval_to_amqp_value_internal(zval *value, amqp_field_value_t **field_ptr, char *key, uint8_t depth);
+bool php_amqp_zval_to_amqp_value_internal(zval *value, amqp_field_value_t **field_ptr, char *key, uint8_t depth);
 
 amqp_bytes_t php_amqp_type_char_to_amqp_long(char const *cstr, size_t len)
 {
@@ -90,7 +90,7 @@ void php_amqp_type_zval_to_amqp_container_internal(zval *array, amqp_field_value
 
     ht = Z_ARRVAL_P(array);
 
-    zend_bool is_amqp_array = 1;
+    bool is_amqp_array = 1;
 
     ZEND_HASH_FOREACH_STR_KEY(ht, key)
         if (key) {
@@ -190,9 +190,9 @@ void php_amqp_type_internal_zval_to_amqp_array(zval *value, amqp_array_t *argume
     ZEND_HASH_FOREACH_END ();
 }
 
-zend_bool php_amqp_zval_to_amqp_value_internal(zval *value, amqp_field_value_t **field_ptr, char *key, uint8_t depth)
+bool php_amqp_zval_to_amqp_value_internal(zval *value, amqp_field_value_t **field_ptr, char *key, uint8_t depth)
 {
-    zend_bool result;
+    bool result;
     char type[16];
     amqp_field_value_t *field;
 
@@ -354,7 +354,7 @@ static void php_amqp_type_free_amqp_array_internal(amqp_array_t *array)
     }
 }
 
-static void php_amqp_type_free_amqp_table_internal(amqp_table_t *object, zend_bool clear_root)
+static void php_amqp_type_free_amqp_table_internal(amqp_table_t *object, bool clear_root)
 {
     if (!object) {
         return;

--- a/infra/tools/pamqp-diff-bc
+++ b/infra/tools/pamqp-diff-bc
@@ -8,7 +8,7 @@ $prev = $_SERVER['argv'][1] ?? null;
 $next = $_SERVER['argv'][2] ?? null;
 
 assert($prev !== null, 'First argument must be path to previous stubs version');
-assert($next !== null, 'First argument must be path to next stubs version');
+assert($next !== null, 'Second argument must be path to next stubs version');
 
 function pamqp_string_ends_with(string $haystack, string $needle): bool
 {

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -27,6 +27,8 @@
     #include "config.h"
 #endif
 
+#include <stdbool.h>
+
 /* True global resources - no need for thread safety here */
 extern zend_class_entry *amqp_exception_class_entry, *amqp_connection_exception_class_entry,
     *amqp_channel_exception_class_entry, *amqp_exchange_exception_class_entry, *amqp_queue_exception_class_entry,

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -189,9 +189,9 @@ struct _amqp_channel_object {
 };
 
 struct _amqp_connection_resource {
-    zend_bool is_connected;
-    zend_bool is_persistent;
-    zend_bool is_dirty;
+    bool is_connected;
+    bool is_persistent;
+    bool is_dirty;
     zend_resource *resource;
     amqp_connection_object *parent;
     amqp_channel_t max_slots;
@@ -463,14 +463,14 @@ void php_amqp_maybe_release_buffers_on_channel(
     amqp_channel_resource *channel_resource
 );
 
-zend_bool php_amqp_is_valid_identifier(zend_string *val);
-zend_bool php_amqp_is_valid_credential(zend_string *val);
-zend_bool php_amqp_is_valid_port(zend_long val);
-zend_bool php_amqp_is_valid_timeout(double timeout);
-zend_bool php_amqp_is_valid_channel_max(zend_long val);
-zend_bool php_amqp_is_valid_frame_size_max(zend_long val);
-zend_bool php_amqp_is_valid_heartbeat(zend_long val);
-zend_bool php_amqp_is_valid_prefetch_count(zend_long val);
-zend_bool php_amqp_is_valid_prefetch_size(zend_long val);
+bool php_amqp_is_valid_identifier(zend_string *val);
+bool php_amqp_is_valid_credential(zend_string *val);
+bool php_amqp_is_valid_port(zend_long val);
+bool php_amqp_is_valid_timeout(double timeout);
+bool php_amqp_is_valid_channel_max(zend_long val);
+bool php_amqp_is_valid_frame_size_max(zend_long val);
+bool php_amqp_is_valid_heartbeat(zend_long val);
+bool php_amqp_is_valid_prefetch_count(zend_long val);
+bool php_amqp_is_valid_prefetch_size(zend_long val);
 
 #endif /* PHP_AMQP_H */

--- a/stubs/AMQPExchange.php
+++ b/stubs/AMQPExchange.php
@@ -111,7 +111,7 @@ class AMQPExchange
      * @throws AMQPChannelException If the channel is not open.
      * @throws AMQPConnectionException If the connection to the broker was lost.
      */
-    public function delete(?string $exchangeName = null, int $flags = AMQP_NOPARAM): void
+    public function delete(?string $exchangeName = null, ?int $flags = null): void
     {
     }
 
@@ -195,7 +195,7 @@ class AMQPExchange
     public function publish(
         string $message,
         ?string $routingKey = null,
-        int $flags = AMQP_NOPARAM,
+        ?int $flags = null,
         array $headers = []
     ): void {
     }

--- a/stubs/AMQPQueue.php
+++ b/stubs/AMQPQueue.php
@@ -50,7 +50,7 @@ class AMQPQueue
      * @throws AMQPConnectionException If the connection to the broker was lost.
      * @throws AMQPChannelException If the channel is not open.
      */
-    public function ack(int $deliveryTag, int $flags = AMQP_NOPARAM): void
+    public function ack(int $deliveryTag, ?int $flags = null): void
     {
     }
 
@@ -125,11 +125,8 @@ class AMQPQueue
      * @throws AMQPEnvelopeException When no queue found for envelope.
      * @throws AMQPQueueException If timeout occurs or queue is not exists.
      */
-    public function consume(
-        callable $callback = null,
-        int $flags = AMQP_NOPARAM,
-        ?string $consumerTag = null
-    ): void {
+    public function consume(callable $callback = null, ?int $flags = null, ?string $consumerTag = null): void
+    {
     }
 
     /**
@@ -173,7 +170,7 @@ class AMQPQueue
      *
      * @return integer The number of deleted messages.
      */
-    public function delete(int $flags = AMQP_NOPARAM): int
+    public function delete(?int $flags = null): int
     {
     }
 
@@ -198,7 +195,7 @@ class AMQPQueue
      * @throws AMQPConnectionException If the connection to the broker was lost.
      * @throws AMQPQueueException If queue is not exist.
      */
-    public function get(int $flags = AMQP_NOPARAM): ?AMQPEnvelope
+    public function get(?int $flags = null): ?AMQPEnvelope
     {
     }
 
@@ -261,7 +258,7 @@ class AMQPQueue
      * @throws AMQPConnectionException If the connection to the broker was lost.
      * @throws AMQPChannelException If the channel is not open.
      */
-    public function nack(int $deliveryTag, int $flags = AMQP_NOPARAM): void
+    public function nack(int $deliveryTag, ?int $flags = null): void
     {
     }
 
@@ -279,7 +276,7 @@ class AMQPQueue
      * @throws AMQPConnectionException If the connection to the broker was lost.
      * @throws AMQPChannelException If the channel is not open.
      */
-    public function reject(int $deliveryTag, int $flags = AMQP_NOPARAM): void
+    public function reject(int $deliveryTag, ?int $flags = null): void
     {
     }
 

--- a/tests/amqpenvelope_get_accessors.phpt
+++ b/tests/amqpenvelope_get_accessors.phpt
@@ -21,10 +21,10 @@ $q->declareQueue();
 // Bind it on the exchange to routing.key
 $q->bind($ex->getName(), 'routing.*');
 // Publish a message to the exchange with a routing key
-$ex->publish('message', 'routing.1', AMQP_NOPARAM, array('headers' => array('foo' => 'bar')));
+$ex->publish('message', 'routing.1', null, array('headers' => array('foo' => 'bar')));
 
 // Read from the queue
-$msg = $q->get();
+$msg = $q->get(null);
 var_dump($msg);
 dump_message($msg);
 

--- a/tests/amqpenvelope_var_dump.phpt
+++ b/tests/amqpenvelope_var_dump.phpt
@@ -29,7 +29,7 @@ $ex->publish('message', 'routing.1', AMQP_NOPARAM, array("headers" => array("tes
 
 // Read from the queue
 $q->consume("consumeThings");
-$q->consume("consumeThings");
+$q->consume("consumeThings", null);
 ?>
 --EXPECTF--
 object(AMQPEnvelope)#5 (20) {

--- a/tests/amqpexchange_delete_null_name.phpt
+++ b/tests/amqpexchange_delete_null_name.phpt
@@ -13,7 +13,7 @@ $ex->setName('test.queue.' . bin2hex(random_bytes(32)));
 $ex->setType(AMQP_EX_TYPE_DIRECT);
 $ex->declareExchange();
 
-$ex->delete(null);
+$ex->delete(null, null);
 
 // Deleting with explicit null deleted the current exchange, so we should be able to redeclare
 $ex->setType(AMQP_EX_TYPE_FANOUT);

--- a/tests/amqpqueue_delete_basic.phpt
+++ b/tests/amqpqueue_delete_basic.phpt
@@ -19,7 +19,7 @@ $queue->declareQueue();
 $queue->bind($ex->getName());
 
 var_dump($queue->delete());
-var_dump($queue->delete());
+var_dump($queue->delete(null));
 
 $queue->declareQueue();
 $queue->bind($ex->getName());

--- a/tests/amqpqueue_nack.phpt
+++ b/tests/amqpqueue_nack.phpt
@@ -38,7 +38,7 @@ $q->nack($env->getDeliveryTag(), AMQP_REQUEUE);
 // read again
 $env2  = $q->get(AMQP_NOPARAM);
 if (false !== $env2) {
-    $q->ack($env2->getDeliveryTag());
+    $q->ack($env2->getDeliveryTag(), null);
     echo $env2->getBody() . PHP_EOL;
     echo $env2->isRedelivery() ? 'true' : 'false';
     echo PHP_EOL;

--- a/tests/bug_gh155_direct_reply_to.phpt
+++ b/tests/bug_gh155_direct_reply_to.phpt
@@ -48,7 +48,7 @@ $q_reply->declareQueue();
 
 echo 'Publishing response...' . PHP_EOL;
 
-$exchange->publish('response', $reply_to, AMQP_NOPARAM);
+$exchange->publish('response', $reply_to);
 
 
 echo 'Waiting for reply...' . PHP_EOL;


### PR DESCRIPTION
Allow null as "empty bitmask" in these methods:
 * `AMQPExchange::delete`
 * `AMQPExchange::publish`
 * `AMQPQueue::ack`
 * `AMQPQueue::consume`
 * `AMQPQueue::delete`
 * `AMQPQueue::get`
 * `AMQPQueue::nack`
 * `AMQPQueue::reject`

Use standard type `bool` instead of `zend_bool` everywhere