### PR TITLE
Fix double free in amqp::consume()

### DIFF
--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -681,16 +681,14 @@ static PHP_METHOD(amqp_queue_class, consume)
         if (AMQP_RESPONSE_LIBRARY_EXCEPTION == res.reply_type && AMQP_STATUS_TIMEOUT == res.library_error) {
             zend_throw_exception(amqp_queue_exception_class_entry, "Consumer timeout exceed", 0);
 
-            amqp_destroy_envelope(&envelope);
             php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
             return;
         }
 
-        if (PHP_AMQP_MAYBE_ERROR_RECOVERABLE(res, channel_resource)) {
+        if (AMQP_RESPONSE_NORMAL != res.reply_type) {
 
             if (PHP_AMQP_IS_ERROR_RECOVERABLE(res, channel_resource, channel)) {
                 /* In case no message was received, continue the loop */
-                amqp_destroy_envelope(&envelope);
 
                 continue;
             } else {
@@ -703,7 +701,6 @@ static PHP_METHOD(amqp_queue_class, consume)
 
             php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry);
 
-            amqp_destroy_envelope(&envelope);
             php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
             return;


### PR DESCRIPTION
The envolope should not be used unless amqp_consume_message() replies with AMQP_RESPONSE_NORMAL.

See https://github.com/alanxz/rabbitmq-c/blob/9a91cf59760471b49307535d839d38d6c9a08d66/librabbitmq/amqp_consumer.c#L162

Fixes #416 