### PR TITLE
AMQPValue interface for custom value objects

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install clang-format
         uses: myci-actions/add-deb-repo@11
         with:
-          repo: "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
+          repo: 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main'
           repo-name: llvm
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
           install: clang-format-17
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.3", "8.2", "8.1", "8.0", "7.4" ]
+        php-version: [ '8.3', '8.2', '8.1', '8.0', '7.4' ]
 
     steps:
       - name: Checkout
@@ -95,7 +95,7 @@ jobs:
 
   test:
     name: ${{ matrix.test-php-args == '-m' && 'Memtest' || 'Test' }} php-${{ matrix.php-version }}${{ matrix.php-thread-safe && '-ts' || '-nts' }} librabbitmq-${{ matrix.librabbitmq-version }} ${{ matrix.compiler }}
-    # librabbitmq < 0.11 needs older OpenSSL version
+    # librabbitmq < 0.11 needs older OpenSSL version which comes with Ubuntu 20.04
     runs-on: ${{ (matrix.librabbitmq-version == '0.10.0' || matrix.librabbitmq-version == '0.9.0' || matrix.librabbitmq-version == '0.8.0') && 'ubuntu-20.04' || 'ubuntu-22.04' }}
     needs: dedup
     if: needs.dedup.outputs.should_skip != 'true'
@@ -105,7 +105,7 @@ jobs:
       TEST_PHP_ARGS: -j4 ${{ matrix.test-php-args }}
       PHP_AMQP_HOST: localhost
       PHP_AMQP_SSL_HOST: rabbitmq.example.org
-      VALGRIND_OPTS: "--suppressions=infra/tools/valgrind-suppressions"
+      VALGRIND_OPTS: '--suppressions=infra/tools/valgrind-suppressions'
 
     strategy:
       fail-fast: false
@@ -218,8 +218,8 @@ jobs:
         env:
           # Reset defaults to a) only run local tests, b) don’t run memory checks as the full test suite run will do so
           TEST_PHP_ARGS: -j4
-          PHP_AMQP_HOST: ""
-          PHP_AMQP_SSL_HOST: ""
+          PHP_AMQP_HOST: ''
+          PHP_AMQP_SSL_HOST: ''
 
       - name: Test full test suite
         run: make test | tee result-full.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ env:
   TEST_TIMEOUT: 120
   CFLAGS: -g -O0 -fstack-protector-strong -Wall -Werror -D_GNU_SOURCE
   MAKEFLAGS: -j4
+  PHP_VERSIONS: ${{ toJSON([ '8.3', '8.2', '8.1', '8.0', '7.4' ]) }}
 
 jobs:
   dedup:
@@ -55,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.3', '8.2', '8.1', '8.0', '7.4' ]
+        php-version: ${{ fromJson(env.PHP_VERSIONS) }}
 
     steps:
       - name: Checkout
@@ -110,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.3', '8.2', '8.1', '8.0', '7.4' ]
+        php-version: ${{ fromJSON(env.PHP_VERSIONS) }}
         php-thread-safe: [ true, false ]
         librabbitmq-version: [ 'master', '0.13.0', '0.12.0', '0.11.0', '0.10.0', '0.9.0', '0.8.0' ]
         compiler: [gcc, clang]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ${{ fromJson(env.PHP_VERSIONS) }}
