### PR TITLE
Drop bad executable settings

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -6,9 +6,6 @@ PHP_ARG_WITH(amqp, for amqp support,
 PHP_ARG_WITH(librabbitmq-dir,	for amqp,
 [	--with-librabbitmq-dir[=DIR]	 Set the path to librabbitmq install prefix.], yes)
 
-dnl Set test wrapper binary to ignore any local ini settings
-PHP_EXECUTABLE="\$(top_srcdir)/infra/tools/pamqp-php-cli-deterministic"
-
 if test "$PHP_AMQP" != "no"; then
 	AC_MSG_CHECKING([for supported PHP versions])        
 	PHP_REF_FOUND_VERSION=$PHP_VERSION


### PR DESCRIPTION
If needed, set it before running your test locally