### PR TITLE
Revamp error handling

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -443,7 +443,7 @@ int php_amqp_error_advanced(
                 break;
             }
             /* Library or other non-protocol or even protocol related errors may be here. */
-            /* In most cases it designate some underlying hard errors. Fail fast. */
+            /* In most cases it indicates some underlying hard errors. Fail fast. */
         case PHP_AMQP_RESOURCE_RESPONSE_ERROR_CONNECTION_CLOSED:
             /* Mark connection resource as closed to prevent sending any further requests */
             connection_resource->is_connected = '\0';
@@ -490,7 +490,18 @@ void php_amqp_zend_throw_exception(
             exception_ce = amqp_exception_class_entry;
             break;
         case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-            exception_ce = amqp_exception_class_entry;
+            switch (reply.library_error) {
+                case AMQP_STATUS_CONNECTION_CLOSED:
+                case AMQP_STATUS_SOCKET_ERROR:
+                case AMQP_STATUS_SOCKET_CLOSED:
+                case AMQP_STATUS_SOCKET_INUSE:
+                case AMQP_STATUS_BROKER_UNSUPPORTED_SASL_METHOD:
+                case AMQP_STATUS_HOSTNAME_RESOLUTION_FAILED:
+                    exception_ce = amqp_connection_exception_class_entry;
+                    break;
+                default:
+                    exception_ce = amqp_exception_class_entry;
+            }
             break;
         case AMQP_RESPONSE_SERVER_EXCEPTION:
             switch (reply.reply.id) {

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -301,7 +301,7 @@ int php_amqp_connection_resource_error_advanced(amqp_rpc_reply_t reply, char **m
                 spprintf(
                     message,
                     0,
-                    "Library error: An unexpected method was received 0x%08X\n",
+                    "An unexpected method was received 0x%08X\n",
                     frame.payload.method.id
                 );
                 return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
@@ -368,7 +368,7 @@ int php_amqp_set_resource_rpc_timeout(amqp_connection_resource *resource, double
     rpc_timeout.tv_usec = (int) ((timeout - floor(timeout)) * 1.e+6);
 
     if (AMQP_STATUS_OK != amqp_set_rpc_timeout(resource->connection_state, &rpc_timeout)) {
-        zend_throw_exception(amqp_connection_exception_class_entry, "Library error: cannot set rpc_timeout", 0);
+        zend_throw_exception(amqp_connection_exception_class_entry, "Cannot set rpc_timeout", 0);
         return 0;
     }
 #endif

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -104,7 +104,7 @@ int php_amqp_connection_resource_error(
             return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
 
         case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-            spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
+            spprintf(message, 0, "%s", amqp_error_string2(reply.library_error));
             return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
 
         case AMQP_RESPONSE_SERVER_EXCEPTION:
@@ -250,12 +250,12 @@ int php_amqp_connection_resource_error_advanced(amqp_rpc_reply_t reply, char **m
             efree(*message);
         }
 
-        spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
+        spprintf(message, 0, "%s", amqp_error_string2(reply.library_error));
         return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
     }
 
     if (channel->channel_resource->channel_id != frame.channel) {
-        spprintf(message, 0, "Library error: channel mismatch");
+        spprintf(message, 0, "Channel mismatch");
         return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
     }
 
@@ -312,7 +312,7 @@ int php_amqp_connection_resource_error_advanced(amqp_rpc_reply_t reply, char **m
         efree(*message);
     }
 
-    spprintf(message, 0, "Library error: %s", amqp_error_string2(reply.library_error));
+    spprintf(message, 0, "%s", amqp_error_string2(reply.library_error));
     return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
 }
 
@@ -645,7 +645,7 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
 
         php_amqp_connection_resource_error(res, &message, resource, 0);
 
-        spprintf(&long_message, 0, "%s - Potential login failure.", message);
+        spprintf(&long_message, 0, "%s", message);
         zend_throw_exception(amqp_connection_exception_class_entry, long_message, PHP_AMQP_G(error_code));
 
         efree(message);

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -298,12 +298,7 @@ int php_amqp_connection_resource_error_advanced(amqp_rpc_reply_t reply, char **m
                     efree(*message);
                 }
 
-                spprintf(
-                    message,
-                    0,
-                    "An unexpected method was received 0x%08X\n",
-                    frame.payload.method.id
-                );
+                spprintf(message, 0, "An unexpected method was received 0x%08X\n", frame.payload.method.id);
                 return PHP_AMQP_RESOURCE_RESPONSE_ERROR;
         }
     }

--- a/tests/amqpconnection_connect_login_failure.phpt
+++ b/tests/amqpconnection_connect_login_failure.phpt
@@ -28,10 +28,8 @@ try {
 }
 //
 echo ($cnn->isConnected() ? 'connected' : 'disconnected'), PHP_EOL;
-
-// NOTE: in real-world environment (incl. travis ci) "a socket error occurred" happens, but in vagrant environment "connection closed unexpectedly" happens. WTF?
 ?>
 --EXPECTF--
 disconnected
-AMQPConnectionException(%d): %s error: %s - Potential login failure.
+AMQPConnectionException(403): %s
 disconnected

--- a/tests/amqpconnection_heartbeat.phpt
+++ b/tests/amqpconnection_heartbeat.phpt
@@ -30,11 +30,11 @@ echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
 echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
 echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
 ?>
---EXPECTF--
+--EXPECTREGEX--
 heartbeat: 2
 connected: true
 persistent: false
-AMQPConnectionException(0): a socket error occurred
+AMQPConnectionException\(0\): (a socket error occurred|connection closed unexpectedly)
 heartbeat: 2
 connected: false
 persistent: false

--- a/tests/amqpconnection_heartbeat.phpt
+++ b/tests/amqpconnection_heartbeat.phpt
@@ -29,14 +29,12 @@ try {
 echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
 echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
 echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
-
-// NOTE: in real-world environment (incl. travis ci) "a socket error occurred" happens, but in virtual environment "connection closed unexpectedly" happens
 ?>
 --EXPECTF--
 heartbeat: 2
 connected: true
 persistent: false
-AMQPException(0): Library error: %s
+AMQPConnectionException(0): a socket error occurred
 heartbeat: 2
 connected: false
 persistent: false

--- a/tests/amqpconnection_heartbeat_with_persistent.phpt
+++ b/tests/amqpconnection_heartbeat_with_persistent.phpt
@@ -66,7 +66,7 @@ echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
 echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
 echo PHP_EOL;
 ?>
---EXPECT--
+--EXPECTREGEX--
 heartbeat: 2
 connected: false
 persistent: false
@@ -75,7 +75,7 @@ heartbeat: 2
 connected: true
 persistent: true
 
-AMQPConnectionException(0): a socket error occurred
+AMQPConnectionException\(0\): (a socket error occurred|connection closed unexpectedly)
 
 heartbeat: 2
 connected: false

--- a/tests/amqpconnection_heartbeat_with_persistent.phpt
+++ b/tests/amqpconnection_heartbeat_with_persistent.phpt
@@ -65,10 +65,8 @@ echo 'heartbeat: ', var_export($cnn->getHeartbeatInterval(), true), PHP_EOL;
 echo 'connected: ', var_export($cnn->isConnected(), true), PHP_EOL;
 echo 'persistent: ', var_export($cnn->isPersistent(), true), PHP_EOL;
 echo PHP_EOL;
-
-// NOTE: in real-world environment (incl. travis ci) "a socket error occurred" happens, but in virtual environment "connection closed unexpectedly" happens
 ?>
---EXPECTF--
+--EXPECT--
 heartbeat: 2
 connected: false
 persistent: false
@@ -77,7 +75,7 @@ heartbeat: 2
 connected: true
 persistent: true
 
-AMQPException(0): Library error: %s
+AMQPConnectionException(0): a socket error occurred
 
 heartbeat: 2
 connected: false

--- a/tests/amqpexchange_publish_mandatory_multiple_channels_pitfall.phpt
+++ b/tests/amqpexchange_publish_mandatory_multiple_channels_pitfall.phpt
@@ -81,5 +81,5 @@ AMQPQueueException(0): Wait timeout exceed
 NULL
 NULL
 NULL
-AMQPException(0): Library error: unexpected method received
+AMQPException(0): unexpected method received
 Connection active: no


### PR DESCRIPTION
 * Use AMQPConnectionException for connection-specific errors
 * Don’t prefix error messages with the unnecessary (for the user) "Library error" prefix

Closes #357