### PR TITLE
Set custom PHP executable dynamically

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 PHP_AMQP_HOST=rabbitmq
 PHP_AMQP_SSL_HOST=rabbitmq.example.org
-MAKEFLAGS="-j16"
+MAKEFLAGS="-j16 PHP_EXECUTABLE=/src/infra/tools/pamqp-php-cli-deterministic"
 CFLAGS="-g -O0 -fstack-protector-strong -Wall -Werror -D_GNU_SOURCE"
 TEST_PHP_ARGS="-j16 -q"
 CC=clang

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 env:
   TEST_TIMEOUT: 120
   CFLAGS: -g -O0 -fstack-protector-strong -Wall -Werror -D_GNU_SOURCE
-  MAKEFLAGS: -j4
+  MAKEFLAGS: -j4 PHP_EXECUTABLE=./infra/tools/pamqp-php-cli-deterministic
 
 jobs:
   prep:

--- a/config.m4
+++ b/config.m4
@@ -7,7 +7,6 @@ PHP_ARG_WITH(librabbitmq-dir,	for amqp,
 [	--with-librabbitmq-dir[=DIR]	 Set the path to librabbitmq install prefix.], yes)
 
 dnl Set test wrapper binary to ignore any local ini settings
-PHP_EXECUTABLE="\$(top_srcdir)/infra/tools/pamqp-php-cli-deterministic"
 
 if test "$PHP_AMQP" != "no"; then
 	AC_MSG_CHECKING([for supported PHP versions])        


### PR DESCRIPTION
Sets the deterministic custom PHP binary via env variables instead of hardcoding it in the configure line. That way local test runs still work. Supersedes #487.