### PR TITLE
consume is void, so don't set return value

### DIFF
--- a/amqp_envelope.c
+++ b/amqp_envelope.c
@@ -256,7 +256,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_envelope_class_isRedelivery, ZEND_SEND_BY_VAL, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_envelope_class_getHeader, ZEND_SEND_BY_VAL, 1, IS_STRING, 1)
+#ifdef IS_MIXED
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_amqp_envelope_class_getHeader, ZEND_SEND_BY_VAL, 1, IS_MIXED, 1)
+#else
+/* PHP < 8.0 */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_amqp_envelope_class_getHeader, 0, 0, 1)
+#endif
     ZEND_ARG_TYPE_INFO(0, headerName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -445,7 +445,7 @@ static PHP_METHOD(amqp_queue_class, bind)
     if (PHP_AMQP_MAYBE_ERROR(res, channel_resource)) {
         php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry);
         php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-        return;
+        RETURN_THROWS();
     }
 
     php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
@@ -583,7 +583,7 @@ static PHP_METHOD(amqp_queue_class, consume)
             "Invalid channel consumers, forgot to call channel constructor?",
             0
         );
-        return;
+        RETURN_THROWS();
     }
 
     amqp_channel_object *channel = PHP_AMQP_GET_CHANNEL(channel_zv);
@@ -615,7 +615,7 @@ static PHP_METHOD(amqp_queue_class, consume)
 
             zend_throw_exception(amqp_queue_exception_class_entry, PHP_AMQP_G(error_message), PHP_AMQP_G(error_code));
             php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
-            return;
+            RETURN_THROWS();
         }
 
         char *key;
@@ -625,7 +625,7 @@ static PHP_METHOD(amqp_queue_class, consume)
             // This should never happen as AMQP server guarantees that consumer tag is unique within channel
             zend_throw_exception(amqp_exception_class_entry, "Duplicate consumer tag", 0);
             efree(key);
-            return;
+            RETURN_THROWS();
         }
 
         zval tmp;
@@ -703,7 +703,7 @@ static PHP_METHOD(amqp_queue_class, consume)
             php_amqp_zend_throw_exception_short(res, amqp_queue_exception_class_entry);
             php_amqp_maybe_release_buffers_on_channel(channel_resource->connection_resource, channel_resource);
 
-            return;
+            RETURN_THROWS();
         }
 
         ZVAL_UNDEF(&message);
@@ -801,7 +801,7 @@ static PHP_METHOD(amqp_queue_class, consume)
 
         /* Call the function, and track the return value */
         if (zend_call_function(&fci, &fci_cache) == SUCCESS && fci.retval) {
-            RETVAL_ZVAL(&retval, 1, 1);
+//          RETVAL_ZVAL(&retval, 1, 1);
         }
 
         /* Clean up our mess */
@@ -810,7 +810,7 @@ static PHP_METHOD(amqp_queue_class, consume)
         zval_ptr_dtor(&message);
 
         /* Check if user land function wants to bail */
-        if (EG(exception) || Z_TYPE_P(return_value) == IS_FALSE) {
+        if (EG(exception) || Z_TYPE_P(&retval) == IS_FALSE) {
             break;
         }
     }
@@ -1038,7 +1038,7 @@ static PHP_METHOD(amqp_queue_class, cancel)
             "Invalid channel consumers, forgot to call channel constructor?",
             0
         );
-        return;
+        RETURN_THROWS();
     }
 
     channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(channel_zv);


### PR DESCRIPTION
See #488  

Only fixes some failure

after this change

```
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
AMQPChannel - consumers [tests/003-channel-consumers.phpt]
AMQPConnection var_dump [tests/amqpconnection_var_dump.phpt]
AMQPExchange publish with properties - ignore unsupported header values (NULL, object, resources) [tests/amqpexchange_publish_with_properties_ignore_unsupported_header_values.phpt]
AMQPExchange publish with properties - nested header values [tests/amqpexchange_publish_xdeath.phpt]
AMQPQueue::get headers [tests/amqpqueue_get_headers.phpt]
AMQPQueue::get headers with bool values [tests/amqpqueue_headers_with_bool.phpt]
AMQPQueue::get headers with float values [tests/amqpqueue_headers_with_float.phpt]
AMQPQueue::get headers [tests/amqpqueue_nested_arrays.phpt]
AMQPQueue::get headers [tests/amqpqueue_nested_headers.phpt]
Serialize custom AMQP value - errors [tests/serialize-custom-amqpvalue-errors.phpt]
Serialize custom AMQP value [tests/serialize-custom-amqpvalue.phpt]
=====================================================================

```