### PR TITLE
Use ZEND_LONG_FMT and ZEND_ULONG_FMT to fix warnings on 32-bit

### DIFF
--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -607,7 +607,7 @@ bool php_amqp_basic_properties_value_to_zval_internal(amqp_field_value_t *value,
         zend_throw_exception_ex(
             amqp_exception_class_entry,
             0,
-            "Maximum deserialization depth limit of %ld reached while deserializing value",
+            "Maximum deserialization depth limit of " ZEND_LONG_FMT " reached while deserializing value",
             PHP_AMQP_G(deserialization_depth)
         );
         return 0;

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -142,8 +142,8 @@ static void php_amqp_close_connection_from_server(
         spprintf(
             message,
             0,
-            "Server connection error: %ld, message: %s",
-            (long) PHP_AMQP_G(error_code),
+            "Server connection error: " ZEND_LONG_FMT ", message: %s",
+            PHP_AMQP_G(error_code),
             "unexpected response"
         );
     } else {
@@ -198,8 +198,8 @@ static void php_amqp_close_channel_from_server(
         spprintf(
             message,
             0,
-            "Server channel error: %ld, message: %s",
-            (long) PHP_AMQP_G(error_code),
+            "Server channel error: " ZEND_LONG_FMT ", message: %s",
+            PHP_AMQP_G(error_code),
             "unexpected response"
         );
     } else {

--- a/amqp_type.c
+++ b/amqp_type.c
@@ -141,11 +141,11 @@ void php_amqp_type_zval_to_amqp_table_internal(zval *array, amqp_table_t *amqp_t
                 /* Convert to strings non-string keys */
                 char str[32];
 
-                key_len = snprintf(str, 32, "%lu", index);
+                key_len = snprintf(str, 32, ZEND_ULONG_FMT, index);
                 key = str;
             } else {
                 /* Skip things that are not strings */
-                php_error_docref(NULL, E_WARNING, "Ignoring non-string header field '%lu'", index);
+                php_error_docref(NULL, E_WARNING, "Ignoring non-string header field '" ZEND_ULONG_FMT "'", index);
 
                 continue;
             }
@@ -209,7 +209,7 @@ bool php_amqp_type_zval_to_amqp_value_internal(zval *value, amqp_field_value_t *
         zend_throw_exception_ex(
             amqp_exception_class_entry,
             0,
-            "Maximum serialization depth of %ld reached while serializing value",
+            "Maximum serialization depth of " ZEND_LONG_FMT " reached while serializing value",
             PHP_AMQP_G(serialization_depth)
         );
         return 0;


### PR DESCRIPTION
Succeeds #587