### PR TITLE
Fix missing debug symbols for memory checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Install packages
         uses: awalsh128/cache-apt-pkgs-action@v1.3.1
         with:
-          packages: cmake valgrind libc6-dbg
+          packages: cmake valgrind libc6-dbg:i386
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.29.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,14 +73,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - run: dpkg --add-architecture i386
-      - run: apt-get update
-      - run: apt-get install libc6-dbg:i386
-
       - name: Install packages
         uses: awalsh128/cache-apt-pkgs-action@v1.3.1
         with:
-          packages: cmake valgrind
+          packages: cmake
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.29.0
@@ -148,7 +144,7 @@ jobs:
       - name: Install packages
         uses: awalsh128/cache-apt-pkgs-action@v1.3.1
         with:
-          packages: cmake valgrind ${{ matrix.compiler }}
+          packages: cmake valgrind libc6-dbg ${{ matrix.compiler }}
           version: ${{ (matrix.librabbitmq-version == '0.10.0' || matrix.librabbitmq-version == '0.9.0' || matrix.librabbitmq-version == '0.8.0') && 'ubuntu-20.04' || 'ubuntu-22.04' }}
 
       - name: Setup PHP

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,10 +73,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - run: dpkg --add-architecture i386
+      - run: apt-get update
+      - run: apt-get install libc6-dbg:i386
+
       - name: Install packages
         uses: awalsh128/cache-apt-pkgs-action@v1.3.1
         with:
-          packages: cmake valgrind libc6-dbg:i386
+          packages: cmake valgrind
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.29.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Install packages
         uses: awalsh128/cache-apt-pkgs-action@v1.3.1
         with:
-          packages: cmake valgrind
+          packages: cmake valgrind libc6-dbg
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.29.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,7 +144,7 @@ jobs:
       - name: Install packages
         uses: awalsh128/cache-apt-pkgs-action@v1.3.1
         with:
-          packages: cmake valgrind libc6-dbg ${{ matrix.compiler }}
+          packages: cmake valgrind libc6-dbg gcc clang
           version: ${{ (matrix.librabbitmq-version == '0.10.0' || matrix.librabbitmq-version == '0.9.0' || matrix.librabbitmq-version == '0.8.0') && 'ubuntu-20.04' || 'ubuntu-22.04' }}
 
       - name: Setup PHP


### PR DESCRIPTION
Install libc6-dbg to unbreak memory tests using valgrind.