### PR TITLE
Use RETURN_THROWS for parameter parsing errors

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,6 @@ PHP_AMQP_HOST=rabbitmq
 PHP_AMQP_SSL_HOST=rabbitmq.example.org
 MAKEFLAGS="-j16"
 CFLAGS="-g -O0 -fstack-protector-strong -Wall -Werror -D_GNU_SOURCE"
-TEST_PHP_ARGS="-j16"
+TEST_PHP_ARGS="-j16 -q"
 CC=clang
 VALGRIND_OPTS="--suppressions=infra/tools/valgrind-suppressions"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -170,7 +170,7 @@ jobs:
         run: make test | tee result-minimal.txt
         env:
           # Reset defaults to a) only run local tests, b) don’t run memory checks as the full test suite run will do so
-          TEST_PHP_ARGS: -j4
+          TEST_PHP_ARGS: '-j4 -q'
           PHP_AMQP_HOST: ''
           PHP_AMQP_SSL_HOST: ''
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,13 +78,27 @@ symlink available to make that as simple as possible:
 cat tests/amqp_some_test.out
 ```
 
+### Run all checks locally
+
+Before pushing a change, run tests, lint and validate stubs, validates argument parsing, and checks formatting of both C
+and PHP code:
+
+```commandline
+pamqp-check
+```
+
 ### Formatting
 
 Discussing coding style is as much as it is futile, so PHP AMQP using clang-format to automatically format the source
-code. Run this command to format:
+code. Run this command to format C code:
 
 ```commandline
 pamqp-format