+        php-version: ${{ fromJSON(env.PHP_VERSIONS) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ env:
   TEST_TIMEOUT: 120
   CFLAGS: -g -O0 -fstack-protector-strong -Wall -Werror -D_GNU_SOURCE
   MAKEFLAGS: -j4
-  PHP_VERSIONS: ${{ toJSON([ '8.3', '8.2', '8.1', '8.0', '7.4' ]) }}
+  PHP_VERSIONS: ${{ toJSON(["8.3", "8.2", "8.1", "8.0", "7.4"]) }}
 
 jobs:
   dedup:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -124,9 +124,9 @@ jobs:
       matrix:
         php-version: ${{ fromJson(needs.prep.outputs.php_versions) }}
         php-thread-safe: [ true, false ]
-        librabbitmq-version: ${{ fromJson(needs.prep.outputs.librabbitmq_versions }}
+        librabbitmq-version: ${{ fromJson(needs.prep.outputs.librabbitmq_versions) }}
         compiler: [gcc, clang]
-        include: ${{ fromJson(needs.prep.outputs..memory_test_matrix }}
+        include: ${{ fromJson(needs.prep.outputs..memory_test_matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: '${{ fromJSON(env.PHP_VERSIONS) }}'
+        php-version: '${{ fromJson(env.PHP_VERSIONS) }}'
 
     steps:
       - name: Checkout
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: '${{ fromJSON(env.PHP_VERSIONS) }}'
+        php-version: '${{ fromJson(env.PHP_VERSIONS) }}'
         php-thread-safe: [ true, false ]
         librabbitmq-version: [ 'master', '0.13.0', '0.12.0', '0.11.0', '0.10.0', '0.9.0', '0.8.0' ]
         compiler: [gcc, clang]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
       php_versions: ${{ steps.matrix.outputs.php_versions }}
       librabbitmq_versions: ${{ steps.matrix.outputs.librabbitmq_versions }}
-      memory_test_matrix: ${{ steps.matrix.outputs.memory_test_matrix }}
+      memory_build_matrix: ${{ steps.matrix.outputs.memory_build_matrix }}
     steps:
       - id: skip_check
         name: Prevent duplicate builds
@@ -126,7 +126,7 @@ jobs:
         php-thread-safe: [ true, false ]
         librabbitmq-version: ${{ fromJson(needs.prep.outputs.librabbitmq_versions) }}
         compiler: [gcc, clang]
-        include: ${{ fromJson(needs.prep.outputs.memory_test_matrix) }}
+        include: ${{ fromJson(needs.prep.outputs.memory_build_matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,7 +92,6 @@ jobs:
 
       - name: Validate argument parsing
         run: ./infra/tools/pamqp-php-cli-deterministic -d extension=modules/amqp.so ./infra/tools/pamqp-arguments-validate
-        if: matrix.php-version == '8.2' || matrix.php-version == '8.3'
 
   test:
     name: ${{ matrix.test-php-args == '-m' && 'Memtest' || 'Test' }} php-${{ matrix.php-version }}${{ matrix.php-thread-safe && '-ts' || '-nts' }} librabbitmq-${{ matrix.librabbitmq-version }} ${{ matrix.compiler }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
         php-thread-safe: [ true, false ]
         librabbitmq-version: ${{ fromJson(needs.prep.outputs.librabbitmq_versions) }}
         compiler: [gcc, clang]
-        include: ${{ fromJson(needs.prep.outputs..memory_test_matrix) }}
+        include: ${{ fromJson(needs.prep.outputs.memory_test_matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,28 +9,34 @@ env:
   TEST_TIMEOUT: 120
   CFLAGS: -g -O0 -fstack-protector-strong -Wall -Werror -D_GNU_SOURCE
   MAKEFLAGS: -j4
-  PHP_VERSIONS: '["8.3", "8.2", "8.1", "8.0", "7.4"]'
 
 jobs:
-  dedup:
+  prep:
     name: Prevent duplicate builds
     continue-on-error: true
     runs-on: ubuntu-22.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      matrix_php_versions: ${{ steps.matrix.outputs.php_versions }}
     steps:
       - id: skip_check
+        name: Prevent duplicate builds
         uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           skip_after_successful_duplicate: 'true'
           cancel_others: 'true'
           concurrent_skipping: 'same_content_newer'
 
+      - name: Prepare matrix
+        id: matrix
+        run:
+          echo "php_versions='["8.3", "8.2", "8.1", "8.0", "7.4"]'" >> "$GITHUB_OUTPUT"
+
   checkstyle:
     name: Check C formatting
     runs-on: ubuntu-22.04
-    needs: dedup
-    if: needs.dedup.outputs.should_skip != 'true'
+    needs: prep
+    if: needs.prep.outputs.should_skip != 'true'
 
     steps:
       - name: Install clang-format
@@ -50,13 +56,13 @@ jobs:
   stubs:
     name: Check stubs php-${{ matrix.php-version }}
     runs-on: ubuntu-22.04
-    needs: dedup
-    if: needs.dedup.outputs.should_skip != 'true'
+    needs: prep
+    if: needs.prep.outputs.should_skip != 'true'
 
     strategy:
       fail-fast: false
       matrix:
-        php-version: ${{ fromJson(env.PHP_VERSIONS) }}
+        php-version: ${{ fromJson(needs.prep.outputs.php_versions) }}
 
     steps:
       - name: Checkout
@@ -111,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ${{ fromJson(env.PHP_VERSIONS) }}
+        php-version: ${{ fromJson(needs.prep.outputs.php_versions) }}
         php-thread-safe: [ true, false ]
         librabbitmq-version: [ 'master', '0.13.0', '0.12.0', '0.11.0', '0.10.0', '0.9.0', '0.8.0' ]
         compiler: [gcc, clang]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   prep:
-    name: Prevent duplicate builds
+    name: Prepare
     continue-on-error: true
     runs-on: ubuntu-22.04
     outputs:
@@ -30,7 +30,7 @@ jobs:
       - name: Prepare matrix
         id: matrix
         run:
-          echo "php_versions='["8.3", "8.2", "8.1", "8.0", "7.4"]'" >> "$GITHUB_OUTPUT"
+          echo 'php_versions=["8.3", "8.2", "8.1", "8.0", "7.4"]' >> "$GITHUB_OUTPUT"
 
   checkstyle:
     name: Check C formatting

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: '${{ fromJson(env.PHP_VERSIONS) }}'
+        php-version: ${{ fromJson(env.PHP_VERSIONS) }}
 
     steps:
       - name: Checkout
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: '${{ fromJson(env.PHP_VERSIONS) }}'
+        php-version: ${{ fromJson(env.PHP_VERSIONS) }}
         php-thread-safe: [ true, false ]
         librabbitmq-version: [ 'master', '0.13.0', '0.12.0', '0.11.0', '0.10.0', '0.9.0', '0.8.0' ]
         compiler: [gcc, clang]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
-      matrix_php_versions: ${{ steps.matrix.outputs.php_versions }}
+      php_versions: ${{ steps.matrix.outputs.php_versions }}
     steps:
       - id: skip_check
         name: Prevent duplicate builds

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,8 +104,8 @@ jobs:
     name: ${{ matrix.test-php-args == '-m' && 'Memtest' || 'Test' }} php-${{ matrix.php-version }}${{ matrix.php-thread-safe && '-ts' || '-nts' }} librabbitmq-${{ matrix.librabbitmq-version }} ${{ matrix.compiler }}
     # librabbitmq < 0.11 needs older OpenSSL version which comes with Ubuntu 20.04
     runs-on: ${{ (matrix.librabbitmq-version == '0.10.0' || matrix.librabbitmq-version == '0.9.0' || matrix.librabbitmq-version == '0.8.0') && 'ubuntu-20.04' || 'ubuntu-22.04' }}
-    needs: dedup
-    if: needs.dedup.outputs.should_skip != 'true'
+    needs: prep
+    if: needs.prep.outputs.should_skip != 'true'
 
     env:
       CC: ${{ matrix.compiler }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,8 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
       php_versions: ${{ steps.matrix.outputs.php_versions }}
+      librabbitmq_versions: ${{ steps.matrix.outputs.librabbitmq_versions }}
+      memory_test_matrix: ${{ steps.matrix.outputs.memory_test_matrix }}
     steps:
       - id: skip_check
         name: Prevent duplicate builds
@@ -27,10 +29,13 @@ jobs:
           cancel_others: 'true'
           concurrent_skipping: 'same_content_newer'
 
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
+
       - name: Prepare matrix
         id: matrix
-        run:
-          echo 'php_versions=["8.3", "8.2", "8.1", "8.0", "7.4"]' >> "$GITHUB_OUTPUT"
+        run: |
+          infra/tools/pamqp-matrix >> "$GITHUB_OUTPUT"
 
   checkstyle:
     name: Check C formatting
@@ -119,68 +124,9 @@ jobs:
       matrix:
         php-version: ${{ fromJson(needs.prep.outputs.php_versions) }}
         php-thread-safe: [ true, false ]
-        librabbitmq-version: [ 'master', '0.13.0', '0.12.0', '0.11.0', '0.10.0', '0.9.0', '0.8.0' ]
+        librabbitmq-version: ${{ fromJson(needs.prep.outputs.librabbitmq_versions }}
         compiler: [gcc, clang]
-        include:
-          - php-version: '8.3'
-            php-thread-safe: true
-            librabbitmq-version: 'master'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '8.3'
-            php-thread-safe: true
-            librabbitmq-version: '0.8.0'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '8.2'
-            php-thread-safe: true
-            librabbitmq-version: 'master'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '8.2'
-            php-thread-safe: true
-            librabbitmq-version: '0.8.0'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '8.1'
-            php-thread-safe: true
-            librabbitmq-version: 'master'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '8.1'
-            php-thread-safe: true
-            librabbitmq-version: '0.8.0'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '8.0'
-            php-thread-safe: true
-            librabbitmq-version: 'master'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '8.0'
-            php-thread-safe: true
-            librabbitmq-version: '0.8.0'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '7.4'
-            php-thread-safe: true
-            librabbitmq-version: 'master'
-            test-php-args: '-m'
-            compiler: gcc
-
-          - php-version: '7.4'
-            php-thread-safe: true
-            librabbitmq-version: '0.8.0'
-            test-php-args: '-m'
-            compiler: gcc
+        include: ${{ fromJson(needs.prep.outputs..memory_test_matrix }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ${{ fromJSON(env.PHP_VERSIONS) }}
+        php-version: '${{ fromJSON(env.PHP_VERSIONS) }}'
 
     steps:
       - name: Checkout
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ${{ fromJSON(env.PHP_VERSIONS) }}
+        php-version: '${{ fromJSON(env.PHP_VERSIONS) }}'
         php-thread-safe: [ true, false ]
         librabbitmq-version: [ 'master', '0.13.0', '0.12.0', '0.11.0', '0.10.0', '0.9.0', '0.8.0' ]
         compiler: [gcc, clang]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ env:
   TEST_TIMEOUT: 120
   CFLAGS: -g -O0 -fstack-protector-strong -Wall -Werror -D_GNU_SOURCE
   MAKEFLAGS: -j4
-  PHP_VERSIONS: ${{ toJSON(["8.3", "8.2", "8.1", "8.0", "7.4"]) }}
+  PHP_VERSIONS: '["8.3", "8.2", "8.1", "8.0", "7.4"]'
 
 jobs:
   dedup:

--- a/amqp.c
+++ b/amqp.c
@@ -59,6 +59,7 @@
 #include "amqp_envelope_exception.h"
 #include "amqp_exchange.h"
 #include "amqp_queue.h"
+#include "amqp_value.h"
 #include "amqp_timestamp.h"
 #include "amqp_decimal.h"
 
@@ -69,9 +70,8 @@
 #endif
 
 /* True global resources - no need for thread safety here */
-
 zend_class_entry *amqp_exception_class_entry, *amqp_connection_exception_class_entry,
-    *amqp_channel_exception_class_entry, *amqp_queue_exception_class_entry, *amqp_exchange_exception_class_entry,
+    *amqp_channel_exception_class_entry, *amqp_exchange_exception_class_entry, *amqp_queue_exception_class_entry,
     *amqp_value_exception_class_entry;
 
 /* {{{ amqp_functions[]
@@ -274,7 +274,7 @@ static PHP_MINIT_FUNCTION(amqp) /* {{{ */
         module_number
     );
 
-    /* Class Exceptions */
+    /* Exceptions */
     INIT_CLASS_ENTRY(ce, "AMQPException", NULL);
     amqp_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default());
 
@@ -300,6 +300,7 @@ static PHP_MINIT_FUNCTION(amqp) /* {{{ */
     PHP_MINIT(amqp_basic_properties)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(amqp_envelope)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(amqp_envelope_exception)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(amqp_value)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(amqp_timestamp)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(amqp_decimal)(INIT_FUNC_ARGS_PASSTHRU);
 

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -913,9 +913,7 @@ static PHP_METHOD(amqp_channel_class, startTransaction)
 
     amqp_rpc_reply_t res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
-        return;
-    }
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
     PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not start the transaction.");
@@ -943,9 +941,7 @@ static PHP_METHOD(amqp_channel_class, commitTransaction)
 
     amqp_rpc_reply_t res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
-        return;
-    }
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
     PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not start the transaction.");
@@ -972,10 +968,7 @@ static PHP_METHOD(amqp_channel_class, rollbackTransaction)
 
     amqp_rpc_reply_t res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
-        return;
-    }
-
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
     PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not rollback the transaction.");
@@ -1046,9 +1039,7 @@ PHP_METHOD(amqp_channel_class, confirmSelect)
     amqp_channel_resource *channel_resource;
     amqp_rpc_reply_t res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
-        return;
-    }
+    PHP_AMQP_NOPARAMS()
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
     PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not enable confirms mode.");
@@ -1060,6 +1051,7 @@ PHP_METHOD(amqp_channel_class, confirmSelect)
     if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
         php_amqp_zend_throw_exception_short(res, amqp_channel_exception_class_entry);
         php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
+
         return;
     }
 

--- a/amqp_decimal.c
+++ b/amqp_decimal.c
@@ -27,6 +27,7 @@
 #include "php.h"
 #include "zend_exceptions.h"
 #include "php_amqp.h"
+#include "amqp_value.h"
 
 zend_class_entry *amqp_decimal_class_entry;
 #define this_ce amqp_decimal_class_entry
@@ -93,13 +94,23 @@ static PHP_METHOD(amqp_decimal_class, getExponent)
 /* }}} */
 
 /* {{{ proto int AMQPDecimal::getSignificand()
-Get E */
+Get significand */
 static PHP_METHOD(amqp_decimal_class, getSignificand)
 {
     zval rv;
     PHP_AMQP_NOPARAMS()
 
     PHP_AMQP_RETURN_THIS_PROP("significand");
+}
+/* }}} */
+
+/* {{{ proto int AMQPDecimal::toAmqpValue()
+Get AMQPDecimal as AMQPValue */
+static PHP_METHOD(amqp_decimal_class, toAmqpValue)
+{
+    PHP_AMQP_NOPARAMS()
+
+    RETURN_OBJ(Z_OBJ_P(getThis()));
 }
 /* }}} */
 
@@ -115,11 +126,14 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_decimal_class_getSignificand, ZEND_SEND_BY_VAL, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_decimal_class_toAmqpValue, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+ZEND_END_ARG_INFO()
 
 zend_function_entry amqp_decimal_class_functions[] = {
 	PHP_ME(amqp_decimal_class, __construct, 	arginfo_amqp_decimal_class_construct,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_decimal_class, getExponent, 	arginfo_amqp_decimal_class_getExponent,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_decimal_class, getSignificand, 	arginfo_amqp_decimal_class_getSignificand,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_decimal_class, toAmqpValue, arginfo_amqp_decimal_class_toAmqpValue, ZEND_ACC_PUBLIC)
 
     {NULL, NULL, NULL}
 };
@@ -131,7 +145,11 @@ PHP_MINIT_FUNCTION(amqp_decimal)
 
     INIT_CLASS_ENTRY(ce, "AMQPDecimal", amqp_decimal_class_functions);
     this_ce = zend_register_internal_class(&ce);
-    this_ce->ce_flags = this_ce->ce_flags | ZEND_ACC_FINAL;
+    zend_class_implements(this_ce, 1, amqp_value_class_entry);
+    this_ce->ce_flags |= ZEND_ACC_FINAL;
+	#if PHP_VERSION_ID >= 80200
+	this_ce->ce_flags |= ZEND_ACC_READONLY_CLASS;
+	#endif
 
     zend_declare_class_constant_long(this_ce, ZEND_STRL("EXPONENT_MIN"), AMQP_DECIMAL_EXPONENT_MIN);
     zend_declare_class_constant_long(this_ce, ZEND_STRL("EXPONENT_MAX"), AMQP_DECIMAL_EXPONENT_MAX);

--- a/amqp_decimal.c
+++ b/amqp_decimal.c
@@ -110,7 +110,7 @@ static PHP_METHOD(amqp_decimal_class, toAmqpValue)
 {
     PHP_AMQP_NOPARAMS()
 
-    RETURN_OBJ(Z_OBJ_P(getThis()));
+    RETURN_ZVAL(getThis(), 1, 0);
 }
 /* }}} */
 
@@ -147,9 +147,9 @@ PHP_MINIT_FUNCTION(amqp_decimal)
     this_ce = zend_register_internal_class(&ce);
     zend_class_implements(this_ce, 1, amqp_value_class_entry);
     this_ce->ce_flags |= ZEND_ACC_FINAL;
-	#if PHP_VERSION_ID >= 80200
-	this_ce->ce_flags |= ZEND_ACC_READONLY_CLASS;
-	#endif
+#if PHP_VERSION_ID >= 80200
+    this_ce->ce_flags |= ZEND_ACC_READONLY_CLASS;
+#endif
 
     zend_declare_class_constant_long(this_ce, ZEND_STRL("EXPONENT_MIN"), AMQP_DECIMAL_EXPONENT_MIN);
     zend_declare_class_constant_long(this_ce, ZEND_STRL("EXPONENT_MAX"), AMQP_DECIMAL_EXPONENT_MAX);

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -293,6 +293,7 @@ static PHP_METHOD(amqp_queue_class, setArgument)
         case IS_LONG:
         case IS_DOUBLE:
         case IS_STRING:
+        case IS_ARRAY:
             zend_hash_str_add(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len, value);
             Z_TRY_ADDREF_P(value);
             break;
@@ -300,8 +301,8 @@ static PHP_METHOD(amqp_queue_class, setArgument)
         err:
             zend_throw_exception(
                 amqp_queue_exception_class_entry,
-                "The value parameter must be of type bool, int, double, string, null, AMQPTimestamp, AMQPDecimal, or "
-                "an implementation of AMQPValue.",
+                "The value parameter must be of type bool, int, double, string, null, array, AMQPTimestamp, "
+                "AMQPDecimal, or an implementation of AMQPValue.",
                 0
             );
             return;

--- a/amqp_timestamp.c
+++ b/amqp_timestamp.c
@@ -102,7 +102,7 @@ static PHP_METHOD(amqp_timestamp_class, toAmqpValue)
 {
     PHP_AMQP_NOPARAMS()
 
-    RETURN_OBJ(Z_OBJ_P(getThis()));
+    RETURN_ZVAL(getThis(), 1, 0);
 }
 /* }}} */
 
@@ -138,9 +138,9 @@ PHP_MINIT_FUNCTION(amqp_timestamp)
     this_ce = zend_register_internal_class(&ce);
     zend_class_implements(this_ce, 1, amqp_value_class_entry);
     this_ce->ce_flags |= ZEND_ACC_FINAL;
-	#if PHP_VERSION_ID >= 80200
-	this_ce->ce_flags |= ZEND_ACC_READONLY_CLASS;
-	#endif
+#if PHP_VERSION_ID >= 80200
+    this_ce->ce_flags |= ZEND_ACC_READONLY_CLASS;
+#endif
 
     PHP_AMQP_DECLARE_TYPED_PROPERTY(this_ce, "timestamp", ZEND_ACC_PRIVATE, IS_DOUBLE, 0);
 

--- a/amqp_timestamp.c
+++ b/amqp_timestamp.c
@@ -28,6 +28,7 @@
 #include "zend_exceptions.h"
 #include "php_amqp.h"
 #include "ext/standard/php_math.h"
+#include "amqp_value.h"
 
 zend_class_entry *amqp_timestamp_class_entry;
 #define this_ce amqp_timestamp_class_entry
@@ -95,6 +96,17 @@ static PHP_METHOD(amqp_timestamp_class, __toString)
 }
 /* }}} */
 
+/* {{{ proto string AMQPTimestamp::toAmqpValue()
+Return timestamp as AMQPValue */
+static PHP_METHOD(amqp_timestamp_class, toAmqpValue)
+{
+    PHP_AMQP_NOPARAMS()
+
+    RETURN_OBJ(Z_OBJ_P(getThis()));
+}
+/* }}} */
+
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_timestamp_class_construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
     ZEND_ARG_TYPE_INFO(0, timestamp, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
@@ -105,10 +117,14 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_timestamp_class_toString, ZEND_SEND_BY_VAL, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_timestamp_class_toAmqpValue, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+ZEND_END_ARG_INFO()
+
 zend_function_entry amqp_timestamp_class_functions[] = {
 	PHP_ME(amqp_timestamp_class, __construct, 	arginfo_amqp_timestamp_class_construct,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_timestamp_class, getTimestamp, 	arginfo_amqp_timestamp_class_getTimestamp,	ZEND_ACC_PUBLIC)
 	PHP_ME(amqp_timestamp_class, __toString, 	arginfo_amqp_timestamp_class_toString,	ZEND_ACC_PUBLIC)
+	PHP_ME(amqp_timestamp_class, toAmqpValue, 	arginfo_amqp_timestamp_class_toAmqpValue,	ZEND_ACC_PUBLIC)
 
     {NULL, NULL, NULL}
 };
@@ -120,7 +136,11 @@ PHP_MINIT_FUNCTION(amqp_timestamp)
 
     INIT_CLASS_ENTRY(ce, "AMQPTimestamp", amqp_timestamp_class_functions);
     this_ce = zend_register_internal_class(&ce);
-    this_ce->ce_flags = this_ce->ce_flags | ZEND_ACC_FINAL;
+    zend_class_implements(this_ce, 1, amqp_value_class_entry);
+    this_ce->ce_flags |= ZEND_ACC_FINAL;
+	#if PHP_VERSION_ID >= 80200
+	this_ce->ce_flags |= ZEND_ACC_READONLY_CLASS;
+	#endif
 
     PHP_AMQP_DECLARE_TYPED_PROPERTY(this_ce, "timestamp", ZEND_ACC_PRIVATE, IS_DOUBLE, 0);
 

--- a/amqp_type.c
+++ b/amqp_type.c
@@ -31,6 +31,7 @@
 #endif
 #include "Zend/zend_interfaces.h"
 #include "Zend/zend_exceptions.h"
+#include "amqp_value.h"
 #include "amqp_decimal.h"
 #include "amqp_timestamp.h"
 #include "amqp_type.h"
@@ -293,6 +294,19 @@ bool php_amqp_type_zval_to_amqp_value_internal(zval *value, amqp_field_value_t *
                 zval_ptr_dtor(&result_zv);
 
                 break;
+            } else if (instanceof_function(Z_OBJCE_P(value), amqp_value_class_entry)) {
+                zval result_zv;
+                zend_call_method_with_0_params(
+                    PHP_AMQP_COMPAT_OBJ_P(value),
+                    Z_OBJCE_P(value),
+                    NULL,
+                    "toamqpvalue",
+                    &result_zv
+                );
+                bool recursion_res = php_amqp_type_zval_to_amqp_value_internal(&result_zv, field_ptr, key, depth + 1);
+                zval_ptr_dtor(&result_zv);
+
+                return recursion_res;
             }
         default:
             switch (Z_TYPE_P(value)) {

--- a/amqp_value.c
+++ b/amqp_value.c
@@ -25,9 +25,6 @@
 #endif
 
 #include "php.h"
-#include "zend_exceptions.h"
-#include "php_amqp.h"
-#include "ext/standard/php_math.h"
 
 zend_class_entry *amqp_value_class_entry;
 #define this_ce amqp_value_class_entry

--- a/amqp_value.c
+++ b/amqp_value.c
@@ -1,0 +1,52 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 5                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2007 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Alexandre Kalendarev akalend@mail.ru Copyright (c) 2009-2010 |
+  | Lead:                                                                |
+  | - Pieter de Zwart                                                    |
+  | Maintainers:                                                         |
+  | - Brad Rodriguez                                                     |
+  | - Jonathan Tansavatdi                                                |
+  +----------------------------------------------------------------------+
+*/
+#ifdef HAVE_CONFIG_H
+    #include "config.h"
+#endif
+
+#include "php.h"
+#include "zend_exceptions.h"
+#include "php_amqp.h"
+#include "ext/standard/php_math.h"
+
+zend_class_entry *amqp_value_class_entry;
+#define this_ce amqp_value_class_entry
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_value_class_toAmqpValue, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+ZEND_END_ARG_INFO()
+
+zend_function_entry amqp_value_class_functions[] = {
+    PHP_ABSTRACT_ME(amqp_value_class, toAmqpValue, arginfo_amqp_value_class_toAmqpValue)
+
+        {NULL, NULL, NULL}
+};
+
+PHP_MINIT_FUNCTION(amqp_value)
+{
+    zend_class_entry ce;
+
+    INIT_CLASS_ENTRY(ce, "AMQPValue", amqp_value_class_functions);
+    amqp_value_class_entry = zend_register_internal_interface(&ce);
+
+    return SUCCESS;
+}

--- a/amqp_value.h
+++ b/amqp_value.h
@@ -1,0 +1,27 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 5                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2007 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Alexandre Kalendarev akalend@mail.ru Copyright (c) 2009-2010 |
+  | Lead:                                                                |
+  | - Pieter de Zwart                                                    |
+  | Maintainers:                                                         |
+  | - Brad Rodriguez                                                     |
+  | - Jonathan Tansavatdi                                                |
+  +----------------------------------------------------------------------+
+*/
+#include "php.h"
+
+extern zend_class_entry *amqp_value_class_entry;
+
+PHP_MINIT_FUNCTION(amqp_value);

--- a/config.m4
+++ b/config.m4
@@ -162,7 +162,7 @@ if test "$PHP_AMQP" != "no"; then
 
 	PHP_SUBST(AMQP_SHARED_LIBADD)
 
-	AMQP_SOURCES="amqp.c amqp_envelope_exception.c amqp_type.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_connection_resource.c amqp_channel.c amqp_envelope.c amqp_basic_properties.c amqp_methods_handling.c amqp_timestamp.c amqp_decimal.c"
+	AMQP_SOURCES="amqp.c amqp_envelope_exception.c amqp_type.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_connection_resource.c amqp_channel.c amqp_envelope.c amqp_basic_properties.c amqp_methods_handling.c amqp_value.c amqp_timestamp.c amqp_decimal.c"
 
 	PHP_NEW_EXTENSION(amqp, $AMQP_SOURCES, $ext_shared)
 fi

--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@ if (PHP_AMQP != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("amqp.h", "CFLAGS_AMQP", PHP_PHP_BUILD + "\\include;" + PHP_PHP_BUILD + "\\include\\librabbitmq;" + PHP_AMQP) &&
 		CHECK_LIB("rabbitmq.4.lib", "amqp", PHP_PHP_BUILD + "\\lib;" + PHP_AMQP)) {
 //		ADD_FLAG("CFLAGS_AMQP", "/D HAVE_AMQP_GETSOCKOPT");
-		EXTENSION('amqp', 'amqp.c amqp_envelope_exception.c amqp_type.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_connection_resource.c amqp_channel.c amqp_envelope.c amqp_basic_properties.c amqp_methods_handling.c amqp_timestamp.c amqp_decimal.c');
+		EXTENSION('amqp', 'amqp.c amqp_envelope_exception.c amqp_type.c amqp_exchange.c amqp_queue.c amqp_connection.c amqp_connection_resource.c amqp_channel.c amqp_envelope.c amqp_basic_properties.c amqp_methods_handling.c amqp_value.c amqp_timestamp.c amqp_decimal.c');
 		AC_DEFINE('HAVE_AMQP', 1);
 	} else {
 		WARNING("amqp not enabled; libraries and headers not found");

--- a/infra/tools/pamqp-arguments-validate
+++ b/infra/tools/pamqp-arguments-validate
@@ -15,6 +15,7 @@ const CLASSES = [
     'AMQPQueue',
     'AMQPQueueException',
     'AMQPTimestamp',
+    'AMQPValue',
     'AMQPValueException',
 ];
 
@@ -35,6 +36,10 @@ function getSource(string $class): ?string
 function validate(string $class)
 {
     $refl = new ReflectionClass($class);
+
+    if ($refl->isInterface()) {
+        return;
+    }
 
     $source = getSource($class);
 
@@ -107,7 +112,7 @@ function validate(string $class)
                 );
             }
 
-            $reflectionNullable = $parameter->allowsNull();
+            $reflectionNullable = $parameter->allowsNull() || !$parameter->hasType();
             if ($reflectionNullable !== $types[$pos]['nullable']) {
                 error(
                     '%s::%s(%s): type parsing and Reflection nullability differs. Parameter parsing: %s (%s). Reflection: %s',
@@ -133,6 +138,10 @@ function error(string $message, ...$args): void
 
 function parseParameterString(string $str): array
 {
+    if ($str == '') {
+        return [[], 0];
+    }
+
     $types = [
         's' => 'string',
         'O' => 'object',
@@ -163,7 +172,7 @@ function parseParameterString(string $str): array
         } elseif ($char === '/') {
             // Ignored
         } else {
-            throw new InvalidArgumentException($char);
+            throw new InvalidArgumentException(sprintf('Cannot handle char <%s>', $char));
         }
     }
 

--- a/infra/tools/pamqp-dump-reflection
+++ b/infra/tools/pamqp-dump-reflection
@@ -15,16 +15,28 @@ function sortByName(array $array): array
     return $array;
 }
 
-function getTypeMetadata(?ReflectionNamedType $type): ?array
+function getTypeMetadata(?ReflectionType $type): ?array
 {
     if ($type == null) {
         return null;
     }
 
-    return [
-        'name' => $type->getName(),
-        'nullable' => $type->allowsNull(),
-    ];
+    if ($type instanceof ReflectionNamedType) {
+        return [
+            'name' => $type->getName(),
+            'nullable' => $type->allowsNull(),
+            'builtin' => $type->isBuiltin(),
+        ];
+    }
+
+    if ($type instanceof ReflectionUnionType || $type instanceof ReflectionIntersectionType) {
+        return [
+            'type' => $type instanceof ReflectionUnionType ? 'union' : 'intersection',
+            'types' => array_map('getTypeMetadata', $type->getTypes()),
+        ];
+    }
+
+    assert(false, 'Unreachable');
 }
 
 $error = false;

--- a/infra/tools/pamqp-dump-reflection
+++ b/infra/tools/pamqp-dump-reflection
@@ -37,6 +37,15 @@ function error(string $message, ...$args): void
 
 const MAGIC_METHODS = ['__construct', '__toString', '__wakeup', '__clone'];
 
+function getParents(ReflectionClass $r): array {
+    $parents = [];
+    while ($r = $r->getParentClass()) {
+        $parents[] = $r->getName();
+    }
+
+    return $parents;
+}
+
 function getClassMetadata(string $class): array
 {
     $refl = new ReflectionClass($class);
@@ -45,7 +54,16 @@ function getClassMetadata(string $class): array
         'constants' => [],
         'properties' => [],
         'methods' => [],
+        'final' => $refl->isFinal(),
+        'abstract' => $refl->isAbstract(),
+        'interface' => $refl->isInterface(),
+        'implements' => $refl->getInterfaceNames(),
+        'readonly' => method_exists($refl, 'isReadonly') ? $refl->isReadonly() || strpos($refl->getDocComment(), '@readonly') !== false : null,
+        'extends' => getParents($refl),
     ];
+
+    sort($classMetadata['implements']);
+    sort($classMetadata['extends']);
 
     foreach ($refl->getReflectionConstants() as $constant) {
         if ($constant->getDeclaringClass()->getName() !== $refl->getName()) {
@@ -246,6 +264,7 @@ $symbols['classes'][] = getClassMetadata('AMQPConnection');
 $symbols['classes'][] = getClassMetadata('AMQPChannelException');
 $symbols['classes'][] = getClassMetadata('AMQPChannel');
 $symbols['classes'][] = getClassMetadata('AMQPBasicProperties');
+$symbols['classes'][] = getClassMetadata('AMQPValue');
 
 // Ensure we captured all AMQP classes
 foreach (get_declared_classes() as $className) {

--- a/infra/tools/pamqp-dump-reflection
+++ b/infra/tools/pamqp-dump-reflection
@@ -277,7 +277,7 @@ sort($symbols['classNames']);
 $filename = $_SERVER['argv'][1] ?? null;
 assert($filename !== null, 'Output filename must be passed');
 
-file_put_contents($filename, json_encode($symbols, JSON_PRETTY_PRINT));
+file_put_contents($filename, json_encode($symbols, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
 
 if ($error) {
     exit(1);

--- a/infra/tools/pamqp-matrix
+++ b/infra/tools/pamqp-matrix
@@ -1,32 +1,18 @@
-#!/usr/bin/env bash
-PHP_VERSIONS=("8.3" "8.2" "8.1" "8.0" "7.4")
-LIBRABBITMQ_VERSIONS=("master" "0.13.0" "0.12.0" "0.11.0" "0.10.0" "0.9.0" "0.8.0")
+#!/usr/bin/env node
+const PHP_VERSIONS = ["8.3", "8.2", "8.1", "8.0", "7.4"]
+const LIBRABBITMQ_VERSIONS = ["master", "0.13.0", "0.12.0", "0.11.0", "0.10.0", "0.9.0", "0.8.0"]
 
-stringListToJson() {
-  echo -n "["
-  local pos=0
-  for str in $@; do
-    echo -n \"$str\"
-    pos=$((pos + 1))
-    [ $pos -lt $# ] && echo -n ", "
-  done
-  echo "]"
-}
+const toOutput = (k, v) => console.log(`${k}=${JSON.stringify(v)}`)
+const stringSum = (s) => ([...s].map(c => c.charCodeAt(0)).reduce((c, v) => c + v, 0))
 
-memoryMatrix() {
-  pos=0
-  max=$((${#PHP_VERSIONS[@]} * 2))
-  echo -n "["
-  for php_version in ${PHP_VERSIONS[@]}; do
-    for librabbitmq_high_low in ${LIBRABBITMQ_VERSIONS[0]} ${LIBRABBITMQ_VERSIONS[${#LIBRABBITMQ_VERSIONS[@]} - 1]}; do
-      pos=$((pos + 1))
-      printf '{"php-version": "%s", "librabbitmq-version": "%s", "test-php-args": "-m", "compiler": "gcc"}' $php_version, $librabbitmq_high_low
-      [ $pos -lt $max ] && echo -n ", "
-    done
-  done
-  echo "]"
-}
+const memoryBuilds = PHP_VERSIONS.flatMap(php => [LIBRABBITMQ_VERSIONS[0], LIBRABBITMQ_VERSIONS.slice(-1)[0]].map(librabbitmq => ({
+    "php-version": php,
+    "php-thread-safe": (stringSum(php) + stringSum(librabbitmq)) % 2 === 0,
+    "librabbitmq-version": librabbitmq,
+    "test-php-args": "-m",
+    "compiler": "gcc"
+})))
 
-echo "php_versions=$(stringListToJson "${PHP_VERSIONS[@]}")"
-echo "librabbitmq_versions=$(stringListToJson "${LIBRABBITMQ_VERSIONS[@]}")"
-echo "memory_test_matrix=$(memoryMatrix)"
+toOutput('php_versions', PHP_VERSIONS)
+toOutput('php_versions', LIBRABBITMQ_VERSIONS)
+toOutput('memory_builds', memoryBuilds)

--- a/infra/tools/pamqp-matrix
+++ b/infra/tools/pamqp-matrix
@@ -27,6 +27,6 @@ memoryMatrix() {
   echo "]"
 }
 
-echo "php_versions='$(stringListToJson "${PHP_VERSIONS[@]}")'"
-echo "librabbitmq_versions='$(stringListToJson "${LIBRABBITMQ_VERSIONS[@]}")'"
-echo "memory_test_matrix='$(memoryMatrix)'"
+echo "php_versions=$(stringListToJson "${PHP_VERSIONS[@]}")"
+echo "librabbitmq_versions=$(stringListToJson "${LIBRABBITMQ_VERSIONS[@]}")"
+echo "memory_test_matrix=$(memoryMatrix)"

--- a/infra/tools/pamqp-matrix
+++ b/infra/tools/pamqp-matrix
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 PHP_VERSIONS=("8.3" "8.2" "8.1" "8.0" "7.4")
 LIBRABBITMQ_VERSIONS=("master" "0.13.0" "0.12.0" "0.11.0" "0.10.0" "0.9.0" "0.8.0")
 

--- a/infra/tools/pamqp-matrix
+++ b/infra/tools/pamqp-matrix
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+PHP_VERSIONS=("8.3" "8.2" "8.1" "8.0" "7.4")
+LIBRABBITMQ_VERSIONS=("master" "0.13.0" "0.12.0" "0.11.0" "0.10.0" "0.9.0" "0.8.0")
+
+stringListToJson() {
+  echo -n "["
+  local pos=0
+  for str in $@; do
+    echo -n \"$str\"
+    pos=$((pos + 1))
+    [ $pos -lt $# ] && echo -n ", "
+  done
+  echo "]"
+}
+
+memoryMatrix() {
+  pos=0
+  max=$((${#PHP_VERSIONS[@]} * 2))
+  echo -n "["
+  for php_version in ${PHP_VERSIONS[@]}; do
+    for librabbitmq_high_low in ${LIBRABBITMQ_VERSIONS[0]} ${LIBRABBITMQ_VERSIONS[${#LIBRABBITMQ_VERSIONS[@]} - 1]}; do
+      pos=$((pos + 1))
+      printf '{"php-version": "%s", "librabbitmq-version": "%s", "test-php-args": "-m", "compiler": "gcc"}' $php_version, $librabbitmq_high_low
+      [ $pos -lt $max ] && echo -n ", "
+    done
+  done
+  echo "]"
+}
+
+echo "php_versions='$(stringListToJson "${PHP_VERSIONS[@]}")'"
+echo "librabbitmq_versions='$(stringListToJson "${LIBRABBITMQ_VERSIONS[@]}")'"
+echo "memory_test_matrix='$(memoryMatrix)'"

--- a/infra/tools/pamqp-matrix
+++ b/infra/tools/pamqp-matrix
@@ -15,4 +15,4 @@ const memoryBuilds = PHP_VERSIONS.flatMap(php => [LIBRABBITMQ_VERSIONS[0], LIBRA
 
 toOutput('php_versions', PHP_VERSIONS)
 toOutput('librabbitmq_versions', LIBRABBITMQ_VERSIONS)
-toOutput('memory_builds', memoryBuilds)
+toOutput('memory_build_matrix', memoryBuilds)

--- a/infra/tools/pamqp-matrix
+++ b/infra/tools/pamqp-matrix
@@ -14,5 +14,5 @@ const memoryBuilds = PHP_VERSIONS.flatMap(php => [LIBRABBITMQ_VERSIONS[0], LIBRA
 })))
 
 toOutput('php_versions', PHP_VERSIONS)
-toOutput('php_versions', LIBRABBITMQ_VERSIONS)
+toOutput('librabbitmq_versions', LIBRABBITMQ_VERSIONS)
 toOutput('memory_builds', memoryBuilds)

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -34,7 +34,6 @@ extern zend_class_entry *amqp_exception_class_entry, *amqp_connection_exception_
     *amqp_channel_exception_class_entry, *amqp_exchange_exception_class_entry, *amqp_queue_exception_class_entry,
     *amqp_value_exception_class_entry;
 
-
 typedef struct _amqp_connection_resource amqp_connection_resource;
 typedef struct _amqp_connection_object amqp_connection_object;
 typedef struct _amqp_channel_object amqp_channel_object;

--- a/stubs/AMQPDecimal.php
+++ b/stubs/AMQPDecimal.php
@@ -2,8 +2,10 @@
 
 /**
  * stub class representing AMQPDecimal from pecl-amqp
+ *
+ * @readonly
  */
-final class AMQPDecimal
+final /* readonly */ class AMQPDecimal implements AMQPValue
 {
     /**
      * @var int
@@ -41,6 +43,10 @@ final class AMQPDecimal
     }
 
     public function getSignificand(): int
+    {
+    }
+
+    public function toAmqpValue()
     {
     }
 }

--- a/stubs/AMQPQueue.php
+++ b/stubs/AMQPQueue.php
@@ -200,26 +200,6 @@ class AMQPQueue
     }
 
     /**
-     * Get the argument associated with the given key.
-     *
-     * @param string $argumentName The key to look up.
-     * @throws AMQPQueueException If key does not exist
-     * @return bool|int|double|string|null
-     */
-    public function getArgument(string $argumentName)
-    {
-    }
-
-    /**
-     * Get all set arguments as an array of key/value pairs.
-     *
-     * @return array An array containing all the set key/value pairs.
-     */
-    public function getArguments(): array
-    {
-    }
-
-    /**
      * Get all the flags currently set on the given queue.
      *
      * @return int An integer bitmask of all the flags currently set on this
@@ -293,10 +273,21 @@ class AMQPQueue
     }
 
     /**
+     * Get the argument associated with the given key.
+     *
+     * @param string $argumentName The key to look up.
+     * @throws AMQPQueueException If key does not exist
+     * @return bool|int|double|string|null|array|AMQPValue|AMQPDecimal|AMQPTimestamp
+     */
+    public function getArgument(string $argumentName)
+    {
+    }
+
+    /**
      * Set a queue argument.
      *
      * @param string $argumentName The argument name to set.
-     * @param bool|int|double|string|null|AMQPValue|AMQPDecimal|AMQPTimestamp $argumentValue The argument value to set.
+     * @param bool|int|double|string|null|array|AMQPValue|AMQPDecimal|AMQPTimestamp $argumentValue The argument value to set.
      */
     public function setArgument(string $argumentName, $argumentValue): void
     {
@@ -319,6 +310,15 @@ class AMQPQueue
      * @param array $arguments An array of name/value pairs of arguments.
      */
     public function setArguments(array $arguments): void
+    {
+    }
+
+    /**
+     * Get all set arguments as an array of key/value pairs.
+     *
+     * @return array An array containing all the set key/value pairs.
+     */
+    public function getArguments(): array
     {
     }
 

--- a/stubs/AMQPQueue.php
+++ b/stubs/AMQPQueue.php
@@ -296,7 +296,7 @@ class AMQPQueue
      * Set a queue argument.
      *
      * @param string $argumentName The argument name to set.
-     * @param bool|int|double|string|null $argumentValue The argument value to set.
+     * @param bool|int|double|string|null|AMQPValue|AMQPDecimal|AMQPTimestamp $argumentValue The argument value to set.
      */
     public function setArgument(string $argumentName, $argumentValue): void
     {

--- a/stubs/AMQPTimestamp.php
+++ b/stubs/AMQPTimestamp.php
@@ -2,8 +2,10 @@
 
 /**
  * stub class representing AMQPTimestamp from pecl-amqp
+ *
+ * @readonly
  */
-final class AMQPTimestamp
+final /* readonly */ class AMQPTimestamp implements AMQPValue
 {
     /**
      * @var float
@@ -29,6 +31,10 @@ final class AMQPTimestamp
     }
 
     public function getTimestamp(): float
+    {
+    }
+
+    public function toAmqpValue()
     {
     }
 }

--- a/stubs/AMQPValue.php
+++ b/stubs/AMQPValue.php
@@ -5,7 +5,7 @@
 interface AMQPValue
 {
     /**
-     * @return bool|int|double|string|null|AMQPValue|AMQPDecimal|AMQPTimestamp
+     * @return bool|int|double|string|null|array|AMQPValue|AMQPDecimal|AMQPTimestamp
      */
     public function toAmqpValue();
 }

--- a/stubs/AMQPValue.php
+++ b/stubs/AMQPValue.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Interface representing AMQP values
+ */
+interface AMQPValue
+{
+    /**
+     * @return bool|int|double|string|null|AMQPValue|AMQPDecimal|AMQPTimestamp
+     */
+    public function toAmqpValue();
+}

--- a/tests/amqpdecimal.phpt
+++ b/tests/amqpdecimal.phpt
@@ -9,7 +9,8 @@ if (!extension_loaded("amqp")) print "skip";
 
 $decimal = new AMQPDecimal(1, 2);
 var_dump($decimal->getExponent(), $decimal->getSignificand());
-
+var_dump($decimal === $decimal->toAmqpValue());
+var_dump($decimal instanceof AMQPValue);
 
 try {
     new AMQPDecimal(-1, 1);
@@ -49,6 +50,8 @@ var_dump(AMQPDecimal::SIGNIFICAND_MAX);
 --EXPECT--
 int(1)
 int(2)
+bool(true)
+bool(true)
 Decimal exponent value must be unsigned.
 Decimal significand value must be unsigned.
 Decimal exponent value must be less than 255.

--- a/tests/amqpqueue_setArgument.phpt
+++ b/tests/amqpqueue_setArgument.phpt
@@ -36,6 +36,8 @@ $q_dead->setArgument('x-dead-letter-exchange', '');
 $q_dead->setArgument('x-dead-letter-routing-key', $q_name);
 $q_dead->setArgument('x-message-ttl', $heartbeat * 10 * 1000);
 $q_dead->setArgument('x-null', null);
+$q_dead->setArgument('x-array', [0, 3]);
+$q_dead->setArgument('x-hash', ['foo' => 'bar']);
 $q_dead->setArgument('x-timestamp', new AMQPTimestamp(404));
 $q_dead->setArgument('x-decimal', new AMQPDecimal(1, 2));
 $q_dead->setArgument('x-custom-value', new MyValue());

--- a/tests/amqpqueue_setArgument.phpt
+++ b/tests/amqpqueue_setArgument.phpt
@@ -26,6 +26,9 @@ $q->declareQueue();
 
 var_dump($q);
 
+class MyValue implements AMQPValue {
+    public function toAmqpValue() { return "foo"; }
+}
 
 $q_dead = new AMQPQueue($ch);
 $q_dead->setName($q_dead_name);
@@ -33,6 +36,9 @@ $q_dead->setArgument('x-dead-letter-exchange', '');
 $q_dead->setArgument('x-dead-letter-routing-key', $q_name);
 $q_dead->setArgument('x-message-ttl', $heartbeat * 10 * 1000);
 $q_dead->setArgument('x-null', null);
+$q_dead->setArgument('x-timestamp', new AMQPTimestamp(404));
+$q_dead->setArgument('x-decimal', new AMQPDecimal(1, 2));
+$q_dead->setArgument('x-custom-value', new MyValue());
 $q_dead->setFlags(AMQP_AUTODELETE);
 $q_dead->declareQueue();
 
@@ -42,7 +48,7 @@ $q_dead->removeArgument('x-does-not-exist');
 var_dump($q_dead);
 ?>
 --EXPECTF--
-object(AMQPQueue)#3 (9) {
+object(AMQPQueue)#%d (%d) {
   ["connection":"AMQPQueue":private]=>
   %a
   ["channel":"AMQPQueue":private]=>
@@ -63,7 +69,7 @@ object(AMQPQueue)#3 (9) {
   array(0) {
   }
 }
-object(AMQPQueue)#4 (9) {
+object(AMQPQueue)#%d (%d) {
   ["connection":"AMQPQueue":private]=>
   %a
   ["channel":"AMQPQueue":private]=>
@@ -81,7 +87,7 @@ object(AMQPQueue)#4 (9) {
   ["autoDelete":"AMQPQueue":private]=>
   bool(true)
   ["arguments":"AMQPQueue":private]=>
-  array(4) {
+  array(%d) {
     ["x-dead-letter-exchange"]=>
     string(0) ""
     ["x-dead-letter-routing-key"]=>
@@ -90,9 +96,24 @@ object(AMQPQueue)#4 (9) {
     int(100000)
     ["x-null"]=>
     NULL
+    ["x-timestamp"]=>
+    object(AMQPTimestamp)#%d (%d) {
+      ["timestamp":"AMQPTimestamp":private]=>
+      float(404)
+    }
+    ["x-decimal"]=>
+    object(AMQPDecimal)#%d (%d) {
+      ["exponent":"AMQPDecimal":private]=>
+      int(1)
+      ["significand":"AMQPDecimal":private]=>
+      int(2)
+    }
+    ["x-custom-value"]=>
+    object(MyValue)#%d (%d) {
+    }
   }
 }
-object(AMQPQueue)#4 (9) {
+object(AMQPQueue)#%d (%d) {
   ["connection":"AMQPQueue":private]=>
   %a
   ["channel":"AMQPQueue":private]=>
@@ -110,12 +131,27 @@ object(AMQPQueue)#4 (9) {
   ["autoDelete":"AMQPQueue":private]=>
   bool(true)
   ["arguments":"AMQPQueue":private]=>
-  array(3) {
+  array(%d) {
     ["x-dead-letter-exchange"]=>
     string(0) ""
     ["x-dead-letter-routing-key"]=>
     string(%d) "test.queue.%s"
     ["x-message-ttl"]=>
     int(100000)
+    ["x-timestamp"]=>
+    object(AMQPTimestamp)#%d (%d) {
+      ["timestamp":"AMQPTimestamp":private]=>
+      float(404)
+    }
+    ["x-decimal"]=>
+    object(AMQPDecimal)#%d (%d) {
+      ["exponent":"AMQPDecimal":private]=>
+      int(1)
+      ["significand":"AMQPDecimal":private]=>
+      int(2)
+    }
+    ["x-custom-value"]=>
+    object(MyValue)#%d (%d) {
+    }
   }
 }

--- a/tests/amqpqueue_setArgument.phpt
+++ b/tests/amqpqueue_setArgument.phpt
@@ -98,6 +98,18 @@ object(AMQPQueue)#%d (%d) {
     int(100000)
     ["x-null"]=>
     NULL
+    ["x-array"]=>
+    array(2) {
+      [0]=>
+      int(0)
+      [1]=>
+      int(3)
+    }
+    ["x-hash"]=>
+    array(1) {
+      ["foo"]=>
+      string(3) "bar"
+    }
     ["x-timestamp"]=>
     object(AMQPTimestamp)#%d (%d) {
       ["timestamp":"AMQPTimestamp":private]=>
@@ -140,6 +152,18 @@ object(AMQPQueue)#%d (%d) {
     string(%d) "test.queue.%s"
     ["x-message-ttl"]=>
     int(100000)
+    ["x-array"]=>
+    array(2) {
+      [0]=>
+      int(0)
+      [1]=>
+      int(3)
+    }
+    ["x-hash"]=>
+    array(1) {
+      ["foo"]=>
+      string(3) "bar"
+    }
     ["x-timestamp"]=>
     object(AMQPTimestamp)#%d (%d) {
       ["timestamp":"AMQPTimestamp":private]=>

--- a/tests/amqptimestamp.phpt
+++ b/tests/amqptimestamp.phpt
@@ -9,6 +9,8 @@ if (!extension_loaded("amqp")) print "skip";
 
 $timestamp = new AMQPTimestamp(100000);
 var_dump($timestamp->getTimestamp(), (string) $timestamp);
+var_dump($timestamp === $timestamp->toAmqpValue());
+var_dump($timestamp instanceof AMQPValue);
 
 $timestamp = new AMQPTimestamp(100000.1);
 var_dump($timestamp->getTimestamp(), (string) $timestamp);
@@ -35,6 +37,8 @@ var_dump(AMQPTimestamp::MIN);
 --EXPECTF--
 float(100000)
 string(6) "100000"
+bool(true)
+bool(true)
 float(100000)
 string(6) "100000"
 The timestamp parameter must be greater than 0.

--- a/tests/serialize-custom-amqpvalue-errors.phpt
+++ b/tests/serialize-custom-amqpvalue-errors.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Serialize custom AMQP value - errors
+--SKIPIF--
+<?php
+if (!extension_loaded("amqp")) print "skip";
+if (!getenv("PHP_AMQP_HOST")) print "skip";
+?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->setHost(getenv('PHP_AMQP_HOST'));
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+$ex = new AMQPExchange($ch);
+$ex->setName('ex-' . bin2hex(random_bytes(32)));
+$ex->setType(AMQP_EX_TYPE_FANOUT);
+$ex->declare();
+
+class RecursiveValue implements AMQPValue {
+    public function toAmqpValue()
+    {
+        return $this;
+    }
+}
+
+class NestedValue implements AMQPValue {
+    private $v;
+
+    public function __construct($v)
+    {
+        $this->v = $v;
+    }
+
+    public function toAmqpValue()
+    {
+        return $this->v;
+    }
+}
+
+try {
+    $ex->publish('msg', null, null, ['headers' => ['x-val' => new RecursiveValue()]]);
+} catch (AMQPException $e) {
+    var_dump($e->getMessage());
+}
+$ex->publish('msg', null, null, ['headers' => ['x-val' => new NestedValue(new stdClass())]]);
+
+$ex->publish('msg', null, null, ['headers' => ['x-val' => new NestedValue(new NestedValue(new stdClass()))]]);
+
+?>
+==DONE==
+--EXPECTF--
+string(%d) "Maximum serialization depth of 128 reached while serializing value"
+
+Warning: AMQPExchange::publish(): Ignoring field 'x-val' due to unsupported value type (object) in %s on line %d
+
+Warning: AMQPExchange::publish(): Ignoring field 'x-val' due to unsupported value type (object) in %s on line %d
+==DONE==

--- a/tests/serialize-custom-amqpvalue.phpt
+++ b/tests/serialize-custom-amqpvalue.phpt
@@ -32,7 +32,7 @@ class MyAmqpValue implements AMQPValue {
 
 class MyNestedAmqpValue implements AMQPValue {
     private $val;
-    public function __construct(AMQPValue $val) {
+    public function __construct($val) {
         $this->val = $val;
     }
 
@@ -44,6 +44,8 @@ class MyNestedAmqpValue implements AMQPValue {
 $ex->publish('msg', null, null, ['headers' => [
     'x-val' => new MyAmqpValue(),
     'x-nested' => new MyNestedAmqpValue(new MyAmqpValue()),
+    'x-array' => [new MyNestedAmqpValue(new MyAmqpValue())],
+    'x-array-nested' => new MyNestedAmqpValue([new MyNestedAmqpValue(1), 2]),
     'x-nested-decimal' => new MyNestedAmqpValue(new AMQPDecimal(1, 2345)),
     'x-nested-timestamp' => new MyNestedAmqpValue(new AMQPTimestamp(987))
 ]]);
@@ -52,6 +54,8 @@ $msg = $q->get(AMQP_AUTOACK);
 
 var_dump($msg->getHeader('x-val'));
 var_dump($msg->getHeader('x-nested'));
+var_dump($msg->getHeader('x-array'));
+var_dump($msg->getHeader('x-array-nested'));
 var_dump($msg->getHeader('x-nested-decimal')->getExponent());
 var_dump($msg->getHeader('x-nested-decimal')->getSignificand());
 var_dump($msg->getHeader('x-nested-timestamp')->getTimestamp());
@@ -60,6 +64,16 @@ var_dump($msg->getHeader('x-nested-timestamp')->getTimestamp());
 --EXPECT--
 string(3) "foo"
 string(3) "foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}
 int(1)
 int(2345)
 float(987)

--- a/tests/serialize-custom-amqpvalue.phpt
+++ b/tests/serialize-custom-amqpvalue.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Serialize custom AMQP value
+--SKIPIF--
+<?php
+if (!extension_loaded("amqp")) print "skip";
+if (!getenv("PHP_AMQP_HOST")) print "skip";
+?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->setHost(getenv('PHP_AMQP_HOST'));
+$cnn->connect();
+
+$ch = new AMQPChannel($cnn);
+
+$ex = new AMQPExchange($ch);
+$ex->setName('ex-' . bin2hex(random_bytes(32)));
+$ex->setType(AMQP_EX_TYPE_FANOUT);
+$ex->declare();
+
+$q = new AMQPQueue($ch);
+$q->setName('q-' . bin2hex(random_bytes(32)));
+$q->declare();
+$q->bind($ex->getName());
+
+class MyAmqpValue implements AMQPValue {
+    public function toAmqpValue()
+    {
+        return 'foo';
+    }
+}
+
+class MyNestedAmqpValue implements AMQPValue {
+    private $val;
+    public function __construct(AMQPValue $val) {
+        $this->val = $val;
+    }
+
+    public function toAmqpValue() {
+        return $this->val;
+    }
+}
+
+$ex->publish('msg', null, null, ['headers' => [
+    'x-val' => new MyAmqpValue(),
+    'x-nested' => new MyNestedAmqpValue(new MyAmqpValue()),
+    'x-nested-decimal' => new MyNestedAmqpValue(new AMQPDecimal(1, 2345)),
+    'x-nested-timestamp' => new MyNestedAmqpValue(new AMQPTimestamp(987))
+]]);
+
+$msg = $q->get(AMQP_AUTOACK);
+
+var_dump($msg->getHeader('x-val'));
+var_dump($msg->getHeader('x-nested'));
+var_dump($msg->getHeader('x-nested-decimal')->getExponent());
+var_dump($msg->getHeader('x-nested-decimal')->getSignificand());
+var_dump($msg->getHeader('x-nested-timestamp')->getTimestamp());
+?>
+==DONE==
+--EXPECT--
+string(3) "foo"
+string(3) "foo"
+int(1)
+int(2345)
+float(987)
+==DONE==


### PR DESCRIPTION
Allow implementing serializable value objects by implementing `AMQPValue`. Fix `AMQPQueue::setArgument()` to take `AMQPValue`, `AMQPDecimal`, `AMQPTimestamp` or arrays as well.