### PR TITLE
Updated composer.json to enable support for PIE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "php-amqp/php-amqp",
-  "type": "library",
+  "type": "php-ext",
   "description": "PHP AMQP Binding Library",
   "keywords": [
     "rabbitmq",
@@ -31,5 +31,19 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": false
     }
+  },
+  "php-ext": {
+    "extension-name": "amqp",
+    "configure-options": [
+      {
+        "name": "with-amqp",
+        "description": "Include amqp support"
+      },
+      {
+        "name": "with-librabbitmq-dir",
+        "description": "Set the path to librabbitmq install prefix.",
+        "needs-value": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
Adds support for [PIE](https://github.com/php/pie).

Once merged, a maintainer would need to add this repo's URL to https://packagist.org/packages/submit :)

More info/documentation can be read on: https://github.com/php/pie/blob/main/docs/extension-maintainers.md