+```
+
+Run this to format the stubs:
+```commandline
+pamqp-stubs-format
 ```
 
 ### Validating stubs

--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -155,7 +155,7 @@ static PHP_METHOD(AMQPBasicProperties, __construct)
             /* s */ &cluster_id,
             &cluster_id_len
         ) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
     zend_update_property_stringl(
         this_ce,

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -330,7 +330,7 @@ static PHP_METHOD(amqp_channel_class, __construct)
             "Could not create channel. No connection resource.",
             0
         );
-        return;
+        RETURN_THROWS();
     }
 
     if (!connection->connection_resource->is_connected) {
@@ -515,7 +515,7 @@ static PHP_METHOD(amqp_channel_class, setPrefetchCount)
     zend_long prefetch_count;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &prefetch_count) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (!php_amqp_is_valid_prefetch_count(prefetch_count)) {
@@ -603,7 +603,7 @@ static PHP_METHOD(amqp_channel_class, setPrefetchSize)
     zend_long prefetch_size;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &prefetch_size) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (!php_amqp_is_valid_prefetch_size(prefetch_size)) {
@@ -688,7 +688,7 @@ static PHP_METHOD(amqp_channel_class, setGlobalPrefetchCount)
     zend_long global_prefetch_count;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &global_prefetch_count) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (!php_amqp_is_valid_prefetch_count(global_prefetch_count)) {
@@ -755,7 +755,7 @@ static PHP_METHOD(amqp_channel_class, setGlobalPrefetchSize)
     zend_long global_prefetch_size;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &global_prefetch_size) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (!php_amqp_is_valid_prefetch_size(global_prefetch_size)) {
@@ -826,7 +826,7 @@ static PHP_METHOD(amqp_channel_class, qos)
     bool global = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll|b", &prefetch_size, &prefetch_count, &global) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
@@ -1008,7 +1008,7 @@ static PHP_METHOD(amqp_channel_class, basicRecover)
     bool requeue = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &requeue) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(getThis());
@@ -1067,7 +1067,7 @@ PHP_METHOD(amqp_channel_class, setReturnCallback)
     zend_fcall_info_cache fcc = empty_fcall_info_cache;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "f!", &fci, &fcc) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     amqp_channel_object *channel = PHP_AMQP_GET_CHANNEL(getThis());
@@ -1098,7 +1098,7 @@ PHP_METHOD(amqp_channel_class, waitForBasicReturn)
     struct timeval *tv_ptr = &tv;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|d", &timeout) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (timeout < 0) {
@@ -1207,7 +1207,7 @@ PHP_METHOD(amqp_channel_class, setConfirmCallback)
     zend_fcall_info_cache nack_fcc = empty_fcall_info_cache;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "f!|f!", &ack_fci, &ack_fcc, &nack_fci, &nack_fcc) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     amqp_channel_object *channel = PHP_AMQP_GET_CHANNEL(getThis());
@@ -1247,7 +1247,7 @@ PHP_METHOD(amqp_channel_class, waitForConfirm)
     struct timeval *tv_ptr = &tv;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|d", &timeout) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (timeout < 0) {

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -361,7 +361,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
 
     /* Parse out the method parameters */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|a/", &ini_arr) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Pull the login out of the $params array */
@@ -1048,7 +1048,7 @@ static PHP_METHOD(amqp_connection_class, setLogin)
 
     /* Get the login from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &login, &login_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate login length */
@@ -1086,7 +1086,7 @@ static PHP_METHOD(amqp_connection_class, setPassword)
 
     /* Get the password from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &password, &password_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate password length */
@@ -1131,7 +1131,7 @@ static PHP_METHOD(amqp_connection_class, setHost)
 
     /* Get the host from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &host, &host_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate host length */
@@ -1169,7 +1169,7 @@ static PHP_METHOD(amqp_connection_class, setPort)
 
     /* Get the port from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &port) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Check the port value */
@@ -1207,7 +1207,7 @@ static PHP_METHOD(amqp_connection_class, setVhost)
     size_t vhost_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &vhost, &vhost_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate vhost length */
@@ -1259,7 +1259,7 @@ static PHP_METHOD(amqp_connection_class, setTimeout)
 
     /* Get the timeout from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &read_timeout) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate timeout */
@@ -1307,7 +1307,7 @@ static PHP_METHOD(amqp_connection_class, setReadTimeout)
 
     /* Get the timeout from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &read_timeout) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate timeout */
@@ -1355,7 +1355,7 @@ static PHP_METHOD(amqp_connection_class, setWriteTimeout)
 
     /* Get the timeout from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &write_timeout) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate timeout */
@@ -1413,7 +1413,7 @@ static PHP_METHOD(amqp_connection_class, setRpcTimeout)
 
     /* Get the timeout from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &rpc_timeout) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Validate timeout */
@@ -1555,7 +1555,7 @@ static PHP_METHOD(amqp_connection_class, setCACert)
     size_t str_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &str, &str_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (str == NULL) {
@@ -1582,7 +1582,7 @@ static PHP_METHOD(amqp_connection_class, setCert)
     size_t str_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &str, &str_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (str == NULL) {
@@ -1609,7 +1609,7 @@ static PHP_METHOD(amqp_connection_class, setKey)
     size_t str_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &str, &str_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (str == NULL) {
@@ -1636,7 +1636,7 @@ static PHP_METHOD(amqp_connection_class, setVerify)
     bool verify = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &verify) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("verify"), verify);
@@ -1661,7 +1661,7 @@ static PHP_METHOD(amqp_connection_class, setSaslMethod)
 
     /* Get the port from the method params */
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &method) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Check the method value */
@@ -1694,7 +1694,7 @@ static PHP_METHOD(amqp_connection_class, setConnectionName)
     size_t str_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &str, &str_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
     if (str == NULL) {
         zend_update_property_null(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("connectionName"));

--- a/amqp_decimal.c
+++ b/amqp_decimal.c
@@ -45,7 +45,7 @@ static PHP_METHOD(amqp_decimal_class, __construct)
     zend_long exponent, significand;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &exponent, &significand) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (exponent < AMQP_DECIMAL_EXPONENT_MIN) {

--- a/amqp_envelope.c
+++ b/amqp_envelope.c
@@ -199,7 +199,7 @@ static PHP_METHOD(amqp_envelope_class, getHeader)
     zval *tmp = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zval *zv = PHP_AMQP_READ_THIS_PROP_CE("headers", amqp_basic_properties_class_entry);
@@ -223,7 +223,7 @@ static PHP_METHOD(amqp_envelope_class, hasHeader)
     size_t key_len;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zval *zv = PHP_AMQP_READ_THIS_PROP_CE("headers", amqp_basic_properties_class_entry);

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -73,7 +73,7 @@ static PHP_METHOD(amqp_exchange_class, __construct)
     amqp_channel_resource *channel_resource;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &channelObj, amqp_channel_class_entry) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     ZVAL_UNDEF(&arguments);
@@ -120,7 +120,7 @@ static PHP_METHOD(amqp_exchange_class, setName)
     size_t name_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &name, &name_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* Verify that the name is not null and not an empty string */
@@ -178,7 +178,7 @@ static PHP_METHOD(amqp_exchange_class, setFlags)
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l!", &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     flags = flags & PHP_AMQP_EXCHANGE_FLAGS;
@@ -216,7 +216,7 @@ static PHP_METHOD(amqp_exchange_class, setType)
     size_t type_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &type, &type_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zend_update_property_stringl(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("type"), type, type_len);
@@ -236,7 +236,7 @@ static PHP_METHOD(amqp_exchange_class, getArgument)
     size_t key_len;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
@@ -256,7 +256,7 @@ static PHP_METHOD(amqp_exchange_class, hasArgument)
     size_t key_len;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     RETURN_BOOL(zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len) != NULL);
@@ -281,7 +281,7 @@ static PHP_METHOD(amqp_exchange_class, setArguments)
     zval *zvalArguments;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "a/", &zvalArguments) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), zvalArguments);
@@ -299,7 +299,7 @@ static PHP_METHOD(amqp_exchange_class, setArgument)
     zval *value = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz", &key, &key_len, &value) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     switch (Z_TYPE_P(value)) {
@@ -333,7 +333,7 @@ static PHP_METHOD(amqp_exchange_class, removeArgument)
     size_t key_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zend_hash_str_del(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
@@ -417,7 +417,7 @@ static PHP_METHOD(amqp_exchange_class, delete)
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!l!", &name, &name_len, &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -484,7 +484,7 @@ static PHP_METHOD(amqp_exchange_class, publish)
             &flags_is_null,
             &ini_arr
         ) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     /* By default (and for BC) content type is text/plain (may be skipped at all, then set props._flags to 0) */
@@ -701,7 +701,7 @@ static PHP_METHOD(amqp_exchange_class, bind)
             &keyname_len,
             &zvalArguments
         ) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -763,7 +763,7 @@ static PHP_METHOD(amqp_exchange_class, unbind)
             &keyname_len,
             &zvalArguments
         ) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -83,7 +83,7 @@ static PHP_METHOD(amqp_queue_class, __construct)
     amqp_channel_resource *channel_resource;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &channelObj, amqp_channel_class_entry) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     ZVAL_UNDEF(&arguments);
@@ -130,7 +130,7 @@ static PHP_METHOD(amqp_queue_class, setName)
     size_t name_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (name_len < 1 || name_len > 255) {
@@ -188,7 +188,7 @@ static PHP_METHOD(amqp_queue_class, setFlags)
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l!", &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     flags = flags & PHP_AMQP_QUEUE_FLAGS;
@@ -211,7 +211,7 @@ static PHP_METHOD(amqp_queue_class, getArgument)
     size_t key_len;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if ((tmp = zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len)) == NULL) {
@@ -232,7 +232,7 @@ static PHP_METHOD(amqp_queue_class, hasArgument)
     size_t key_len;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     RETURN_BOOL(zend_hash_str_find(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len) != NULL);
@@ -257,7 +257,7 @@ static PHP_METHOD(amqp_queue_class, setArguments)
     zval *zvalArguments;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "a/", &zvalArguments) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zend_update_property(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("arguments"), zvalArguments);
@@ -276,7 +276,7 @@ static PHP_METHOD(amqp_queue_class, setArgument)
     zval *value = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz", &key, &key_len, &value) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     switch (Z_TYPE_P(value)) {
@@ -321,7 +321,7 @@ static PHP_METHOD(amqp_queue_class, removeArgument)
     size_t key_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zend_hash_str_del_ind(PHP_AMQP_READ_THIS_PROP_ARR("arguments"), key, key_len);
@@ -417,7 +417,7 @@ static PHP_METHOD(amqp_queue_class, bind)
             &keyname_len,
             &zvalArguments
         ) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -469,7 +469,7 @@ static PHP_METHOD(amqp_queue_class, get)
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l!", &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -570,7 +570,7 @@ static PHP_METHOD(amqp_queue_class, consume)
             &consumer_tag,
             &consumer_tag_len
         ) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
@@ -838,7 +838,7 @@ static PHP_METHOD(amqp_queue_class, ack)
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l!", &deliveryTag, &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -887,7 +887,7 @@ static PHP_METHOD(amqp_queue_class, nack)
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l!", &deliveryTag, &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -937,7 +937,7 @@ static PHP_METHOD(amqp_queue_class, reject)
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l!", &deliveryTag, &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -1027,7 +1027,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
     size_t consumer_tag_len = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &consumer_tag, &consumer_tag_len) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     zval *channel_zv = PHP_AMQP_READ_THIS_PROP("channel");
@@ -1111,7 +1111,7 @@ static PHP_METHOD(amqp_queue_class, unbind)
             &keyname_len,
             &zvalArguments
         ) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
@@ -1162,7 +1162,7 @@ static PHP_METHOD(amqp_queue_class, delete)
     zend_long message_count;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l!", &flags, &flags_is_null) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));

--- a/amqp_timestamp.c
+++ b/amqp_timestamp.c
@@ -43,7 +43,7 @@ static PHP_METHOD(amqp_timestamp_class, __construct)
     double timestamp;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &timestamp) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (timestamp < AMQP_TIMESTAMP_MIN) {

--- a/infra/tools/pamqp-check
+++ b/infra/tools/pamqp-check
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+make test
+pamqp-stubs-lint
+pamqp-stubs-validate
+php -d extension=modules/amqp.so $(which pamqp-arguments-validate)
+
+pamqp-format-check
+pamqp-stubs-format-check

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -73,6 +73,12 @@ extern zend_module_entry amqp_module_entry;
         ZEND_ARG_TYPE_INFO(pass_by_ref, name, type_hint, allow_null)
     #define PHP_AMQP_DECLARE_PROPERTY_TYPE(type, nullable) ZEND_TYPE_ENCODE(type, nullable)
     #define PHP_AMQP_DECLARE_PROPERTY_OBJ_TYPE(class_name, nullable) ZEND_TYPE_ENCODE_CLASS(class_name, nullable)
+    #define RETURN_THROWS()                                                                                            \
+        do {                                                                                                           \
+            ZEND_ASSERT(EG(exception));                                                                                \
+            (void) return_value;                                                                                       \
+            return;                                                                                                    \
+        } while (0)
 #endif
 #if PHP_VERSION_ID < 80200
     #define zend_ini_parse_quantity_warn(v, name) (zend_atol(ZSTR_VAL(v), ZSTR_LEN(v)))


### PR DESCRIPTION
Use `RETURN_THROWS()` macro instead of `return`.