### PR TITLE
Skip ONLINE test

### DIFF
--- a/tests/amqpconnection_construct_with_connect_timeout.phpt
+++ b/tests/amqpconnection_construct_with_connect_timeout.phpt
@@ -2,7 +2,8 @@
 AMQPConnection constructor with timeout parameter in credentials
 --SKIPIF--
 <?php
-if (!extension_loaded("amqp")) print "skip";
+if (!extension_loaded("amqp")) print "skip amqp extension not loaded";
+if (getenv("SKIP_ONLINE_TESTS")) die('skip online test');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Running test suite offline:

```
TEST 34/191 [tests/amqpconnection_construct_with_connect_timeout.phpt]
========DIFF========
     Parameter 'connect_timeout' must be greater than or equal to zero.
002+ Socket error: could not connect to host, hostname lookup failed
002- Socket error: could not connect to host, request timed out
     error: %f
     limit: %f
005+ timings failed
005- timings OK
========DONE========
FAIL AMQPConnection constructor with timeout parameter in credentials [tests/amqpconnection_construct_with_connect_timeout.phpt] 

```